### PR TITLE
performance enhancement - optimize file preprocessing

### DIFF
--- a/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
@@ -347,7 +347,7 @@ public class GcodeParser {
             i++;
             row++;
             if (i >= interval) {
-                System.out.println("row " + (int)row + " of " + count + "(" + (row/count) + "%)");
+                System.out.println("row " + (int)row + " of " + count);
                 i = 0;
             }
             result.addAll(preprocessCommand(command));

--- a/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
@@ -337,9 +337,19 @@ public class GcodeParser {
     }
 
     public List<String> preprocessCommands(Collection<String> commands) {
-        List<String> result = new ArrayList<>(commands.size());
+        int count = commands.size();
+        int interval = count / 1000;
+        List<String> result = new ArrayList<>(count);
 
+        int i = 0;
+        double row = 0;
         for (String command : commands) {
+            i++;
+            row++;
+            if (i >= interval) {
+                System.out.println("row "+row+" of "+count + "("+(row/count)+"%)");
+                i = 0;
+            }
             result.addAll(preprocessCommand(command));
         }
 

--- a/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
@@ -347,7 +347,7 @@ public class GcodeParser {
             i++;
             row++;
             if (i >= interval) {
-                System.out.println("row "+row+" of "+count + "("+(row/count)+"%)");
+                System.out.println("row " + (int)row + " of " + count + "(" + (row/count) + "%)");
                 i = 0;
             }
             result.addAll(preprocessCommand(command));

--- a/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -41,9 +41,9 @@ public class GcodePreprocessorUtils {
     private static Pattern COMMENT_SEMICOLON = Pattern.compile(";.*");
     private static Pattern COMMENTPARSE = Pattern.compile("(?<=\\()[^\\(\\)]*|(?<=\\;).*|%");
     private static Pattern WHITESPACE = Pattern.compile("\\s");
-    static private Pattern gPattern = Pattern.compile("[Gg]0*(\\d+)");
+    private static Pattern gPattern = Pattern.compile("[Gg]0*(\\d+)");
 
-    static private int decimalLength = -1;
+    private static int decimalLength = -1;
     private static Pattern decimalPattern;
     private static DecimalFormat decimalFormatter;
 
@@ -77,13 +77,7 @@ public class GcodePreprocessorUtils {
         String newCommand = command;
 
         // Remove any comments within ( parentheses ) using regex "\([^\(]*\)"
-
-
         newCommand = COMMENT_PAREN.matcher(command).replaceAll(EMPTY);
-//        newCommand = newCommand.replaceAll("\\([^\\(]*\\)", EMPTY);
-
-        // Remove any comment beginning with ';' using regex ";.*"
-//        newCommand = newCommand.replaceAll(";.*", EMPTY);
         newCommand = COMMENT_SEMICOLON.matcher(newCommand).replaceAll(EMPTY);
 
         // Don't send these to the controller.
@@ -103,7 +97,6 @@ public class GcodePreprocessorUtils {
         // REGEX: Find any comment, includes the comment characters:
         //              "(?<=\()[^\(\)]*|(?<=\;)[^;]*"
         //              "(?<=\\()[^\\(\\)]*|(?<=\\;)[^;]*"
-        
         Matcher matcher = COMMENTPARSE.matcher(command);
         if (matcher.find()){
             comment = matcher.group(0);
@@ -114,29 +107,9 @@ public class GcodePreprocessorUtils {
     
     static public String truncateDecimals(int length, String command) {
         if (length != decimalLength) {
-            StringBuilder df = new StringBuilder();
+            //Only build the decimal formatter if the truncation length has changed.
+            updateDecimalFormatter(length);
 
-            // Build up the decimal formatter.
-            df.append("#");
-
-            if (length != 0) {
-                df.append(".");
-            }
-            for (int i = 0; i < length; i++) {
-                df.append('#');
-            }
-
-            decimalFormatter = new DecimalFormat(df.toString(), Localization.dfs);
-
-            // Build up the regular expression.
-            df = new StringBuilder();
-            df.append("\\d+\\.\\d");
-            for (int i = 0; i < length; i++) {
-                df.append("\\d");
-            }
-            df.append('+');
-            decimalPattern = Pattern.compile(df.toString());
-            decimalLength = length;
         }
         Matcher matcher = decimalPattern.matcher(command);
 
@@ -152,10 +125,35 @@ public class GcodePreprocessorUtils {
         // Return new command.
         return sb.toString();
     }
-    
-    
+
+    private static void updateDecimalFormatter(int length) {
+        StringBuilder df = new StringBuilder();
+
+        // Build up the decimal formatter.
+        df.append("#");
+
+        if (length != 0) {
+            df.append(".");
+        }
+        for (int i = 0; i < length; i++) {
+            df.append('#');
+        }
+
+        decimalFormatter = new DecimalFormat(df.toString(), Localization.dfs);
+
+        // Build up the regular expression.
+        df = new StringBuilder();
+        df.append("\\d+\\.\\d");
+        for (int i = 0; i < length; i++) {
+            df.append("\\d");
+        }
+        df.append('+');
+        decimalPattern = Pattern.compile(df.toString());
+        decimalLength = length;
+    }
+
+
     static public String removeAllWhitespace(String command) {
-//        return command.replaceAll("\\s", EMPTY);
         return WHITESPACE.matcher(command).replaceAll(EMPTY);
     }
     

--- a/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -36,6 +36,17 @@ import javax.vecmath.Point3d;
  */
 public class GcodePreprocessorUtils {
 
+    public static final String EMPTY = "";
+    private static Pattern COMMENT_PAREN = Pattern.compile("\\([^\\(]*\\)");
+    private static Pattern COMMENT_SEMICOLON = Pattern.compile(";.*");
+    private static Pattern COMMENTPARSE = Pattern.compile("(?<=\\()[^\\(\\)]*|(?<=\\;).*|%");
+    private static Pattern WHITESPACE = Pattern.compile("\\s");
+    static private Pattern gPattern = Pattern.compile("[Gg]0*(\\d+)");
+
+    static private int decimalLength = -1;
+    private static Pattern decimalPattern;
+    private static DecimalFormat decimalFormatter;
+
     /**
      * Searches the command string for an 'f' and replaces the speed value 
      * between the 'f' and the next space with a percentage of that speed.
@@ -66,10 +77,14 @@ public class GcodePreprocessorUtils {
         String newCommand = command;
 
         // Remove any comments within ( parentheses ) using regex "\([^\(]*\)"
-        newCommand = newCommand.replaceAll("\\([^\\(]*\\)", "");
+
+
+        newCommand = COMMENT_PAREN.matcher(command).replaceAll(EMPTY);
+//        newCommand = newCommand.replaceAll("\\([^\\(]*\\)", EMPTY);
 
         // Remove any comment beginning with ';' using regex ";.*"
-        newCommand = newCommand.replaceAll(";.*", "");
+//        newCommand = newCommand.replaceAll(";.*", EMPTY);
+        newCommand = COMMENT_SEMICOLON.matcher(newCommand).replaceAll(EMPTY);
 
         // Don't send these to the controller.
         if (newCommand.endsWith("%")) {
@@ -83,14 +98,13 @@ public class GcodePreprocessorUtils {
      * Searches for a comment in the input string and returns the first match.
      */
     static public String parseComment(String command) {
-        String comment = "";
+        String comment = EMPTY;
 
         // REGEX: Find any comment, includes the comment characters:
         //              "(?<=\()[^\(\)]*|(?<=\;)[^;]*"
         //              "(?<=\\()[^\\(\\)]*|(?<=\\;)[^;]*"
         
-        Pattern pattern = Pattern.compile("(?<=\\()[^\\(\\)]*|(?<=\\;).*|%");
-        Matcher matcher = pattern.matcher(command);
+        Matcher matcher = COMMENTPARSE.matcher(command);
         if (matcher.find()){
             comment = matcher.group(0);
         }
@@ -99,34 +113,39 @@ public class GcodePreprocessorUtils {
     }
     
     static public String truncateDecimals(int length, String command) {
-        StringBuilder df = new StringBuilder();
-        
-        // Build up the decimal formatter.
-        df.append("#");
-        
-        if (length != 0) { df.append("."); }
-        for (int i=0; i < length; i++) {
-            df.append('#');
+        if (length != decimalLength) {
+            StringBuilder df = new StringBuilder();
+
+            // Build up the decimal formatter.
+            df.append("#");
+
+            if (length != 0) {
+                df.append(".");
+            }
+            for (int i = 0; i < length; i++) {
+                df.append('#');
+            }
+
+            decimalFormatter = new DecimalFormat(df.toString(), Localization.dfs);
+
+            // Build up the regular expression.
+            df = new StringBuilder();
+            df.append("\\d+\\.\\d");
+            for (int i = 0; i < length; i++) {
+                df.append("\\d");
+            }
+            df.append('+');
+            decimalPattern = Pattern.compile(df.toString());
+            decimalLength = length;
         }
-        
-        DecimalFormat formatter = new DecimalFormat(df.toString(), Localization.dfs);
-        
-        // Build up the regular expression.
-        df = new StringBuilder();
-        df.append("\\d+\\.\\d");
-        for (int i=0; i < length; i++) {
-            df.append("\\d");
-        }
-        df.append('+');
-        Pattern pattern = Pattern.compile(df.toString());
-        Matcher matcher = pattern.matcher(command);
+        Matcher matcher = decimalPattern.matcher(command);
 
         // Build up the truncated command.
         Double d;
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             d = Double.parseDouble(matcher.group());
-            matcher.appendReplacement(sb, formatter.format(d));
+            matcher.appendReplacement(sb, decimalFormatter.format(d));
         }
         matcher.appendTail(sb);
         
@@ -136,7 +155,8 @@ public class GcodePreprocessorUtils {
     
     
     static public String removeAllWhitespace(String command) {
-        return command.replaceAll("\\s","");
+//        return command.replaceAll("\\s", EMPTY);
+        return WHITESPACE.matcher(command).replaceAll(EMPTY);
     }
     
     static public List<String> parseCodes(List<String> args, char code) {
@@ -152,7 +172,7 @@ public class GcodePreprocessorUtils {
         return l;
     }
     
-    static private Pattern gPattern = Pattern.compile("[Gg]0*(\\d+)");
+
     static public List<Integer> parseGCodes(String command) {
         Matcher matcher = gPattern.matcher(command);
         List<Integer> codes = new ArrayList<>();

--- a/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -591,6 +591,7 @@ public class GUIBackend implements BackendAPI, ControllerListener {
                 cs = Charset.forName(fr.getEncoding());
             }
             List<String> lines = Files.readAllLines(this.gcodeFile.toPath(), cs);
+            System.out.println("Finished loading");
             if (this.processedCommandLines == null || forceReprocess)
                 this.processedCommandLines = gcp.preprocessCommands(lines);
 

--- a/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -592,8 +592,12 @@ public class GUIBackend implements BackendAPI, ControllerListener {
             }
             List<String> lines = Files.readAllLines(this.gcodeFile.toPath(), cs);
             System.out.println("Finished loading");
-            if (this.processedCommandLines == null || forceReprocess)
+            long start = System.currentTimeMillis();
+            if (this.processedCommandLines == null || forceReprocess) {
                 this.processedCommandLines = gcp.preprocessCommands(lines);
+            }
+            long end = System.currentTimeMillis();
+            System.out.println("Took " + (end - start) + "ms to preprocess");
 
             if (this.isConnected()) {
                 this.estimatedSendDuration = -1L;


### PR DESCRIPTION
When opening large files, the preprocessing takes a very long time.  By compiling the regular expressions once rather than using the string.replaceAll methods, we can save significant time.

On my laptop, I opened a gcode file with 7233438 lines (laser image raster)
with my changes - 16155ms
master - 56178ms 

I believe this addresses at least part of Issue #168.  