### PR TITLE
Fixed bug with the jog status line that didn't get updated

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -305,8 +305,8 @@ public class Settings {
         
     public void setDefaultUnits(String units) {
         if (Units.getUnit(defaultUnits) != null) {
-        changed();
             defaultUnits = units;
+            changed();
         }
     }
 

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/statusline/JogStatusLineService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/statusline/JogStatusLineService.java
@@ -46,6 +46,7 @@ public class JogStatusLineService implements StatusLineElementProvider {
         private final BackendAPI backend;
         public JogStatusLine(BackendAPI backend) {
             this.backend = backend;
+            this.backend.addUGSEventListener(this);
             setText();
         }
 


### PR DESCRIPTION
Fixed bug where the jog status line unit wasn't updated and that event for the changed setting was fired before the setting was stored.

![screen shot 2017-04-20 at 22 07 18](https://cloud.githubusercontent.com/assets/8962024/25250438/e4beb03c-2615-11e7-93d0-35d9d69ba1a0.png)