### PR TITLE
Fixing tests to clean up temp files

### DIFF
--- a/test/com/willwinder/universalgcodesender/BufferedCommunicatorTest.java
+++ b/test/com/willwinder/universalgcodesender/BufferedCommunicatorTest.java
@@ -63,7 +63,7 @@ public class BufferedCommunicatorTest {
 
     @AfterClass
     static public void teardown() throws IOException {
-        FileUtils.deleteDirectory(tempDir);
+        FileUtils.forceDeleteOnExit(tempDir);
     }
 
     @Before


### PR DESCRIPTION
There were a couple of temp files that fail to be deleted.  The delete failures were causing tests to fail, which in turn prevents the maven package job from completing.