### PR TITLE
Add more navigation controls to the visualizer.

### DIFF
--- a/src/com/willwinder/universalgcodesender/visualizer/VisualizerUtils.java
+++ b/src/com/willwinder/universalgcodesender/visualizer/VisualizerUtils.java
@@ -145,5 +145,21 @@ public class VisualizerUtils {
         }
         return ret;
     }
+
+    /**
+     * Determine the ratio of mouse movement to model movement for panning operations on a single axis.
+     * @param objectMin The lowest value on the axis from the model's size.
+     * @param objectMax The highest point on the axis from the model's size.
+     * @param movementRange The length of the axis in the window displaying the model.
+     * @return the ratio of the model size to the display size on that axis.
+     */
+    static double getRelativeMovementMultiplier(double objectMin, double objectMax, int movementRange) {
+        if (movementRange == 0)
+            return 0;
+
+        double objectAxis = Math.abs(objectMax - objectMin);
+
+        return objectAxis / (double)movementRange;
+    }
     
 }


### PR DESCRIPTION
Allow zooming and panning, but keep the center of rotation at the center
of the model. Some standardish controls implemented: mouse wheel zooms
in-out, middle mouse button pans, shift + mouse movement pans, ctrl-+
and ctrl-- zoom in and out. ctrl-0 returns to 0 zoom. Esc returns to 0
zoom and default rotation.
