### PR TITLE
Ignore empty lines (commands) in gcode file

### DIFF
--- a/src/com/willwinder/universalgcodesender/GcodeCommandBuffer.java
+++ b/src/com/willwinder/universalgcodesender/GcodeCommandBuffer.java
@@ -73,9 +73,12 @@ public class GcodeCommandBuffer {
         GcodeCommand command;
         int commandNum = 0;
         while ((line = fileStream.readLine()) != null) {
-            // Commands end with a newline.
-            command = new GcodeCommand(line + '\n', commandNum++);
-            commands.add(command);
+            // Empty line detection
+            if(!line.trim().equals("")){
+    			// Commands end with a newline.
+                command = new GcodeCommand(line + '\n', commandNum++);
+                commands.add(command);
+            }
         }
         
         return commands;


### PR DESCRIPTION
A empty line in the gcode file breaks the assigment of the answer to the commands so they should be ignored.
