### PR TITLE
Fixed start.sh

### DIFF
--- a/release_files/start.sh
+++ b/release_files/start.sh
@@ -16,10 +16,10 @@ esac
 
 case "$platform" in
         mac)
-                java -Xdock:name=UniversalGCodeSender -jar -Xmx256m $rootdir/UniversalGcodeSender-all*.jar
+                java -Xdock:name=UniversalGCodeSender -jar -Xmx256m $rootdir/UniversalGcodeSender.jar
         ;;
         linux)
-                java -jar -Xmx256m $rootdir/UniversalGcodeSender-all*.jar
+                java -jar -Xmx256m $rootdir/UniversalGcodeSender.jar
         ;;
 esac
         


### PR DESCRIPTION
The jar file produced by the ant target must have been renamed sometime. Small change to start.sh to reflect that.
