### PR TITLE
Add G90.1 and G91.1 support to the visualizer.

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -70,8 +70,8 @@ javac.compilerargs=
 javac.deprecation=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.6
-javac.target=1.6
+javac.source=1.7
+javac.target=1.7
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}:\

--- a/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -131,13 +131,13 @@ public class GcodePreprocessorUtils {
         return command.replaceAll("\\s","");
     }
     
-    static public List<Integer> parseCodes(List<String> args, char code) {
-        List<Integer> l = new ArrayList<Integer>();
+    static public List<String> parseCodes(List<String> args, char code) {
+        List<String> l = new ArrayList<String>();
         char address = Character.toUpperCase(code);
         
         for (String s : args) {
             if (s.length() > 0 && Character.toUpperCase(s.charAt(0)) == address) {
-                l.add(Integer.parseInt(s.substring(1)));
+                l.add(s.substring(1));
             }
         }
         


### PR DESCRIPTION
For Issue #104

Parse G-Code number as a string, instead of an int. Considered using float or double, but didn't want to deal with possible x.0 strings. Using Strings in a switch statement required an update to the target platform version.

![image](https://f.cloud.github.com/assets/3976337/1809377/f480f424-6ddd-11e3-8c7e-00d69b5629ec.png)
