### PR TITLE
Macros are stored in a collection

### DIFF
--- a/src/com/willwinder/universalgcodesender/MainWindow.form
+++ b/src/com/willwinder/universalgcodesender/MainWindow.form
@@ -1002,10 +1002,7 @@
             </Component>
           </SubComponents>
         </Container>
-        <Container class="com.willwinder.universalgcodesender.uielements.MacroPanel" name="macroPanel">
-          <AuxValues>
-            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new com.willwinder.universalgcodesender.uielements.MacroPanel(settings)"/>
-          </AuxValues>
+        <Container class="javax.swing.JScrollPane" name="macroPane">
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
               <JTabbedPaneConstraints tabName="Macros">
@@ -1014,7 +1011,16 @@
             </Constraint>
           </Constraints>
 
-          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+          <SubComponents>
+            <Container class="com.willwinder.universalgcodesender.uielements.MacroPanel" name="macroPanel">
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new com.willwinder.universalgcodesender.uielements.MacroPanel(settings)"/>
+              </AuxValues>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+            </Container>
+          </SubComponents>
         </Container>
       </SubComponents>
     </Container>

--- a/src/com/willwinder/universalgcodesender/MainWindow.form
+++ b/src/com/willwinder/universalgcodesender/MainWindow.form
@@ -1170,6 +1170,17 @@
             </Component>
           </SubComponents>
         </Container>
+        <Container class="com.willwinder.universalgcodesender.uielements.MacroPanel" name="macroPanel1">
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
+              <JTabbedPaneConstraints tabName="tab5">
+                <Property name="tabTitle" type="java.lang.String" value="tab5"/>
+              </JTabbedPaneConstraints>
+            </Constraint>
+          </Constraints>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+        </Container>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="connectionPanel">
@@ -1244,7 +1255,7 @@
                       <Component id="firmwareLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="firmwareComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace pref="25" max="32767" attributes="0"/>
+                  <EmptySpace pref="45" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -1467,7 +1478,7 @@
                           </Group>
                       </Group>
                   </Group>
-                  <EmptySpace pref="6" max="32767" attributes="0"/>
+                  <EmptySpace pref="23" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>

--- a/src/com/willwinder/universalgcodesender/MainWindow.form
+++ b/src/com/willwinder/universalgcodesender/MainWindow.form
@@ -1015,7 +1015,7 @@
           <SubComponents>
             <Container class="com.willwinder.universalgcodesender.uielements.MacroPanel" name="macroPanel">
               <AuxValues>
-                <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new com.willwinder.universalgcodesender.uielements.MacroPanel(settings)"/>
+                <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new com.willwinder.universalgcodesender.uielements.MacroPanel(settings, this)"/>
               </AuxValues>
 
               <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>

--- a/src/com/willwinder/universalgcodesender/MainWindow.form
+++ b/src/com/willwinder/universalgcodesender/MainWindow.form
@@ -1002,7 +1002,10 @@
             </Component>
           </SubComponents>
         </Container>
-        <Container class="javax.swing.JPanel" name="macroPanel">
+        <Container class="com.willwinder.universalgcodesender.uielements.MacroPanel" name="macroPanel">
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new com.willwinder.universalgcodesender.uielements.MacroPanel(settings)"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
               <JTabbedPaneConstraints tabName="Macros">
@@ -1011,175 +1014,7 @@
             </Constraint>
           </Constraints>
 
-          <Layout>
-            <DimensionLayout dim="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="customGcodeButton1" min="-2" pref="49" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" max="-2" attributes="0"/>
-                              <Component id="customGcodeText1" max="32767" attributes="0"/>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="customGcodeButton2" min="-2" pref="49" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" max="-2" attributes="0"/>
-                              <Component id="customGcodeText2" max="32767" attributes="0"/>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="customGcodeButton4" min="-2" pref="49" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" max="-2" attributes="0"/>
-                              <Component id="customGcodeText4" max="32767" attributes="0"/>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="customGcodeButton3" min="-2" pref="49" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" max="-2" attributes="0"/>
-                              <Component id="customGcodeText3" max="32767" attributes="0"/>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="customGcodeButton5" min="-2" pref="49" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" max="-2" attributes="0"/>
-                              <Component id="customGcodeText5" max="32767" attributes="0"/>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="macroInstructions" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                          </Group>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                  </Group>
-              </Group>
-            </DimensionLayout>
-            <DimensionLayout dim="1">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="8" max="-2" attributes="0"/>
-                      <Component id="macroInstructions" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="customGcodeButton1" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="customGcodeText1" alignment="3" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="customGcodeButton2" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="customGcodeText2" alignment="3" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="customGcodeButton3" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="customGcodeText3" alignment="3" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="customGcodeButton4" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="customGcodeText4" alignment="3" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="customGcodeButton5" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="customGcodeText5" alignment="3" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace pref="76" max="32767" attributes="0"/>
-                  </Group>
-              </Group>
-            </DimensionLayout>
-          </Layout>
-          <SubComponents>
-            <Component class="javax.swing.JButton" name="customGcodeButton4">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="C4"/>
-                <Property name="enabled" type="boolean" value="false"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeButton4ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JButton" name="customGcodeButton3">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="C3"/>
-                <Property name="enabled" type="boolean" value="false"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeButton3ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JButton" name="customGcodeButton2">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="C2"/>
-                <Property name="enabled" type="boolean" value="false"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeButton2ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JButton" name="customGcodeButton1">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="C1"/>
-                <Property name="enabled" type="boolean" value="false"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeButton1ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JButton" name="customGcodeButton5">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="C5"/>
-                <Property name="enabled" type="boolean" value="false"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeButton5ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JTextField" name="customGcodeText1">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="G91 X0 Y0"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeText1ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JTextField" name="customGcodeText2">
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeText2ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JTextField" name="customGcodeText3">
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeText3ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JTextField" name="customGcodeText4">
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeText4ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JTextField" name="customGcodeText5">
-              <Properties>
-                <Property name="toolTipText" type="java.lang.String" value=""/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customGcodeText5ActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JLabel" name="macroInstructions">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="asgasg"/>
-              </Properties>
-            </Component>
-          </SubComponents>
-        </Container>
-        <Container class="com.willwinder.universalgcodesender.uielements.MacroPanel" name="macroPanel1">
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
-              <JTabbedPaneConstraints tabName="tab5">
-                <Property name="tabTitle" type="java.lang.String" value="tab5"/>
-              </JTabbedPaneConstraints>
-            </Constraint>
-          </Constraints>
-
-          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
         </Container>
       </SubComponents>
     </Container>

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -259,48 +259,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
         });
     }
 
