### PR TITLE
UGS crashes on "G162 X Y F2000" #237

### DIFF
--- a/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -358,9 +358,13 @@ public class GcodePreprocessorUtils {
         char address = Character.toUpperCase(c);
         for(String t : argList)
         {
-            if (t.length() > 0 && Character.toUpperCase(t.charAt(0)) == address)
+            if (t.length() > 1 && Character.toUpperCase(t.charAt(0)) == address)
             {
-                return Double.parseDouble(t.substring(1));
+                try {
+                    return Double.parseDouble(t.substring(1));
+                } catch (NumberFormatException e) {
+                    return Double.NaN;
+                }
             }
         }
         return Double.NaN;


### PR DESCRIPTION
If the number is missing or not a number, eat the exception and return NaN.  
