### PR TITLE
Machine status window shows units for current position.  See #314

### DIFF
--- a/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -737,11 +737,17 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
         }
     }
 
+    /**
+     * Get current machine reporting units
+     */
     protected Utils.Units getReportingUnits() {
         return reportingUnits;
     }
 
-    @Override
+    /**
+     * Set current machine reporting units
+     * @param units
+     */
     public void setReportingUnits(Utils.Units units) {
         this.reportingUnits = units;
     }

--- a/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -737,8 +737,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
         }
     }
 
-    @Override
-    public Utils.Units getReportingUnits() {
+    protected Utils.Units getReportingUnits() {
         return reportingUnits;
     }
 

--- a/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -748,7 +748,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
      * Set current machine reporting units
      * @param units
      */
-    public void setReportingUnits(Utils.Units units) {
+    protected void setReportingUnits(Utils.Units units) {
         this.reportingUnits = units;
     }
 

--- a/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -25,6 +25,8 @@ import com.willwinder.universalgcodesender.gcode.GcodeCommandCreator;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.SerialCommunicatorListener;
+import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.model.Utils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.GcodeStreamReader;
 
@@ -172,11 +174,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
     private boolean statusUpdatesEnabled = true;
     private int statusUpdateRate = 200;
     
-    // State
-//    private Boolean commOpen = false;
-    
-    // Parser state
-    private Boolean absoluteMode = true;
+    private Utils.Units reportingUnits = Utils.Units.UNKNOWN;
     
     // Added value
     private Boolean isStreaming = false;
@@ -417,7 +415,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
      * response are sent to the comm - with the exception of command streams.
      */
     private void sendStringToComm(String command) {
-        this.comm.queueStringForComm(command+"\n");
+        this.comm.queueStringForComm(command + "\n");
     }
     
     @Override
@@ -675,7 +673,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
         this.listeners.add(cl);
     }
 
-    protected void dispatchStatusString(String state, Point3d machine, Point3d work) {
+    protected void dispatchStatusString(String state, Position machine, Position work) {
         if (listeners != null) {
             for (ControllerListener c : listeners) {
                 c.statusStringListener(state, machine, work);
@@ -737,6 +735,16 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
                 c.postProcessData(numRows);
             }
         }
+    }
+
+    @Override
+    public Utils.Units getReportingUnits() {
+        return reportingUnits;
+    }
+
+    @Override
+    public void setReportingUnits(Utils.Units units) {
+        this.reportingUnits = units;
     }
 
     protected String getUnitsCode() {

--- a/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -23,6 +23,7 @@
 
 package com.willwinder.universalgcodesender;
 
+import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.Utils.Units;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
@@ -49,6 +50,7 @@ public class GrblUtils {
     public static final String GRBL_KILL_ALARM_LOCK_COMMAND = "$X";
     public static final String GRBL_TOGGLE_CHECK_MODE_COMMAND = "$C";
     public static final String GRBL_VIEW_PARSER_STATE_COMMAND = "$G";
+    public static final String GRBL_VIEW_SETTINGS_COMMAND = "$$";
     
     /**
      * Gcode Commands
@@ -257,6 +259,11 @@ public class GrblUtils {
     static protected Boolean isGrblFeedbackMessage(final String response) {
         return response.startsWith("[") && response.endsWith("]");
     }
+
+
+    static protected Boolean isGrblSettingMessage(final String response) {
+        return response.startsWith("$") && response.endsWith(")");
+    }
     
     /**
      * Parse state out of position string.
@@ -296,29 +303,30 @@ public class GrblUtils {
     }
 
     static Pattern machinePattern = Pattern.compile("(?<=MPos:)(-?\\d*\\..\\d*),(-?\\d*\\..\\d*),(-?\\d*\\..\\d*)(?=,WPos:)");
-    static protected Point3d getMachinePositionFromStatusString(final String status, final Capabilities version) {
+    static protected Position getMachinePositionFromStatusString(final String status, final Capabilities version, Units reportingUnits) {
         if (version == Capabilities.STATUS_C) {
-            return GrblUtils.getPositionFromStatusString(status, machinePattern);
+            return GrblUtils.getPositionFromStatusString(status, machinePattern, reportingUnits);
         } else {
             return null;
         }
     }
     
     static Pattern workPattern = Pattern.compile("(?<=WPos:)(\\-?\\d*\\..\\d*),(\\-?\\d*\\..\\d*),(\\-?\\d*\\..\\d*)");
-    static protected Point3d getWorkPositionFromStatusString(final String status, final Capabilities version) {
+    static protected Position getWorkPositionFromStatusString(final String status, final Capabilities version, Units reportingUnits) {
         if (version == Capabilities.STATUS_C) {
-            return GrblUtils.getPositionFromStatusString(status, workPattern);
+            return GrblUtils.getPositionFromStatusString(status, workPattern, reportingUnits);
         } else {
             return null;
         }
     }
     
-    static private Point3d getPositionFromStatusString(final String status, final Pattern pattern) {
+    static private Position getPositionFromStatusString(final String status, final Pattern pattern, Units reportingUnits) {
         Matcher matcher = pattern.matcher(status);
         if (matcher.find()) {
-            return new Point3d( Double.parseDouble(matcher.group(1)),
+            return new Position( Double.parseDouble(matcher.group(1)),
                                 Double.parseDouble(matcher.group(2)),
-                                Double.parseDouble(matcher.group(3)));
+                                Double.parseDouble(matcher.group(3)),
+                                reportingUnits);
         }
         
         return null;

--- a/src/com/willwinder/universalgcodesender/IController.java
+++ b/src/com/willwinder/universalgcodesender/IController.java
@@ -38,12 +38,6 @@ public interface IController {
     */
     public void addListener(ControllerListener cl);
 
-    /**
-     * Set current machine reporting units
-     * @param units
-     */
-    public void setReportingUnits(Units units);
-    
     /*
     Actions
     */

--- a/src/com/willwinder/universalgcodesender/IController.java
+++ b/src/com/willwinder/universalgcodesender/IController.java
@@ -38,10 +38,17 @@ public interface IController {
     */
     public void addListener(ControllerListener cl);
 
-    /*
-    State updates.
-    */
-    public void currentUnits(Units units);
+    /**
+     * Get units to interpret position updates
+     * @return Units
+     */
+    public Units getReportingUnits();
+
+    /**
+     * Set current machine reporting units
+     * @param units
+     */
+    public void setReportingUnits(Units units);
     
     /*
     Actions

--- a/src/com/willwinder/universalgcodesender/IController.java
+++ b/src/com/willwinder/universalgcodesender/IController.java
@@ -39,12 +39,6 @@ public interface IController {
     public void addListener(ControllerListener cl);
 
     /**
-     * Get units to interpret position updates
-     * @return Units
-     */
-    public Units getReportingUnits();
-
-    /**
      * Set current machine reporting units
      * @param units
      */

--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -25,6 +25,7 @@
 
 package com.willwinder.universalgcodesender;
 
+import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.uielements.*;
 import com.willwinder.universalgcodesender.utils.CommUtils;
 import com.willwinder.universalgcodesender.utils.FirmwareUtils;
@@ -2273,20 +2274,20 @@ public class MainWindow extends JFrame implements ControllerListener, ControlSta
     }
     
     @Override
-    public void statusStringListener(String state, Point3d machineCoord, Point3d workCoord) {
+    public void statusStringListener(String state, Position machineCoord, Position workCoord) {
         this.activeStateValueLabel.setText( state );
         this.setStatusColorForState( state );
-        
+
         if (machineCoord != null) {
-            this.machinePositionXValueLabel.setText( Utils.formatter.format(machineCoord.x) + "" );
-            this.machinePositionYValueLabel.setText( Utils.formatter.format(machineCoord.y) + "" );
-            this.machinePositionZValueLabel.setText( Utils.formatter.format(machineCoord.z) + "" );
+            this.machinePositionXValueLabel.setText( Utils.formatter.format(machineCoord.x) + machineCoord.getUnits().abbreviation );
+            this.machinePositionYValueLabel.setText( Utils.formatter.format(machineCoord.y) + machineCoord.getUnits().abbreviation );
+            this.machinePositionZValueLabel.setText( Utils.formatter.format(machineCoord.z) + machineCoord.getUnits().abbreviation );
         }
         
         if (workCoord != null) {
-            this.workPositionXValueLabel.setText( Utils.formatter.format(workCoord.x) + "" );
-            this.workPositionYValueLabel.setText( Utils.formatter.format(workCoord.y) + "" );
-            this.workPositionZValueLabel.setText( Utils.formatter.format(workCoord.z) + "" );
+            this.workPositionXValueLabel.setText( Utils.formatter.format(workCoord.x) + workCoord.getUnits().abbreviation );
+            this.workPositionYValueLabel.setText( Utils.formatter.format(workCoord.y) + workCoord.getUnits().abbreviation );
+            this.workPositionZValueLabel.setText( Utils.formatter.format(workCoord.z) + workCoord.getUnits().abbreviation );
         }
     }
     

--- a/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.willwinder.universalgcodesender.gcode.TinyGGcodeCommandCreator;
 import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.Utils.Units;
 import com.willwinder.universalgcodesender.types.TinyGGcodeCommand;
 import java.io.File;
@@ -42,8 +43,8 @@ public class TinyGController extends AbstractController {
     Units units;
     
     String state = "";
-    Point3d machineLocation = new Point3d();
-    Point3d workLocation = new Point3d();
+    Position machineLocation = new Position();
+    Position workLocation = new Position();
     
     protected TinyGController(TinyGCommunicator comm) {
         super(comm);
@@ -194,11 +195,6 @@ public class TinyGController extends AbstractController {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
-    @Override
-    public void currentUnits(Units units) {
-        this.units = units;
-    }
-    
     static class TinyGUtils {
         static JsonParser parser = new JsonParser();
         

--- a/src/com/willwinder/universalgcodesender/listeners/ControllerListener.java
+++ b/src/com/willwinder/universalgcodesender/listeners/ControllerListener.java
@@ -21,6 +21,8 @@
  */
 package com.willwinder.universalgcodesender.listeners;
 
+import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.model.Utils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import javax.vecmath.Point3d;
 
@@ -59,7 +61,7 @@ public interface ControllerListener {
     /**
      * Controller status information.
      */
-    void statusStringListener(String state, Point3d machineCoord, Point3d workCoord);
+    void statusStringListener(String state, Position machineCoord, Position workCoord);
     
     /**
      * Data gathered while preprocessing commands for queue.

--- a/src/com/willwinder/universalgcodesender/listeners/GrblSettingsListener.java
+++ b/src/com/willwinder/universalgcodesender/listeners/GrblSettingsListener.java
@@ -1,6 +1,9 @@
 package com.willwinder.universalgcodesender.listeners;
 
 import com.willwinder.universalgcodesender.AbstractController;
+import com.willwinder.universalgcodesender.GrblUtils;
+import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.model.Utils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 
 import javax.vecmath.Point3d;
@@ -56,7 +59,7 @@ public class GrblSettingsListener implements ControllerListener {
 
             } while(!ready);
 
-            GcodeCommand command = controller.createCommand("$$");
+            GcodeCommand command = controller.createCommand(GrblUtils.GRBL_VIEW_SETTINGS_COMMAND);
             controller.sendCommandImmediately(command);
             while (this.sending) {
                 Thread.sleep(10);
@@ -117,7 +120,7 @@ public class GrblSettingsListener implements ControllerListener {
     }
 
     @Override
-    public void statusStringListener(String state, Point3d machineCoord, Point3d workCoord) {
+    public void statusStringListener(String state, Position machineCoord, Position workCoord) {
     }
 
     @Override

--- a/src/com/willwinder/universalgcodesender/model/Position.java
+++ b/src/com/willwinder/universalgcodesender/model/Position.java
@@ -1,0 +1,21 @@
+package com.willwinder.universalgcodesender.model;
+
+import javax.vecmath.Point3d;
+
+public class Position extends Point3d {
+
+    private final Utils.Units units;
+
+    public Position() {
+        this.units = Utils.Units.UNKNOWN;
+    }
+
+    public Position(double x, double y, double z, Utils.Units units) {
+        super(x, y, z);
+        this.units = units;
+    }
+
+    public Utils.Units getUnits() {
+        return units;
+    }
+}

--- a/src/com/willwinder/universalgcodesender/model/Utils.java
+++ b/src/com/willwinder/universalgcodesender/model/Utils.java
@@ -11,10 +11,16 @@ package com.willwinder.universalgcodesender.model;
  */
 public class Utils {
     public enum Units {
-        MM,
-        INCH,
-        UNKNOWN
-    };
+        MM("mm"),
+        INCH("\""),
+        UNKNOWN("");
+
+        public final String abbreviation;
+
+        Units(String abbreviation) {
+            this.abbreviation = abbreviation;
+        }
+    }
     
     public enum ControlState {
         COMM_DISCONNECTED,

--- a/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
+++ b/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.vecmath.Point3d;
 
+import com.willwinder.universalgcodesender.model.Position;
 import net.glxn.qrgen.QRCode;
 import net.glxn.qrgen.image.ImageType;
 
@@ -346,7 +347,7 @@ public class PendantUI implements ControllerListener{
     }
 
     @Override
-    public void statusStringListener(String state, Point3d machineCoord, Point3d workCoord) {
+    public void statusStringListener(String state, Position machineCoord, Position workCoord) {
         // TODO Auto-generated method stub
         
     }

--- a/src/com/willwinder/universalgcodesender/types/GrblSettingMessage.java
+++ b/src/com/willwinder/universalgcodesender/types/GrblSettingMessage.java
@@ -1,0 +1,87 @@
+package com.willwinder.universalgcodesender.types;
+
+import com.willwinder.universalgcodesender.model.Utils;
+
+/**
+ * Created by Phil on 1/15/2016.
+ */
+public class GrblSettingMessage {
+    final String message;
+
+    private String setting;
+    private String value;
+
+/* Sample settings.
+$0=10 (step pulse, usec)
+$1=25 (step idle delay, msec)
+$2=0 (step port invert mask:00000000)
+$3=0 (dir port invert mask:00000000)
+$4=0 (step enable invert, bool)
+$5=0 (limit pins invert, bool)
+$6=0 (probe pin invert, bool)
+$10=3 (status report mask:00000011)
+$11=0.010 (junction deviation, mm)
+$12=0.002 (arc tolerance, mm)
+$13=0 (report inches, bool)
+$20=0 (soft limits, bool)
+$21=0 (hard limits, bool)
+$22=0 (homing cycle, bool)
+$23=0 (homing dir invert mask:00000000)
+$24=25.000 (homing feed, mm/min)
+$25=500.000 (homing seek, mm/min)
+$26=250 (homing debounce, msec)
+$27=1.000 (homing pull-off, mm)
+$100=250.000 (x, step/mm)
+$101=250.000 (y, step/mm)
+$102=250.000 (z, step/mm)
+$110=5000.000 (x max rate, mm/min)
+$111=5000.000 (y max rate, mm/min)
+$112=500.000 (z max rate, mm/min)
+$120=400.000 (x accel, mm/sec^2)
+$121=400.000 (y accel, mm/sec^2)
+$122=10.000 (z accel, mm/sec^2)
+$130=200.000 (x max travel, mm)
+$131=200.000 (y max travel, mm)
+$132=200.000 (z max travel, mm)
+*/
+
+    public GrblSettingMessage(String message) {
+        this.message = message;
+        parse();
+    }
+
+    private void parse() {
+        String substring = message.substring(1, message.length());
+
+        String[] parts1 = substring.split("=", 2);
+        if (parts1.length == 2) {
+            String[] parts2 = parts1[1].split(" ", 2);
+            if (parts2.length == 2) {
+                setting = parts1[0];
+                value = parts2[0];
+            }
+        }
+    }
+
+    public boolean isReportingUnits() {
+        return "13".equals(setting);
+    }
+
+    public Utils.Units getReportingUnits() {
+        if (isReportingUnits()) {
+            if ("0".equals(value)) {
+                return Utils.Units.MM;
+            } else if ("1".equals(value)) {
+                return Utils.Units.INCH;
+            }
+        }
+        return Utils.Units.UNKNOWN;
+    }
+
+    @Override
+    public String toString() {
+        return "GrblFeedbackMessage{" +
+                "message='" + message + '\'' +
+                '}';
+    }
+}

--- a/src/com/willwinder/universalgcodesender/uielements/GrblFirmwareSettingsDialog.java
+++ b/src/com/willwinder/universalgcodesender/uielements/GrblFirmwareSettingsDialog.java
@@ -22,9 +22,12 @@
 package com.willwinder.universalgcodesender.uielements;
 
 import com.willwinder.universalgcodesender.GrblController;
+import com.willwinder.universalgcodesender.GrblUtils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
+import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.model.Utils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import java.awt.event.ActionEvent;
 import java.util.regex.Matcher;
@@ -109,7 +112,7 @@ public class GrblFirmwareSettingsDialog extends javax.swing.JDialog implements C
     
     private void initSettings() throws Exception {
         this.loadingSettings = true;
-        this.grblController.sendGcodeCommand("$$");
+        this.grblController.sendGcodeCommand(GrblUtils.GRBL_VIEW_SETTINGS_COMMAND);
     }
     
     private void checkDoneSavingSettings() {
@@ -396,7 +399,7 @@ public class GrblFirmwareSettingsDialog extends javax.swing.JDialog implements C
     }
 
     @Override
-    public void statusStringListener(String state, Point3d machineCoord, Point3d workCoord) {
+    public void statusStringListener(String state, Position machineCoord, Position workCoord) {
         //throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/src/com/willwinder/universalgcodesender/visualizer/VisualizerWindow.java
+++ b/src/com/willwinder/universalgcodesender/visualizer/VisualizerWindow.java
@@ -28,6 +28,8 @@ package com.willwinder.universalgcodesender.visualizer;
 import com.jogamp.opengl.util.FPSAnimator;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
+import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.model.Utils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.types.WindowSettings;
 import java.awt.Dimension;
@@ -52,6 +54,8 @@ implements ControllerListener, WindowListener {
     // Interactive members.
     private Point3d machineCoordinate;
     private Point3d workCoordinate;
+    private Utils.Units reportingUnits = Utils.Units.UNKNOWN;
+
     private int completedCommandNumber = -1;
     private String gcodeFile = null;
     private VisualizerCanvas canvas = null;
@@ -115,13 +119,15 @@ implements ControllerListener, WindowListener {
     }
 
     @Override
-    public void statusStringListener(String state, Point3d machineCoord, Point3d workCoord) {
+    public void statusStringListener(String state, Position machineCoord, Position workCoord) {
         machineCoordinate = machineCoord;
         workCoordinate = workCoord;
-        
+        this.reportingUnits = machineCoord.getUnits();
+
         // Give coordinates to canvas.
         this.canvas.setMachineCoordinate(this.machineCoordinate);
         this.canvas.setWorkCoordinate(this.workCoordinate);
+
     }
     
     @Override

--- a/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -178,18 +178,18 @@ public class GrblControllerTest {
         assertEquals(expResult, mgc.queuedString);
         
         instance.rawResponseHandler("Grbl 0.8c");
-        assertEquals(4, mgc.numStreamCommandsCalls);
+        assertEquals(5, mgc.numStreamCommandsCalls);
 
         instance.performHomingCycle();
-        assertEquals(5, mgc.numStreamCommandsCalls);
+        assertEquals(6, mgc.numStreamCommandsCalls);
         expResult = GrblUtils.GCODE_PERFORM_HOMING_CYCLE_V8C + "\n";
         assertEquals(expResult, mgc.queuedString);
         
         instance.rawResponseHandler("Grbl 0.9");
-        assertEquals(6, mgc.numStreamCommandsCalls);
+        assertEquals(8, mgc.numStreamCommandsCalls);
 
         instance.performHomingCycle();
-        assertEquals(7, mgc.numStreamCommandsCalls);
+        assertEquals(9, mgc.numStreamCommandsCalls);
         expResult = GrblUtils.GCODE_PERFORM_HOMING_CYCLE_V8C + "\n";
         assertEquals(expResult, mgc.queuedString);
     }
@@ -257,9 +257,9 @@ public class GrblControllerTest {
         instance.openCommPort("blah", 1234);
         instance.rawResponseHandler("Grbl 0.8c");
 
-        //$G gets queued on startup
-        assertEquals(1, mgc.numQueueStringForCommCalls);
-        assertEquals(1, mgc.numStreamCommandsCalls);
+        //$G and $$ get queued on startup
+        assertEquals(2, mgc.numQueueStringForCommCalls);
+        assertEquals(2, mgc.numStreamCommandsCalls);
 
         // By default nothing is streaming.
         Boolean expResult = false;
@@ -290,8 +290,8 @@ public class GrblControllerTest {
         result = instance.isStreamingFile();
         expResult = true;
         assertEquals(expResult, result);
-        assertEquals(2, mgc.numQueueStringForCommCalls);
-        assertEquals(2, mgc.numStreamCommandsCalls);
+        assertEquals(3, mgc.numQueueStringForCommCalls);
+        assertEquals(3, mgc.numStreamCommandsCalls);
     
         // Wrap up streaming and make sure isStreaming switches back.
         GcodeCommand command = new GcodeCommand("G0X1"); // Whitespace removed.
@@ -483,12 +483,13 @@ public class GrblControllerTest {
         GrblController instance = new GrblController(mgc);
         instance.openCommPort("blah", 123);
         instance.rawResponseHandler("Grbl 0.8c");
-        assertEquals(1, mgc.numQueueStringForCommCalls);
-        assertEquals(1, mgc.numStreamCommandsCalls);
-        GcodeCommand command = instance.createCommand(str);
-        instance.sendCommandImmediately(command);
+        //$G and $$ get queued on startup
         assertEquals(2, mgc.numQueueStringForCommCalls);
         assertEquals(2, mgc.numStreamCommandsCalls);
+        GcodeCommand command = instance.createCommand(str);
+        instance.sendCommandImmediately(command);
+        assertEquals(3, mgc.numQueueStringForCommCalls);
+        assertEquals(3, mgc.numStreamCommandsCalls);
         assertEquals(str  + "\n", mgc.queuedString);
     }
 
@@ -577,7 +578,8 @@ public class GrblControllerTest {
         
         instance.openCommPort("blah", 1234);
         instance.rawResponseHandler("Grbl 0.8c");
-        assertEquals(1, mgc.numQueueStringForCommCalls);
+        //$G and $$ get queued on startup
+        assertEquals(2, mgc.numQueueStringForCommCalls);
 
         // Test 1. No commands to stream.
         boolean caughtException = false;
@@ -601,7 +603,7 @@ public class GrblControllerTest {
             assertEquals("Cannot stream while there are active commands (controller).", ex.getMessage());
         }
         assertFalse(caughtException);
-        assertEquals(2, mgc.numQueueStringForCommCalls);
+        assertEquals(3, mgc.numQueueStringForCommCalls);
 
         // Wrap up test 2.
         GcodeCommand command = new GcodeCommand("G0X1"); // Whitespace removed.
@@ -625,7 +627,7 @@ public class GrblControllerTest {
         assertFalse(caughtException);
         
         assertEquals(30, instance.rowsRemaining());
-        assertEquals(32, mgc.numQueueStringForCommCalls);
+        assertEquals(33, mgc.numQueueStringForCommCalls);
         // Wrap up test 3.
         for (int i=0; i < 30; i++) {
             command.setCommand("G0X" + i);

--- a/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -21,6 +21,9 @@ package com.willwinder.universalgcodesender;
 import com.willwinder.universalgcodesender.GrblUtils.Capabilities;
 import javax.vecmath.Point3d;
 import static org.junit.Assert.*;
+
+import com.willwinder.universalgcodesender.model.*;
+import com.willwinder.universalgcodesender.model.Utils;
 import org.junit.Test;
 
 /**
@@ -336,8 +339,8 @@ public class GrblUtilsTest {
         System.out.println("getMachinePositionFromStatusString");
         String status = "<Idle,MPos:5.529,0.560,7.000,WPos:1.529,-5.440,-0.000>";
         Capabilities version = Capabilities.STATUS_C;
-        Point3d expResult = new Point3d(5.529, 0.560, 7.000);
-        Point3d result = GrblUtils.getMachinePositionFromStatusString(status, version);
+        Position expResult = new Position(5.529, 0.560, 7.000, Utils.Units.UNKNOWN);
+        Position result = GrblUtils.getMachinePositionFromStatusString(status, version, Utils.Units.UNKNOWN);
         assertEquals(expResult, result);
     }
 
@@ -349,8 +352,8 @@ public class GrblUtilsTest {
         System.out.println("getWorkPositionFromStatusString");
         String status = "<Idle,MPos:5.529,0.560,7.000,WPos:1.529,-5.440,-0.000>";
         Capabilities version = Capabilities.STATUS_C;
-        Point3d expResult = new Point3d(1.529, -5.440, -0.000);
-        Point3d result = GrblUtils.getWorkPositionFromStatusString(status, version);
+        Position expResult = new Position(1.529, -5.440, -0.000, Utils.Units.UNKNOWN);
+        Position result = GrblUtils.getWorkPositionFromStatusString(status, version, Utils.Units.UNKNOWN);
         assertEquals(expResult, result);
     }
     

--- a/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
+++ b/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
@@ -610,8 +610,8 @@ public class GUIBackendTest {
     public void testStatusStringListener() {
         System.out.println("statusStringListener");
         String state = "";
-        Point3d machineCoord = null;
-        Point3d workCoord = null;
+        Position machineCoord = null;
+        Position workCoord = null;
         GUIBackend instance = new GUIBackend();
         instance.statusStringListener(state, machineCoord, workCoord);
         // TODO review the generated test code and remove the default call to fail.


### PR DESCRIPTION
The machine position window now shows units for the coordinates.  This depends entirely on the grbl settings.  I assume there's something similar in tinyg, but I can't test that.  TinyG behavior should be unchanged.  

The jog units are independent from the display units (setting $13), which is also independent from the parser modal state.  We may want to add a display on the UI somewhere to show how incoming motions commands will be interpreted.