-
-
-    private void customGcodeText1ActionPerformed(java.awt.event.ActionEvent evt) {
-
-    }
-
-    private void customGcodeText2ActionPerformed(java.awt.event.ActionEvent evt) {
-
-    }
-
-    private void customGcodeText3ActionPerformed(java.awt.event.ActionEvent evt) {
-
-    }
-
-    private void customGcodeText4ActionPerformed(java.awt.event.ActionEvent evt) {
-
-    }
-
-    private void customGcodeText5ActionPerformed(java.awt.event.ActionEvent evt) {
-
-    }
-
-    private void customGcodeButton1ActionPerformed(ActionEvent evt) {
-
-    }
-
-    private void customGcodeButton2ActionPerformed(ActionEvent evt) {
-
-    }
-
-    private void customGcodeButton3ActionPerformed(ActionEvent evt) {
-
-    }
-
-    private void customGcodeButton4ActionPerformed(ActionEvent evt) {
-
-    }
-
-    private void customGcodeButton5ActionPerformed(ActionEvent evt) {
-
-    }
-
     /** This method is called from within the constructor to
      * initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is
@@ -372,7 +330,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         resetYButton = new javax.swing.JButton();
         resetZButton = new javax.swing.JButton();
         macroPane = new javax.swing.JScrollPane();
-        macroPanel = new com.willwinder.universalgcodesender.uielements.MacroPanel(settings);
+        macroPanel = new com.willwinder.universalgcodesender.uielements.MacroPanel(settings, this);
         connectionPanel = new javax.swing.JPanel();
         commPortComboBox = new javax.swing.JComboBox();
         baudrateSelectionComboBox = new javax.swing.JComboBox();
@@ -1863,7 +1821,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private void mmRadioButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mmRadioButtonActionPerformed
     }//GEN-LAST:event_mmRadioButtonActionPerformed
 
-    private void executeCustomGcode(String str)
+    public void executeCustomGcode(String str)
     {
         if (str == null) {
             return;

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -132,11 +132,11 @@ implements KeyListener, ControllerListener, ControlStateListener {
         checkScrollWindow();
         showVerboseOutputCheckBox.setSelected(settings.isVerboseOutputEnabled());
         firmwareComboBox.setSelectedItem(settings.getFirmwareVersion());
-        customGcodeText1.setText(settings.getCustomGcode1());
-        customGcodeText2.setText(settings.getCustomGcode2());
-        customGcodeText3.setText(settings.getCustomGcode3());
-        customGcodeText4.setText(settings.getCustomGcode4());
-        customGcodeText5.setText(settings.getCustomGcode5());
+        customGcodeText1.setText(settings.getMacro(1).getGcode());
+        customGcodeText2.setText(settings.getMacro(2).getGcode());
+        customGcodeText3.setText(settings.getMacro(3).getGcode());
+        customGcodeText4.setText(settings.getMacro(4).getGcode());
+        customGcodeText5.setText(settings.getMacro(5).getGcode());
         setSize(settings.getMainWindowSettings().width, settings.getMainWindowSettings().height);
         setLocation(settings.getMainWindowSettings().xLocation, settings.getMainWindowSettings().yLocation);
 //        mw.setSize(java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds().width, java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds().width);
@@ -160,24 +160,24 @@ implements KeyListener, ControllerListener, ControlStateListener {
                 settings.setVerboseOutputEnabled(showVerboseOutputCheckBox.isSelected());
                 settings.setFirmwareVersion(firmwareComboBox.getSelectedItem().toString());
 
-                if (!customGcodeText1.getText().equals(settings.getCustomGcode1())) {
-                    settings.setCustomGcode1(customGcodeText1.getText());
+                if (!customGcodeText1.getText().equals(settings.getMacro(1).getGcode())) {
+                    settings.updateMacro(1, null, null, customGcodeText1.getText());
                 }
 
-                if (!customGcodeText2.getText().equals(settings.getCustomGcode2())) {
-                    settings.setCustomGcode2(customGcodeText2.getText());
+                if (!customGcodeText2.getText().equals(settings.getMacro(2).getGcode())) {
+                    settings.updateMacro(2, null, null, customGcodeText2.getText());
                 }
 
-                if (!customGcodeText3.getText().equals(settings.getCustomGcode3())) {
-                    settings.setCustomGcode3(customGcodeText3.getText());
+                if (!customGcodeText3.getText().equals(settings.getMacro(3))) {
+                    settings.updateMacro(3, null, null, customGcodeText3.getText());
                 }
 
-                if (!customGcodeText4.getText().equals(settings.getCustomGcode4())) {
-                    settings.setCustomGcode4(customGcodeText4.getText());
+                if (!customGcodeText4.getText().equals(settings.getMacro(4))) {
+                    settings.updateMacro(4, null, null, customGcodeText4.getText());
                 }
 
-                if (!customGcodeText5.getText().equals(settings.getCustomGcode5())) {
-                    settings.setCustomGcode5(customGcodeText5.getText());
+                if (!customGcodeText5.getText().equals(settings.getMacro(5))) {
+                    settings.updateMacro(5, null, null, customGcodeText5.getText());
                 }
 
                 SettingsFactory.saveSettings(settings);
@@ -1892,7 +1892,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         }//GEN-LAST:event_stopPendantServerButtonActionPerformed
 
     private void customGcodeText1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeText1ActionPerformed
-        this.settings.setCustomGcode1(this.customGcodeText1.getText());
+        this.settings.updateMacro(1, null, null, this.customGcodeText1.getText());
     }//GEN-LAST:event_customGcodeText1ActionPerformed
 
     private void customGcodeButton5ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeButton5ActionPerformed
@@ -2066,19 +2066,19 @@ implements KeyListener, ControllerListener, ControlStateListener {
     }//GEN-LAST:event_resetCoordinatesButtonActionPerformed
 
     private void customGcodeText2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeText2ActionPerformed
-        this.settings.setCustomGcode2(this.customGcodeText2.getText());
+        this.settings.updateMacro(2, null, null, this.customGcodeText2.getText());
     }//GEN-LAST:event_customGcodeText2ActionPerformed
 
     private void customGcodeText3ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeText3ActionPerformed
-        this.settings.setCustomGcode3(this.customGcodeText3.getText());
+        this.settings.updateMacro(3, null, null, this.customGcodeText3.getText());
     }//GEN-LAST:event_customGcodeText3ActionPerformed
 
     private void customGcodeText4ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeText4ActionPerformed
-        this.settings.setCustomGcode4(this.customGcodeText4.getText());
+        this.settings.updateMacro(4, null, null, this.customGcodeText4.getText());
     }//GEN-LAST:event_customGcodeText4ActionPerformed
 
     private void customGcodeText5ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeText5ActionPerformed
-        this.settings.setCustomGcode5(this.customGcodeText5.getText());
+        this.settings.updateMacro(5, null, null, this.customGcodeText5.getText());
     }//GEN-LAST:event_customGcodeText5ActionPerformed
 
     private void inchRadioButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_inchRadioButtonActionPerformed
@@ -2430,7 +2430,9 @@ implements KeyListener, ControllerListener, ControlStateListener {
         String[] portList = CommUtils.getSerialPortList();
 
         if (portList.length < 1) {
-            MainWindow.displayErrorDialog(Localization.getString("mainWindow.error.noSerialPort"));
+            if (settings.isShowSerialPortWarning()) {
+                MainWindow.displayErrorDialog(Localization.getString("mainWindow.error.noSerialPort"));
+            }
         } else {
             // Sort?
             //java.util.Collections.sort(portList);

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -371,6 +371,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         resetXButton = new javax.swing.JButton();
         resetYButton = new javax.swing.JButton();
         resetZButton = new javax.swing.JButton();
+        macroPane = new javax.swing.JScrollPane();
         macroPanel = new com.willwinder.universalgcodesender.uielements.MacroPanel(settings);
         connectionPanel = new javax.swing.JPanel();
         commPortComboBox = new javax.swing.JComboBox();
@@ -982,7 +983,10 @@ implements KeyListener, ControllerListener, ControlStateListener {
         );
 
         controlContextTabbedPane.addTab("Machine Control", machineControlPanel);
-        controlContextTabbedPane.addTab("Macros", macroPanel);
+
+        macroPane.setViewportView(macroPanel);
+
+        controlContextTabbedPane.addTab("Macros", macroPane);
 
         connectionPanel.setBorder(javax.swing.BorderFactory.createTitledBorder("Connection"));
         connectionPanel.setMaximumSize(new java.awt.Dimension(247, 100));
@@ -2193,7 +2197,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         this.stepSizeLabel.setText(Localization.getString("mainWindow.swing.stepSizeLabel"));
         this.visualizeButton.setText(Localization.getString("mainWindow.swing.visualizeButton"));
         this.workPositionLabel.setText(Localization.getString("mainWindow.swing.workPositionLabel"));
-//        this.macroInstructions.setText(Localization.getString("mainWindow.swing.macroInstructions"));
+        this.macroPane.setToolTipText(Localization.getString("mainWindow.swing.macroInstructions"));
         this.inchRadioButton.setText(Localization.getString("mainWindow.swing.inchRadioButton"));
         this.mmRadioButton.setText(Localization.getString("mainWindow.swing.mmRadioButton"));
     }
@@ -2421,6 +2425,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private javax.swing.JLabel machinePositionYValueLabel;
     private javax.swing.JLabel machinePositionZLabel;
     private javax.swing.JLabel machinePositionZValueLabel;
+    private javax.swing.JScrollPane macroPane;
     private com.willwinder.universalgcodesender.uielements.MacroPanel macroPanel;
     private javax.swing.JMenuBar mainMenuBar;
     private javax.swing.JRadioButton mmRadioButton;

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -281,6 +281,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
             }
         }
 
+
         org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(macroPanel);
 
         GroupLayout.ParallelGroup parallelGroup = macroPanelLayout.createParallelGroup(GroupLayout.LEADING);
@@ -413,6 +414,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         resetYButton = new javax.swing.JButton();
         resetZButton = new javax.swing.JButton();
         macroPanel = new javax.swing.JPanel();
+        macroScrollPane = new JScrollPane(macroPanel);
         macroInstructions = new javax.swing.JLabel();
         connectionPanel = new javax.swing.JPanel();
         commPortComboBox = new javax.swing.JComboBox();
@@ -1025,7 +1027,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
 
         controlContextTabbedPane.addTab("Machine Control", machineControlPanel);
 
-        controlContextTabbedPane.addTab("Macros", macroPanel);
+        controlContextTabbedPane.addTab("Macros", macroScrollPane);
 
         connectionPanel.setBorder(javax.swing.BorderFactory.createTitledBorder("Connection"));
         connectionPanel.setMaximumSize(new java.awt.Dimension(247, 100));
@@ -2291,21 +2293,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
         this.commandTable.setAutoWindowScroll(scrollWindowCheckBox.isSelected());
     }
     
-    private String getNewline() {
-        return "\r\n";
-        
-        /*
-        if (lineBreakNR.isSelected())
-            return "\n\r";
-        else if (lineBreakRN.isSelected())
-            return "\r\n";
-        else if (lineBreakN.isSelected())
-            return "\n";
-        else
-            return "wtfbbq";
-        */
-    }
-    
     void clearTable() {
         this.commandTable.clear();
     }
@@ -2483,6 +2470,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private javax.swing.JLabel machinePositionZValueLabel;
     private javax.swing.JLabel macroInstructions;
     private javax.swing.JPanel macroPanel;
+    private javax.swing.JScrollPane macroScrollPane;
     private javax.swing.JMenuBar mainMenuBar;
     private javax.swing.JRadioButton mmRadioButton;
     private javax.swing.JPanel movementButtonPanel;

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -26,6 +26,7 @@
 package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.types.Macro;
+import com.willwinder.universalgcodesender.uielements.*;
 import com.willwinder.universalgcodesender.utils.CommUtils;
 import com.willwinder.universalgcodesender.utils.FirmwareUtils;
 import com.willwinder.universalgcodesender.utils.Settings;
@@ -35,10 +36,6 @@ import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.pendantui.PendantUI;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
-import com.willwinder.universalgcodesender.uielements.ConnectionSettingsDialog;
-import com.willwinder.universalgcodesender.uielements.GcodeFileTypeFilter;
-import com.willwinder.universalgcodesender.uielements.GrblFirmwareSettingsDialog;
-import com.willwinder.universalgcodesender.uielements.StepSizeSpinnerModel;
 import com.willwinder.universalgcodesender.visualizer.VisualizerWindow;
 import com.willwinder.universalgcodesender.model.ControlStateEvent;
 import com.willwinder.universalgcodesender.listeners.ControlStateListener;
@@ -154,26 +151,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
                 settings.setVerboseOutputEnabled(showVerboseOutputCheckBox.isSelected());
                 settings.setFirmwareVersion(firmwareComboBox.getSelectedItem().toString());
 
-//                if (!customGcodeText1.getText().equals(settings.getCustomGcode1())) {
-//                    settings.setCustomGcode1(customGcodeText1.getText());
-//                }
-//
-//                if (!customGcodeText2.getText().equals(settings.getCustomGcode2())) {
-//                    settings.setCustomGcode2(customGcodeText2.getText());
-//                }
-//
-//                if (!customGcodeText3.getText().equals(settings.getCustomGcode3())) {
-//                    settings.setCustomGcode3(customGcodeText3.getText());
-//                }
-//
-//                if (!customGcodeText4.getText().equals(settings.getCustomGcode4())) {
-//                    settings.setCustomGcode4(customGcodeText4.getText());
-//                }
-//
-//                if (!customGcodeText5.getText().equals(settings.getCustomGcode5())) {
-//                    settings.setCustomGcode5(customGcodeText5.getText());
-//                }
-
                 SettingsFactory.saveSettings(settings);
                 
                 if(pendantUI!=null){
@@ -286,12 +263,13 @@ implements KeyListener, ControllerListener, ControlStateListener {
     }
 
     private  void initMacroButtons(Settings settings) {
-        Map<Integer, Macro> macros = settings.getMacros();
-        for (int i = 0; i < macros.size(); i++) {
+        Integer lastMacroIndex = settings.getLastMacroIndex()+1;
+        logger.info((lastMacroIndex) + " macros");
+        for (int i = 0; i <= lastMacroIndex; i++) {
             JButton button = createMacroButton(i);
-            JTextField textField = createMacroTextField();
+            JTextField textField = createMacroTextField(i);
 
-            Macro macro = macros.get(i);
+            Macro macro = settings.getMacro(i);
             if (macro != null) {
                 textField.setText(macro.getGcode());
                 if (macro.getName() != null) {
@@ -302,10 +280,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
                 }
             }
         }
-
-        //Add extras for future expansion
-        JButton button = createMacroButton(macros.size());
-        JTextField textField = createMacroTextField();
 
         org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(macroPanel);
 
@@ -348,8 +322,9 @@ implements KeyListener, ControllerListener, ControlStateListener {
         macroPanel.setLayout(macroPanelLayout);
     }
 
-    private JTextField createMacroTextField() {
-        JTextField textField = new JTextField();
+    private JTextField createMacroTextField(int index) {
+        JTextField textField = new MacroTextField(index, settings);
+
         customGcodeTextFields.add(textField);
         return textField;
     }
@@ -1714,36 +1689,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
             MainWindow.displayErrorDialog(e.getMessage());
         }
         
-        /*
-        SwingWorker<Boolean, Void> worker = new SwingWorker<Boolean, Void>() {
-            
-            boolean error = false;
-            String errorMessage = "";
-            @Override
-            protected Boolean doInBackground() throws Exception {
-                try {
-                    backend.send();
-                    resetSentRowLabels(backend.getNumRows());
-                    timer.start();
-                } catch (Exception e) {
-                    timer.stop();
-                    logger.log(Level.INFO, "Exception in sendButtonActionPerformed.", e);
-                    error = true;
-                    errorMessage = e.getMessage();
-                    //MainWindow.displayErrorDialog(e.getMessage());
-                }
-                return true;
-            }
-
-            // Can safely update the GUI from this method.
-            protected void done() {
-                if (error)
-                    MainWindow.displayErrorDialog(errorMessage);
-            }
-        };
-
-        worker.execute();
-        */
     }//GEN-LAST:event_sendButtonActionPerformed
 
     private void grblFirmwareSettingsMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_grblFirmwareSettingsMenuItemActionPerformed
@@ -1800,30 +1745,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
 	    this.startPendantServerButton.setEnabled(true);
 	    this.stopPendantServerButton.setEnabled(false);
         }//GEN-LAST:event_stopPendantServerButtonActionPerformed
-
-//    private void customGcodeText1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeText1ActionPerformed
-//        this.settings.setCustomGcode1(this.customGcodeText1.getText());
-//    }//GEN-LAST:event_customGcodeText1ActionPerformed
-//
-//    private void customGcodeButton5ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeButton5ActionPerformed
-//        executeCustomGcode(this.customGcodeText5.getText());
-//    }//GEN-LAST:event_customGcodeButton5ActionPerformed
-//
-//    private void customGcodeButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeButton1ActionPerformed
-//        executeCustomGcode(this.customGcodeText1.getText());
-//    }//GEN-LAST:event_customGcodeButton1ActionPerformed
-//
-//    private void customGcodeButton2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeButton2ActionPerformed
-//        executeCustomGcode(this.customGcodeText2.getText());
-//    }//GEN-LAST:event_customGcodeButton2ActionPerformed
-//
-//    private void customGcodeButton3ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeButton3ActionPerformed
-//        executeCustomGcode(this.customGcodeText3.getText());
-//    }//GEN-LAST:event_customGcodeButton3ActionPerformed
-//
-//    private void customGcodeButton4ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_customGcodeButton4ActionPerformed
-//        executeCustomGcode(this.customGcodeText4.getText());
-//    }//GEN-LAST:event_customGcodeButton4ActionPerformed
 
     private void resetZCoordinateButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_resetZCoordinateButtonActionPerformed
         try {
@@ -1983,6 +1904,10 @@ implements KeyListener, ControllerListener, ControlStateListener {
 
     private void executeCustomGcode(String str)
     {
+        if (str == null) {
+            return;
+        }
+
         str = str.replaceAll("(\\r\\n|\\n\\r|\\r|\\n)", "");
         final String[] parts = str.split(";");
         java.awt.EventQueue.invokeLater(new Runnable() {
@@ -2234,9 +2159,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private void updateCustomGcodeControls(boolean enabled) {
         for(JButton button : customGcodeButtons) {
             button.setEnabled(enabled);
-        }
-        for (JTextField field : customGcodeTextFields) {
-            field.setEnabled(enabled);
         }
     }
 

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -92,7 +92,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
     
     // Duration timer
     private Timer timer;
-    
+
     /** Creates new form MainWindow */
     public MainWindow(BackendAPI backend) {
         this.backend = backend;
@@ -126,7 +126,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         checkScrollWindow();
         showVerboseOutputCheckBox.setSelected(settings.isVerboseOutputEnabled());
         firmwareComboBox.setSelectedItem(settings.getFirmwareVersion());
-        initMacroButtons(settings);
+//        macroPanel1.initMacroButtons(settings);
 
         setSize(settings.getMainWindowSettings().width, settings.getMainWindowSettings().height);
         setLocation(settings.getMainWindowSettings().xLocation, settings.getMainWindowSettings().yLocation);
@@ -262,85 +262,46 @@ implements KeyListener, ControllerListener, ControlStateListener {
         });
     }
 
-    private  void initMacroButtons(Settings settings) {
-        Integer lastMacroIndex = settings.getLastMacroIndex()+1;
-        logger.info((lastMacroIndex) + " macros");
-        for (int i = 0; i <= lastMacroIndex; i++) {
-            JButton button = createMacroButton(i);
-            JTextField textField = createMacroTextField(i);
-
-            Macro macro = settings.getMacro(i);
-            if (macro != null) {
-                textField.setText(macro.getGcode());
-                if (macro.getName() != null) {
-                    button.setText(macro.getName());
-                }
-                if (macro.getDescription() != null) {
-                    button.setToolTipText(macro.getDescription());
-                }
-            }
-        }
 
 
-        org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(macroPanel);
+    private void customGcodeText1ActionPerformed(java.awt.event.ActionEvent evt) {
 
-        GroupLayout.ParallelGroup parallelGroup = macroPanelLayout.createParallelGroup(GroupLayout.LEADING);
-
-        GroupLayout.SequentialGroup sequentialGroup = macroPanelLayout.createSequentialGroup();
-        parallelGroup.add(sequentialGroup);
-
-        sequentialGroup.addContainerGap();
-        GroupLayout.ParallelGroup parallelGroup1 = macroPanelLayout.createParallelGroup(GroupLayout.LEADING);
-        sequentialGroup.add(parallelGroup1);
-
-        for (int i = 0; i < customGcodeButtons.size(); i++) {
-            GroupLayout.SequentialGroup group = macroPanelLayout.createSequentialGroup();
-            group.add(customGcodeButtons.get(i), org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                    .add(customGcodeTextFields.get(i));
-            parallelGroup1.add(group);
-        }
-//        sequentialGroup.addContainerGap();
-
-        macroPanelLayout.setHorizontalGroup( parallelGroup );
-        GroupLayout.SequentialGroup sequentialGroup1 = macroPanelLayout.createSequentialGroup();
-        macroPanelLayout.setVerticalGroup(
-                macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                        .add(sequentialGroup1
-                                        .add(8, 8, 8)
-//                                        .add(macroInstructions)
-                        ));
-
-
-        for (int i = 0; i < customGcodeButtons.size(); i++) {
-//            sequentialGroup1.addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-            sequentialGroup1.add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(customGcodeButtons.get(i))
-                            .add(customGcodeTextFields.get(i), org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE));
-        }
-//        sequentialGroup1.addContainerGap(76, Short.MAX_VALUE);
-
-        macroPanel.setLayout(macroPanelLayout);
     }
 
-    private JTextField createMacroTextField(int index) {
-        JTextField textField = new MacroTextField(index, settings);
+    private void customGcodeText2ActionPerformed(java.awt.event.ActionEvent evt) {
 
-        customGcodeTextFields.add(textField);
-        return textField;
     }
 
-    private JButton createMacroButton(int i) {
-        JButton button = new JButton(i+"");
+    private void customGcodeText3ActionPerformed(java.awt.event.ActionEvent evt) {
 
-        button.setEnabled(false);
-        button.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent evt) {
-                customGcodeButtonActionPerformed(evt);
-            }
-        });
-        customGcodeButtons.add(button);
-        return button;
+    }
+
+    private void customGcodeText4ActionPerformed(java.awt.event.ActionEvent evt) {
+
+    }
+
+    private void customGcodeText5ActionPerformed(java.awt.event.ActionEvent evt) {
+
+    }
+
+    private void customGcodeButton1ActionPerformed(ActionEvent evt) {
+
+    }
+
+    private void customGcodeButton2ActionPerformed(ActionEvent evt) {
+
+    }
+
+    private void customGcodeButton3ActionPerformed(ActionEvent evt) {
+
+    }
+
+    private void customGcodeButton4ActionPerformed(ActionEvent evt) {
+
+    }
+
+    private void customGcodeButton5ActionPerformed(ActionEvent evt) {
+
     }
 
     /** This method is called from within the constructor to
@@ -414,8 +375,18 @@ implements KeyListener, ControllerListener, ControlStateListener {
         resetYButton = new javax.swing.JButton();
         resetZButton = new javax.swing.JButton();
         macroPanel = new javax.swing.JPanel();
-        macroScrollPane = new JScrollPane(macroPanel);
+        customGcodeButton4 = new javax.swing.JButton();
+        customGcodeButton3 = new javax.swing.JButton();
+        customGcodeButton2 = new javax.swing.JButton();
+        customGcodeButton1 = new javax.swing.JButton();
+        customGcodeButton5 = new javax.swing.JButton();
+        customGcodeText1 = new javax.swing.JTextField();
+        customGcodeText2 = new javax.swing.JTextField();
+        customGcodeText3 = new javax.swing.JTextField();
+        customGcodeText4 = new javax.swing.JTextField();
+        customGcodeText5 = new javax.swing.JTextField();
         macroInstructions = new javax.swing.JLabel();
+        macroPanel1 = new com.willwinder.universalgcodesender.uielements.MacroPanel(settings);
         connectionPanel = new javax.swing.JPanel();
         commPortComboBox = new javax.swing.JComboBox();
         baudrateSelectionComboBox = new javax.swing.JComboBox();
@@ -1027,7 +998,142 @@ implements KeyListener, ControllerListener, ControlStateListener {
 
         controlContextTabbedPane.addTab("Machine Control", machineControlPanel);
 
-        controlContextTabbedPane.addTab("Macros", macroScrollPane);
+        customGcodeButton4.setText("C4");
+        customGcodeButton4.setEnabled(false);
+        customGcodeButton4.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeButton4ActionPerformed(evt);
+            }
+        });
+
+        customGcodeButton3.setText("C3");
+        customGcodeButton3.setEnabled(false);
+        customGcodeButton3.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeButton3ActionPerformed(evt);
+            }
+        });
+
+        customGcodeButton2.setText("C2");
+        customGcodeButton2.setEnabled(false);
+        customGcodeButton2.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeButton2ActionPerformed(evt);
+            }
+        });
+
+        customGcodeButton1.setText("C1");
+        customGcodeButton1.setEnabled(false);
+        customGcodeButton1.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeButton1ActionPerformed(evt);
+            }
+        });
+
+        customGcodeButton5.setText("C5");
+        customGcodeButton5.setEnabled(false);
+        customGcodeButton5.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeButton5ActionPerformed(evt);
+            }
+        });
+
+        customGcodeText1.setText("G91 X0 Y0");
+        customGcodeText1.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeText1ActionPerformed(evt);
+            }
+        });
+
+        customGcodeText2.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeText2ActionPerformed(evt);
+            }
+        });
+
+        customGcodeText3.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeText3ActionPerformed(evt);
+            }
+        });
+
+        customGcodeText4.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeText4ActionPerformed(evt);
+            }
+        });
+
+        customGcodeText5.setToolTipText("");
+        customGcodeText5.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                customGcodeText5ActionPerformed(evt);
+            }
+        });
+
+        macroInstructions.setText("asgasg");
+
+        org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(macroPanel);
+        macroPanel.setLayout(macroPanelLayout);
+        macroPanelLayout.setHorizontalGroup(
+            macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+            .add(macroPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                    .add(macroPanelLayout.createSequentialGroup()
+                        .add(customGcodeButton1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                        .add(customGcodeText1))
+                    .add(macroPanelLayout.createSequentialGroup()
+                        .add(customGcodeButton2, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                        .add(customGcodeText2))
+                    .add(macroPanelLayout.createSequentialGroup()
+                        .add(customGcodeButton4, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                        .add(customGcodeText4))
+                    .add(macroPanelLayout.createSequentialGroup()
+                        .add(customGcodeButton3, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                        .add(customGcodeText3))
+                    .add(macroPanelLayout.createSequentialGroup()
+                        .add(customGcodeButton5, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                        .add(customGcodeText5))
+                    .add(macroPanelLayout.createSequentialGroup()
+                        .add(macroInstructions)
+                        .add(0, 0, Short.MAX_VALUE)))
+                .addContainerGap())
+        );
+        macroPanelLayout.setVerticalGroup(
+            macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+            .add(macroPanelLayout.createSequentialGroup()
+                .add(8, 8, 8)
+                .add(macroInstructions)
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(customGcodeButton1)
+                    .add(customGcodeText1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(customGcodeButton2)
+                    .add(customGcodeText2, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(customGcodeButton3)
+                    .add(customGcodeText3, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(customGcodeButton4)
+                    .add(customGcodeText4, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(customGcodeButton5)
+                    .add(customGcodeText5, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .addContainerGap(76, Short.MAX_VALUE))
+        );
+
+        controlContextTabbedPane.addTab("Macros", macroPanel);
+        controlContextTabbedPane.addTab("tab5", macroPanel1);
 
         connectionPanel.setBorder(javax.swing.BorderFactory.createTitledBorder("Connection"));
         connectionPanel.setMaximumSize(new java.awt.Dimension(247, 100));
@@ -1111,7 +1217,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
                 .add(connectionPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                     .add(firmwareLabel)
                     .add(firmwareComboBox, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(25, Short.MAX_VALUE))
+                .addContainerGap(45, Short.MAX_VALUE))
         );
 
         showVerboseOutputCheckBox.setText("Show verbose output");
@@ -1254,7 +1360,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
                         .add(statusPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                             .add(machinePositionZLabel)
                             .add(machinePositionZValueLabel))))
-                .addContainerGap(6, Short.MAX_VALUE))
+                .addContainerGap(23, Short.MAX_VALUE))
         );
 
         settingsMenu.setText("Settings");
@@ -2085,19 +2191,19 @@ implements KeyListener, ControllerListener, ControlStateListener {
                 this.updateConnectionControlsStateOpen(false);
                 this.updateManualControls(false);
                 this.updateWorkflowControls(false);
-                this.updateCustomGcodeControls(false);
+                this.macroPanel1.updateCustomGcodeControls(false);
                 this.setStatusColorForState("");
                 break;
             case COMM_IDLE:
                 this.updateConnectionControlsStateOpen(true);
                 this.updateManualControls(true);
                 this.updateWorkflowControls(true);
-                this.updateCustomGcodeControls(true);
+                this.macroPanel1.updateCustomGcodeControls(true);
                 break;
             case COMM_SENDING:
                 // Workflow tab
                 this.updateWorkflowControls(false);
-                this.updateCustomGcodeControls(false);
+                this.macroPanel1.updateCustomGcodeControls(false);
                 // Jogging commands
                 this.updateManualControls(false);
         
@@ -2158,17 +2264,17 @@ implements KeyListener, ControllerListener, ControlStateListener {
         this.requestStateInformation.setEnabled(enabled);
     }
     
-    private void updateCustomGcodeControls(boolean enabled) {
-        for(JButton button : customGcodeButtons) {
-            button.setEnabled(enabled);
-        }
-    }
+//    private void updateCustomGcodeControls(boolean enabled) {
+//        for(JButton button : customGcodeButtons) {
+//            button.setEnabled(enabled);
+//        }
+//    }
 
-    private void customGcodeButtonActionPerformed(java.awt.event.ActionEvent evt) {
-        //This is probably totally wrong.  Need to get the button out of the event, and from there figure out the macro.
-        Macro macro = settings.getMacro(Integer.parseInt(evt.getActionCommand()));
-        executeCustomGcode(macro.getGcode());
-    }
+//    private void customGcodeButtonActionPerformed(java.awt.event.ActionEvent evt) {
+//        //This is probably totally wrong.  Need to get the button out of the event, and from there figure out the macro.
+//        Macro macro = settings.getMacro(Integer.parseInt(evt.getActionCommand()));
+//        executeCustomGcode(macro.getGcode());
+//    }
 
     private void resetTimerLabels() {
         // Reset labels
@@ -2433,8 +2539,16 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private javax.swing.JPanel connectionPanel;
     private javax.swing.JTextArea consoleTextArea;
     private javax.swing.JTabbedPane controlContextTabbedPane;
-    private List<javax.swing.JButton> customGcodeButtons = new ArrayList<JButton>();
-    private List<javax.swing.JTextField> customGcodeTextFields = new ArrayList<JTextField>();
+    private javax.swing.JButton customGcodeButton1;
+    private javax.swing.JButton customGcodeButton2;
+    private javax.swing.JButton customGcodeButton3;
+    private javax.swing.JButton customGcodeButton4;
+    private javax.swing.JButton customGcodeButton5;
+    private javax.swing.JTextField customGcodeText1;
+    private javax.swing.JTextField customGcodeText2;
+    private javax.swing.JTextField customGcodeText3;
+    private javax.swing.JTextField customGcodeText4;
+    private javax.swing.JTextField customGcodeText5;
     private javax.swing.JLabel durationLabel;
     private javax.swing.JLabel durationValueLabel;
     private javax.swing.JLabel fileLabel;
@@ -2470,7 +2584,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private javax.swing.JLabel machinePositionZValueLabel;
     private javax.swing.JLabel macroInstructions;
     private javax.swing.JPanel macroPanel;
-    private javax.swing.JScrollPane macroScrollPane;
+    private com.willwinder.universalgcodesender.uielements.MacroPanel macroPanel1;
     private javax.swing.JMenuBar mainMenuBar;
     private javax.swing.JRadioButton mmRadioButton;
     private javax.swing.JPanel movementButtonPanel;

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -25,7 +25,6 @@
 
 package com.willwinder.universalgcodesender;
 
-import com.willwinder.universalgcodesender.types.Macro;
 import com.willwinder.universalgcodesender.uielements.*;
 import com.willwinder.universalgcodesender.utils.CommUtils;
 import com.willwinder.universalgcodesender.utils.FirmwareUtils;
@@ -42,7 +41,6 @@ import com.willwinder.universalgcodesender.listeners.ControlStateListener;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.model.GUIBackend;
 import com.willwinder.universalgcodesender.model.Utils.Units;
-import org.jdesktop.layout.GroupLayout;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -58,7 +56,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.*;
@@ -126,7 +123,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         checkScrollWindow();
         showVerboseOutputCheckBox.setSelected(settings.isVerboseOutputEnabled());
         firmwareComboBox.setSelectedItem(settings.getFirmwareVersion());
-//        macroPanel1.initMacroButtons(settings);
+//        macroPanel.initMacroButtons(settings);
 
         setSize(settings.getMainWindowSettings().width, settings.getMainWindowSettings().height);
         setLocation(settings.getMainWindowSettings().xLocation, settings.getMainWindowSettings().yLocation);
@@ -374,19 +371,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         resetXButton = new javax.swing.JButton();
         resetYButton = new javax.swing.JButton();
         resetZButton = new javax.swing.JButton();
-        macroPanel = new javax.swing.JPanel();
-        customGcodeButton4 = new javax.swing.JButton();
-        customGcodeButton3 = new javax.swing.JButton();
-        customGcodeButton2 = new javax.swing.JButton();
-        customGcodeButton1 = new javax.swing.JButton();
-        customGcodeButton5 = new javax.swing.JButton();
-        customGcodeText1 = new javax.swing.JTextField();
-        customGcodeText2 = new javax.swing.JTextField();
-        customGcodeText3 = new javax.swing.JTextField();
-        customGcodeText4 = new javax.swing.JTextField();
-        customGcodeText5 = new javax.swing.JTextField();
-        macroInstructions = new javax.swing.JLabel();
-        macroPanel1 = new com.willwinder.universalgcodesender.uielements.MacroPanel(settings);
+        macroPanel = new com.willwinder.universalgcodesender.uielements.MacroPanel(settings);
         connectionPanel = new javax.swing.JPanel();
         commPortComboBox = new javax.swing.JComboBox();
         baudrateSelectionComboBox = new javax.swing.JComboBox();
@@ -997,143 +982,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         );
 
         controlContextTabbedPane.addTab("Machine Control", machineControlPanel);
-
-        customGcodeButton4.setText("C4");
-        customGcodeButton4.setEnabled(false);
-        customGcodeButton4.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeButton4ActionPerformed(evt);
-            }
-        });
-
-        customGcodeButton3.setText("C3");
-        customGcodeButton3.setEnabled(false);
-        customGcodeButton3.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeButton3ActionPerformed(evt);
-            }
-        });
-
-        customGcodeButton2.setText("C2");
-        customGcodeButton2.setEnabled(false);
-        customGcodeButton2.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeButton2ActionPerformed(evt);
-            }
-        });
-
-        customGcodeButton1.setText("C1");
-        customGcodeButton1.setEnabled(false);
-        customGcodeButton1.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeButton1ActionPerformed(evt);
-            }
-        });
-
-        customGcodeButton5.setText("C5");
-        customGcodeButton5.setEnabled(false);
-        customGcodeButton5.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeButton5ActionPerformed(evt);
-            }
-        });
-
-        customGcodeText1.setText("G91 X0 Y0");
-        customGcodeText1.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeText1ActionPerformed(evt);
-            }
-        });
-
-        customGcodeText2.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeText2ActionPerformed(evt);
-            }
-        });
-
-        customGcodeText3.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeText3ActionPerformed(evt);
-            }
-        });
-
-        customGcodeText4.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeText4ActionPerformed(evt);
-            }
-        });
-
-        customGcodeText5.setToolTipText("");
-        customGcodeText5.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                customGcodeText5ActionPerformed(evt);
-            }
-        });
-
-        macroInstructions.setText("asgasg");
-
-        org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(macroPanel);
-        macroPanel.setLayout(macroPanelLayout);
-        macroPanelLayout.setHorizontalGroup(
-            macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(macroPanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(macroPanelLayout.createSequentialGroup()
-                        .add(customGcodeButton1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(customGcodeText1))
-                    .add(macroPanelLayout.createSequentialGroup()
-                        .add(customGcodeButton2, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(customGcodeText2))
-                    .add(macroPanelLayout.createSequentialGroup()
-                        .add(customGcodeButton4, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(customGcodeText4))
-                    .add(macroPanelLayout.createSequentialGroup()
-                        .add(customGcodeButton3, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(customGcodeText3))
-                    .add(macroPanelLayout.createSequentialGroup()
-                        .add(customGcodeButton5, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(customGcodeText5))
-                    .add(macroPanelLayout.createSequentialGroup()
-                        .add(macroInstructions)
-                        .add(0, 0, Short.MAX_VALUE)))
-                .addContainerGap())
-        );
-        macroPanelLayout.setVerticalGroup(
-            macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(macroPanelLayout.createSequentialGroup()
-                .add(8, 8, 8)
-                .add(macroInstructions)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(customGcodeButton1)
-                    .add(customGcodeText1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(customGcodeButton2)
-                    .add(customGcodeText2, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(customGcodeButton3)
-                    .add(customGcodeText3, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(customGcodeButton4)
-                    .add(customGcodeText4, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(customGcodeButton5)
-                    .add(customGcodeText5, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(76, Short.MAX_VALUE))
-        );
-
         controlContextTabbedPane.addTab("Macros", macroPanel);
-        controlContextTabbedPane.addTab("tab5", macroPanel1);
 
         connectionPanel.setBorder(javax.swing.BorderFactory.createTitledBorder("Connection"));
         connectionPanel.setMaximumSize(new java.awt.Dimension(247, 100));
@@ -2191,19 +2040,19 @@ implements KeyListener, ControllerListener, ControlStateListener {
                 this.updateConnectionControlsStateOpen(false);
                 this.updateManualControls(false);
                 this.updateWorkflowControls(false);
-                this.macroPanel1.updateCustomGcodeControls(false);
+                this.macroPanel.updateCustomGcodeControls(false);
                 this.setStatusColorForState("");
                 break;
             case COMM_IDLE:
                 this.updateConnectionControlsStateOpen(true);
                 this.updateManualControls(true);
                 this.updateWorkflowControls(true);
-                this.macroPanel1.updateCustomGcodeControls(true);
+                this.macroPanel.updateCustomGcodeControls(true);
                 break;
             case COMM_SENDING:
                 // Workflow tab
                 this.updateWorkflowControls(false);
-                this.macroPanel1.updateCustomGcodeControls(false);
+                this.macroPanel.updateCustomGcodeControls(false);
                 // Jogging commands
                 this.updateManualControls(false);
         
@@ -2344,7 +2193,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
         this.stepSizeLabel.setText(Localization.getString("mainWindow.swing.stepSizeLabel"));
         this.visualizeButton.setText(Localization.getString("mainWindow.swing.visualizeButton"));
         this.workPositionLabel.setText(Localization.getString("mainWindow.swing.workPositionLabel"));
-        this.macroInstructions.setText(Localization.getString("mainWindow.swing.macroInstructions"));
+//        this.macroInstructions.setText(Localization.getString("mainWindow.swing.macroInstructions"));
         this.inchRadioButton.setText(Localization.getString("mainWindow.swing.inchRadioButton"));
         this.mmRadioButton.setText(Localization.getString("mainWindow.swing.mmRadioButton"));
     }
@@ -2539,16 +2388,6 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private javax.swing.JPanel connectionPanel;
     private javax.swing.JTextArea consoleTextArea;
     private javax.swing.JTabbedPane controlContextTabbedPane;
-    private javax.swing.JButton customGcodeButton1;
-    private javax.swing.JButton customGcodeButton2;
-    private javax.swing.JButton customGcodeButton3;
-    private javax.swing.JButton customGcodeButton4;
-    private javax.swing.JButton customGcodeButton5;
-    private javax.swing.JTextField customGcodeText1;
-    private javax.swing.JTextField customGcodeText2;
-    private javax.swing.JTextField customGcodeText3;
-    private javax.swing.JTextField customGcodeText4;
-    private javax.swing.JTextField customGcodeText5;
     private javax.swing.JLabel durationLabel;
     private javax.swing.JLabel durationValueLabel;
     private javax.swing.JLabel fileLabel;
@@ -2582,9 +2421,7 @@ implements KeyListener, ControllerListener, ControlStateListener {
     private javax.swing.JLabel machinePositionYValueLabel;
     private javax.swing.JLabel machinePositionZLabel;
     private javax.swing.JLabel machinePositionZValueLabel;
-    private javax.swing.JLabel macroInstructions;
-    private javax.swing.JPanel macroPanel;
-    private com.willwinder.universalgcodesender.uielements.MacroPanel macroPanel1;
+    private com.willwinder.universalgcodesender.uielements.MacroPanel macroPanel;
     private javax.swing.JMenuBar mainMenuBar;
     private javax.swing.JRadioButton mmRadioButton;
     private javax.swing.JPanel movementButtonPanel;

--- a/src/com/willwinder/universalgcodesender/types/Macro.java
+++ b/src/com/willwinder/universalgcodesender/types/Macro.java
@@ -40,4 +40,13 @@ public class Macro {
     public void setGcode(String gcode) {
         this.gcode = gcode;
     }
+
+    @Override
+    public String toString() {
+        return "Macro{" +
+                "name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", gcode='" + gcode + '\'' +
+                '}';
+    }
 }

--- a/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
+++ b/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
@@ -1,0 +1,138 @@
+package com.willwinder.universalgcodesender.uielements;
+
+import com.willwinder.universalgcodesender.types.Macro;
+import com.willwinder.universalgcodesender.utils.Settings;
+import org.jdesktop.layout.*;
+
+import javax.swing.*;
+import javax.swing.GroupLayout;
+import java.awt.*;
+import java.awt.List;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.*;
+
+public class MacroPanel extends JScrollPane {
+
+    private Settings settings;
+    private java.util.List<JButton> customGcodeButtons = new ArrayList<JButton>();
+    private java.util.List<JTextField> customGcodeTextFields = new ArrayList<JTextField>();
+
+//    public void init(Settings settings) {
+//        this.settings = settings;
+//    }
+
+    public MacroPanel() {
+
+    }
+
+    public MacroPanel(Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+    }
+
+    @Override
+    public void doLayout() {
+        super.doLayout();
+        initMacroButtons();
+    }
+
+    public void initMacroButtons() {
+        if (settings == null) {
+            return;
+        }
+        Integer lastMacroIndex = settings.getLastMacroIndex()+1;
+//        logger.info((lastMacroIndex) + " macros");
+        for (int i = 0; i <= lastMacroIndex; i++) {
+            JButton button = createMacroButton(i);
+            JTextField textField = createMacroTextField(i);
+
+            Macro macro = settings.getMacro(i);
+            if (macro != null) {
+                textField.setText(macro.getGcode());
+                if (macro.getName() != null) {
+                    button.setText(macro.getName());
+                }
+                if (macro.getDescription() != null) {
+                    button.setToolTipText(macro.getDescription());
+                }
+            }
+        }
+
+
+        JPanel macroPanel = new JPanel();
+        org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(macroPanel);
+
+        org.jdesktop.layout.GroupLayout.ParallelGroup parallelGroup = macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING);
+
+        org.jdesktop.layout.GroupLayout.SequentialGroup sequentialGroup = macroPanelLayout.createSequentialGroup();
+        parallelGroup.add(sequentialGroup);
+
+        sequentialGroup.addContainerGap();
+        org.jdesktop.layout.GroupLayout.ParallelGroup parallelGroup1 = macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING);
+        sequentialGroup.add(parallelGroup1);
+
+        for (int i = 0; i < customGcodeButtons.size(); i++) {
+            org.jdesktop.layout.GroupLayout.SequentialGroup group = macroPanelLayout.createSequentialGroup();
+            group.add(customGcodeButtons.get(i), org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 49, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                    .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                    .add(customGcodeTextFields.get(i));
+            parallelGroup1.add(group);
+        }
+//        sequentialGroup.addContainerGap();
+
+        macroPanelLayout.setHorizontalGroup( parallelGroup );
+        org.jdesktop.layout.GroupLayout.SequentialGroup sequentialGroup1 = macroPanelLayout.createSequentialGroup();
+        macroPanelLayout.setVerticalGroup(
+                macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(sequentialGroup1
+                                        .add(8, 8, 8)
+//                                        .add(macroInstructions)
+                        ));
+
+
+        for (int i = 0; i < customGcodeButtons.size(); i++) {
+//            sequentialGroup1.addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+            sequentialGroup1.add(macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(customGcodeButtons.get(i))
+                    .add(customGcodeTextFields.get(i), org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE));
+        }
+//        sequentialGroup1.addContainerGap(76, Short.MAX_VALUE);
+
+        macroPanel.setLayout(macroPanelLayout);
+    }
+
+    private JTextField createMacroTextField(int index) {
+        JTextField textField = new MacroTextField(index, settings);
+
+        customGcodeTextFields.add(textField);
+        return textField;
+    }
+
+    private JButton createMacroButton(int i) {
+        JButton button = new JButton(i+"");
+
+        button.setEnabled(false);
+        button.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                customGcodeButtonActionPerformed(evt);
+            }
+        });
+        customGcodeButtons.add(button);
+        return button;
+    }
+
+    private void customGcodeButtonActionPerformed(java.awt.event.ActionEvent evt) {
+        //This is probably totally wrong.  Need to get the button out of the event, and from there figure out the macro.
+        Macro macro = settings.getMacro(Integer.parseInt(evt.getActionCommand()));
+//        executeCustomGcode(macro.getGcode());
+    }
+
+    public void updateCustomGcodeControls(boolean enabled) {
+
+    }
+}

--- a/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
+++ b/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
@@ -1,5 +1,6 @@
 package com.willwinder.universalgcodesender.uielements;
 
+import com.willwinder.universalgcodesender.MainWindow;
 import com.willwinder.universalgcodesender.types.Macro;
 import com.willwinder.universalgcodesender.utils.Settings;
 import org.jdesktop.layout.*;
@@ -14,6 +15,7 @@ import java.util.*;
 
 public class MacroPanel extends JPanel {
 
+    private MainWindow mainWindow;
     private Settings settings;
     private java.util.List<JButton> customGcodeButtons = new ArrayList<JButton>();
     private java.util.List<JTextField> customGcodeTextFields = new ArrayList<JTextField>();
@@ -22,8 +24,9 @@ public class MacroPanel extends JPanel {
 
     }
 
-    public MacroPanel(Settings settings) {
+    public MacroPanel(Settings settings, MainWindow mainWindow) {
         this.settings = settings;
+        this.mainWindow = mainWindow;
     }
 
     @Override
@@ -126,10 +129,20 @@ public class MacroPanel extends JPanel {
     private void customGcodeButtonActionPerformed(java.awt.event.ActionEvent evt) {
         //This is probably totally wrong.  Need to get the button out of the event, and from there figure out the macro.
         Macro macro = settings.getMacro(Integer.parseInt(evt.getActionCommand()));
-//        executeCustomGcode(macro.getGcode());
+
+        //Poor coupling here.  We should probably pull the executeCustomGcode method out into the backend.
+        if (mainWindow == null) {
+            System.err.println("MacroPanel not properly initialized.  Cannot execute custom gcode");
+        } else {
+            mainWindow.executeCustomGcode(macro.getGcode());
+        }
     }
 
     public void updateCustomGcodeControls(boolean enabled) {
+        for (JButton button : customGcodeButtons) {
+            button.setEnabled(enabled);
+        }
+
 
     }
 }

--- a/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
+++ b/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
@@ -12,7 +12,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.*;
 
-public class MacroPanel extends JScrollPane {
+public class MacroPanel extends JPanel {
 
     private Settings settings;
     private java.util.List<JButton> customGcodeButtons = new ArrayList<JButton>();
@@ -37,11 +37,11 @@ public class MacroPanel extends JScrollPane {
 
     @Override
     public void doLayout() {
-        super.doLayout();
         initMacroButtons();
+        super.doLayout();
     }
 
-    public void initMacroButtons() {
+    private void initMacroButtons() {
         if (settings == null) {
             return;
         }
@@ -63,9 +63,7 @@ public class MacroPanel extends JScrollPane {
             }
         }
 
-
-        JPanel macroPanel = new JPanel();
-        org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(macroPanel);
+        org.jdesktop.layout.GroupLayout macroPanelLayout = new org.jdesktop.layout.GroupLayout(this);
 
         org.jdesktop.layout.GroupLayout.ParallelGroup parallelGroup = macroPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING);
 
@@ -103,7 +101,7 @@ public class MacroPanel extends JScrollPane {
         }
 //        sequentialGroup1.addContainerGap(76, Short.MAX_VALUE);
 
-        macroPanel.setLayout(macroPanelLayout);
+        setLayout(macroPanelLayout);
     }
 
     private JTextField createMacroTextField(int index) {

--- a/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
+++ b/src/com/willwinder/universalgcodesender/uielements/MacroPanel.java
@@ -18,10 +18,6 @@ public class MacroPanel extends JPanel {
     private java.util.List<JButton> customGcodeButtons = new ArrayList<JButton>();
     private java.util.List<JTextField> customGcodeTextFields = new ArrayList<JTextField>();
 
-//    public void init(Settings settings) {
-//        this.settings = settings;
-//    }
-
     public MacroPanel() {
 
     }
@@ -43,11 +39,14 @@ public class MacroPanel extends JPanel {
 
     private void initMacroButtons() {
         if (settings == null) {
+            //I suppose this should be in a text field.
+            System.err.println("settings is null!  Cannot init buttons!");
             return;
         }
         Integer lastMacroIndex = settings.getLastMacroIndex()+1;
 //        logger.info((lastMacroIndex) + " macros");
-        for (int i = 0; i <= lastMacroIndex; i++) {
+
+        for (int i = customGcodeButtons.size(); i <= lastMacroIndex; i++) {
             JButton button = createMacroButton(i);
             JTextField textField = createMacroTextField(i);
 

--- a/src/com/willwinder/universalgcodesender/uielements/MacroTextField.java
+++ b/src/com/willwinder/universalgcodesender/uielements/MacroTextField.java
@@ -1,0 +1,35 @@
+package com.willwinder.universalgcodesender.uielements;
+
+import com.willwinder.universalgcodesender.utils.Settings;
+
+import javax.swing.*;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+public class MacroTextField extends JTextField {
+
+    private final Integer index;
+    private final Settings settings;
+
+    public MacroTextField(final Integer index, Settings settings) {
+        this.index = index;
+        this.settings = settings;
+
+        addKeyListener(new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+                //ignore
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+                //ignore
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+                MacroTextField.this.settings.updateMacro(MacroTextField.this.index, MacroTextField.this.getText());
+            }
+        });
+    }
+}

--- a/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -309,8 +309,24 @@ public class Settings {
         return macro;
     }
 
+    public Integer getLastMacroIndex() {
+        //Obviously it would be more efficient to just store the max index value, but this is safer in that it's one less thing
+        //to keep in sync.
+        int i = -1;
+        for (Integer index : macros.keySet()) {
+            i = Math.max(i, index);
+        }
+        return i;
+    }
+
+
     public void clearMacro(Integer index) {
         macros.remove(index);
+    }
+
+    public void updateMacro(Integer index, String gcode) {
+        Macro macro = getMacro(index);
+        updateMacro(index, macro.getName(), macro.getDescription(), gcode);
     }
 
     public void updateMacro(Integer index, String name, String description, String gcode) {

--- a/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -34,6 +34,7 @@ public class Settings {
     private String defaultUnits = "mm";
 
     private boolean showNightlyWarning = true;
+    private boolean showSerialPortWarning = true;
 
     //vvv deprecated fields, still here to not break the old save files
     @Expose(serialize = false)
@@ -71,23 +72,23 @@ public class Settings {
      */
     public void finalizeInitialization() {
         if (customGcode1 != null) {
-            setCustomGcode(1, customGcode1);
+            updateMacro(1, null, null, customGcode1);
             customGcode1 = null;
         }
         if (customGcode2 != null) {
-            setCustomGcode(2, customGcode2);
+            updateMacro(2, null, null, customGcode2);
             customGcode2 = null;
         }
         if (customGcode3 != null) {
-            setCustomGcode(3, customGcode3);
+            updateMacro(3, null, null, customGcode3);
             customGcode3 = null;
         }
         if (customGcode4 != null) {
-            setCustomGcode(4, customGcode4);
+            updateMacro(4, null, null, customGcode4);
             customGcode4 = null;
         }
         if (customGcode5 != null) {
-            setCustomGcode(5, customGcode5);
+            updateMacro(5, null, null, customGcode5);
             customGcode5 = null;
         }
     }
@@ -292,60 +293,34 @@ public class Settings {
         this.showNightlyWarning = showNightlyWarning;
     }
 
-    public String getCustomGcode1() {
-        Macro macro = getMacro(1);
-        return macro == null ? "" : macro.getGcode();
+    public boolean isShowSerialPortWarning() {
+        return showSerialPortWarning;
     }
 
-    public void setCustomGcode1(String gcode) {
-        setCustomGcode(1, gcode);
-    }
-
-    public String getCustomGcode2() {
-        Macro macro = getMacro(2);
-        return macro == null ? "" : macro.getGcode();
-    }
-
-    public void setCustomGcode2(String gcode) {
-        setCustomGcode(2, gcode);
-    }
-
-    public String getCustomGcode3() {
-        Macro macro = getMacro(3);
-        return macro == null ? "" : macro.getGcode();
-    }
-
-    public void setCustomGcode3(String gcode) {
-        setCustomGcode(3, gcode);
-    }
-
-    public String getCustomGcode4() {
-        Macro macro = getMacro(4);
-        return macro == null ? "" : macro.getGcode();
-    }
-
-    public void setCustomGcode4(String gcode) {
-        setCustomGcode(4, gcode);
-    }
-
-    public String getCustomGcode5() {
-        Macro macro = getMacro(5);
-        return macro == null ? "" : macro.getGcode();
-    }
-
-    public void setCustomGcode5(String gcode) {
-        setCustomGcode(5, gcode);
+    public void setShowSerialPortWarning(boolean showSerialPortWarning) {
+        this.showSerialPortWarning = showSerialPortWarning;
     }
 
     public Macro getMacro(Integer index) {
-        return macros.get(index);
+        Macro macro = macros.get(index);
+        if (macro == null) {
+            macro = new Macro(index.toString(), null, null);
+        }
+        return macro;
     }
 
-    public void setCustomGcode(Integer index, String gcode) {
+    public void clearMacro(Integer index) {
+        macros.remove(index);
+    }
+
+    public void updateMacro(Integer index, String name, String description, String gcode) {
         if (gcode == null || gcode.trim().isEmpty()) {
             macros.remove(index);
         } else {
-            macros.put(index, new Macro(null, null, gcode));
+            if (name == null) {
+                name = index.toString();
+            }
+            macros.put(index, new Macro(name, description, gcode));
         }
     }
 

--- a/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
+++ b/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
@@ -83,11 +83,11 @@ public class SettingsFactory {
                     out.setConvertArcsToLines(Boolean.valueOf(properties.getProperty("convertArcsToLines", "false")));
                     out.setSmallArcThreshold(Double.valueOf(properties.getProperty("smallArcThreshold", "2.0")));
                     out.setSmallArcSegmentLength(Double.valueOf(properties.getProperty("smallArcSegmentLength", "1.3")));
-                    out.setCustomGcode1(properties.getProperty("customGcode1", "G0 X0 Y0;"));
-                    out.setCustomGcode2(properties.getProperty("customGcode2", "G0 G91 X10;G0 G91 Y10;"));
-                    out.setCustomGcode3(properties.getProperty("customGcode3", ""));
-                    out.setCustomGcode4(properties.getProperty("customGcode4", ""));
-                    out.setCustomGcode5(properties.getProperty("customGcode5", ""));
+                    out.updateMacro(1, null, null, properties.getProperty("customGcode1", "G0 X0 Y0;"));
+                    out.updateMacro(2, null, null, properties.getProperty("customGcode2", "G0 G91 X10;G0 G91 Y10;"));
+                    out.updateMacro(3, null, null, properties.getProperty("customGcode3", ""));
+                    out.updateMacro(4, null, null, properties.getProperty("customGcode4", ""));
+                    out.updateMacro(5, null, null, properties.getProperty("customGcode5", ""));
                     out.setLanguage(properties.getProperty("language", "en_US"));
 	    	}
             out.finalizeInitialization();


### PR DESCRIPTION
Move the macros into a collection.  The idea here is to set us up for having an arbitrary number of macros, rather than just 5.  The macro name is stored in the json, and can be used as the macro button label.  The description is stored, and is displayed as hover text.  Also, I moved the nightly build warning into the settings as well.

The changes in this pull request don't directly contribute much, but are setting the stage for better things to come.