### PR TITLE
declare compiler source and target in pom.xml to 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ tar.gz
 /UGSPlatform/CentralLookup/nbproject/private/
 /UGSPlatform/Options/nbproject/private/
 /UGSPlatform/VisualizerModule/build/
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Hi,

as it is required since UGS 1.7, the Java source and target in the pom.xml should also be 1.7.
I also added IntelliJ IDEA project files to the ignore list.

Regards
Martin