### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -1988,6 +1988,8 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
                                 resetCoordinatesButtonActionPerformed(null);
                                 e.consume();
                                 return true;
+                            default:
+                                break;
                         }
                     }
                     
@@ -2408,6 +2410,8 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
                             resetSentRowLabels(gsr.getNumRows());
                         }
                     } catch (IOException ex) {}
+                    break;
+                default:
                     break;
             }
 

--- a/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
+++ b/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
@@ -338,6 +338,8 @@ public class GcodeParser {
             case "91.1":
                 this.inAbsoluteIJKMode = false;
                 break;
+            default:
+                break;
         }
         this.lastGcodeCommand = code;
         return ps;

--- a/src/com/willwinder/universalgcodesender/model/Utils.java
+++ b/src/com/willwinder/universalgcodesender/model/Utils.java
@@ -42,12 +42,16 @@ public class Utils {
                 switch(to) {
                     case MM: return 1.0;
                     case INCH: return 1.0 / mmPerInch;
+                    default: break;
                 }
             case INCH:
                 switch(to) {
                     case MM: return 25.4;
                     case INCH: return 1.0;
+                    default: break;
                 }
+                default:
+                    break;
         }
         return 1.0;
     }

--- a/src/com/willwinder/universalgcodesender/uielements/FPSCounter.java
+++ b/src/com/willwinder/universalgcodesender/uielements/FPSCounter.java
@@ -190,6 +190,8 @@ public class FPSCounter {
           x = drawable.getSurfaceWidth() - fpsWidth - fpsOffset;
           y = fpsOffset;
           break;
+        default:
+          break;
       }
 
       renderer.draw(fpsText, x, y);

--- a/src/com/willwinder/universalgcodesender/uielements/Overlay.java
+++ b/src/com/willwinder/universalgcodesender/uielements/Overlay.java
@@ -175,6 +175,9 @@ public class Overlay {
           x = drawable.getSurfaceWidth() - width - offset;
           y = offset;
           break;
+
+        default:
+          break;
       }
       
       renderer.draw(text, x, y);

--- a/src/com/willwinder/universalgcodesender/uielements/SendStatusPanel.java
+++ b/src/com/willwinder/universalgcodesender/uielements/SendStatusPanel.java
@@ -192,6 +192,8 @@ public class SendStatusPanel extends JPanel implements UGSEventListener, Control
                 case COMM_SENDING:
                     beginSend();
                     break;
+                default:
+                    break;
             }
         }
 
@@ -206,6 +208,8 @@ public class SendStatusPanel extends JPanel implements UGSEventListener, Control
                             resetSentRowLabels(gsr.getNumRows());
                         }
                     } catch (IOException ex) {}
+                    break;
+                default:
                     break;
             }
         }

--- a/src/com/willwinder/universalgcodesender/utils/FirmwareUtils.java
+++ b/src/com/willwinder/universalgcodesender/utils/FirmwareUtils.java
@@ -70,6 +70,8 @@ public class FirmwareUtils {
                 return new GrblController(new LoopBackCommunicator());
             case LOOPBACK2:
                 return new GrblController(new LoopBackCommunicator(10));
+            default:
+                break;
         }
         
         return null;

--- a/src/com/willwinder/universalgcodesender/utils/GcodeStreamWriter.java
+++ b/src/com/willwinder/universalgcodesender/utils/GcodeStreamWriter.java
@@ -78,6 +78,8 @@ public class GcodeStreamWriter extends GcodeStream implements Closeable {
                 case COL_COMMAND_NUMBER:
                     fileWriter.append(Integer.toString(commandNumber));
                     break;
+                default:
+                    break;
             }
             sep = separator;
         }

--- a/src/com/willwinder/universalgcodesender/visualizer/VisualizerCanvas.java
+++ b/src/com/willwinder/universalgcodesender/visualizer/VisualizerCanvas.java
@@ -715,6 +715,8 @@ public class VisualizerCanvas extends GLCanvas implements GLEventListener, KeyLi
                 this.rotation.x = 0;
                 this.rotation.y = -30;
                 this.rotation.z = 0;
+            default:
+                break;
         }
         
         switch(ke.getKeyChar()) {
@@ -745,6 +747,8 @@ public class VisualizerCanvas extends GLCanvas implements GLEventListener, KeyLi
             case '+':
                 if (ke.isControlDown())
                     this.zoomIn(1);
+                break;
+            default:
                 break;
         }
         


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat