### PR TITLE
Reset GRBL on open, to get version string

### DIFF
--- a/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -47,6 +47,14 @@ public abstract class AbstractController implements SerialCommunicatorListener {
     abstract protected void closeCommAfterEvent();
     
     /**
+     * Called after comm opening allowing device specific behavior.
+     * @throws IOException 
+     */
+    protected void openCommAfterEvent() throws IOException {
+    	// Empty default implementation. 
+    }
+    
+    /**
      * Called before and after a send cancel allowing device specific behavior.
      */
     abstract protected void cancelSendBeforeEvent();
@@ -246,6 +254,8 @@ public abstract class AbstractController implements SerialCommunicatorListener {
             this.messageForConsole(
                    "**** Connected to " + port + " @ " + portRate + " baud ****\n");
         }
+        
+        this.openCommAfterEvent();
         
         return this.commOpen;
     }

--- a/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/src/com/willwinder/universalgcodesender/GrblController.java
@@ -158,6 +158,11 @@ public class GrblController extends AbstractController {
     }
     
     @Override
+    protected void openCommAfterEvent() throws IOException {
+        this.comm.sendByteImmediately(GrblUtils.GRBL_RESET_COMMAND);
+    }
+
+    @Override
     protected void isReadyToStreamFileEvent() throws Exception {
         if (this.isReady == false) {
             throw new Exception("Grbl has not finished booting.");


### PR DESCRIPTION
Universal G-Code Sender does not send any Reset command to GRBL, so GRBL does not answer with a version string, which prevents normal operations: sending g-code returns "GRBL has not finished booting", Soft Reset does nothing (since we don't know version). I've inserted code to send reset command on comm open, to get the version string as early as possible. This has the consequence that stopping and restarting Universal G-Code Sender would make GRBL reset, but otherwise it was not very functional... 
