### PR TITLE
#637 fixed stack trace in jog-panel when using GTK-theme

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModel.java
@@ -29,9 +29,6 @@ public class StepSizeSpinnerModel extends SpinnerNumberModel {
         super(1.0, MIN_VALUE, MAX_VALUE, 1.0);
     }
 
-
-
-
     @Override
     public Object getNextValue() {
         double value = (double) getValue();
@@ -43,8 +40,11 @@ public class StepSizeSpinnerModel extends SpinnerNumberModel {
                 stepSize = stepSize / 10;
             }
         }
-        setStepSize(stepSize);
-        return super.getNextValue();
+
+        if( value >= MAX_VALUE) {
+            return 0;
+        }
+        return value + stepSize;
     }
 
     @Override
@@ -58,8 +58,11 @@ public class StepSizeSpinnerModel extends SpinnerNumberModel {
                 stepSize = stepSize / 10;
             }
         }
-        setStepSize(stepSize);
-        return super.getPreviousValue();
+
+        if( value <= MIN_VALUE) {
+            return 0;
+        }
+        return value - stepSize;
     }
 
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModel.java
@@ -42,7 +42,7 @@ public class StepSizeSpinnerModel extends SpinnerNumberModel {
         }
 
         if( value >= MAX_VALUE) {
-            return 0;
+            return null;
         }
         return value + stepSize;
     }
@@ -60,7 +60,7 @@ public class StepSizeSpinnerModel extends SpinnerNumberModel {
         }
 
         if( value <= MIN_VALUE) {
-            return 0;
+            return null;
         }
         return value - stepSize;
     }

--- a/ugs-core/test/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModelTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModelTest.java
@@ -30,7 +30,7 @@ public class StepSizeSpinnerModelTest {
     public void nextValueWhenMaxShouldNotIncrement() {
         StepSizeSpinnerModel model = new StepSizeSpinnerModel();
         model.setValue(StepSizeSpinnerModel.MAX_VALUE);
-        Assert.assertEquals(0, model.getNextValue());
+        Assert.assertEquals(null, model.getNextValue());
     }
 
     @Test
@@ -51,7 +51,7 @@ public class StepSizeSpinnerModelTest {
     public void previousValueWhenMinShouldNotDecrement() {
         StepSizeSpinnerModel model = new StepSizeSpinnerModel();
         model.setValue(StepSizeSpinnerModel.MIN_VALUE);
-        Assert.assertEquals(0, model.getPreviousValue());
+        Assert.assertEquals(null, model.getPreviousValue());
     }
 
     @Test
@@ -76,7 +76,7 @@ public class StepSizeSpinnerModelTest {
         Assert.assertEquals(200.0, model.getNextValue());
 
         model.setValue(StepSizeSpinnerModel.MIN_VALUE * 1000000);
-        Assert.assertEquals(0, model.getNextValue());
+        Assert.assertEquals(null, model.getNextValue());
         Assert.assertEquals(1000.0, model.getValue());
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModelTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/uielements/jog/StepSizeSpinnerModelTest.java
@@ -1,0 +1,82 @@
+/*
+    Copywrite 2017 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.uielements.jog;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Joacim Breiler
+ */
+public class StepSizeSpinnerModelTest {
+
+    @Test
+    public void nextValueWhenMaxShouldNotIncrement() {
+        StepSizeSpinnerModel model = new StepSizeSpinnerModel();
+        model.setValue(StepSizeSpinnerModel.MAX_VALUE);
+        Assert.assertEquals(0, model.getNextValue());
+    }
+
+    @Test
+    public void previousValueWhenMaxShouldDecrement() {
+        StepSizeSpinnerModel model = new StepSizeSpinnerModel();
+        model.setValue(StepSizeSpinnerModel.MAX_VALUE);
+        Assert.assertEquals(StepSizeSpinnerModel.MAX_VALUE - 100, model.getPreviousValue());
+    }
+
+    @Test
+    public void nextValueWhenMinShouldIncrement() {
+        StepSizeSpinnerModel model = new StepSizeSpinnerModel();
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE);
+        Assert.assertEquals(StepSizeSpinnerModel.MIN_VALUE + 0.001, model.getNextValue());
+    }
+
+    @Test
+    public void previousValueWhenMinShouldNotDecrement() {
+        StepSizeSpinnerModel model = new StepSizeSpinnerModel();
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE);
+        Assert.assertEquals(0, model.getPreviousValue());
+    }
+
+    @Test
+    public void stepSizesShouldChange() {
+        StepSizeSpinnerModel model = new StepSizeSpinnerModel();
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE);
+        Assert.assertEquals(0.002, model.getNextValue());
+
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE * 10);
+        Assert.assertEquals(0.02, model.getNextValue());
+
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE * 100);
+        Assert.assertEquals(0.2, model.getNextValue());
+
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE * 1000);
+        Assert.assertEquals(2.0, model.getNextValue());
+
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE * 10000);
+        Assert.assertEquals(20.0, model.getNextValue());
+
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE * 100000);
+        Assert.assertEquals(200.0, model.getNextValue());
+
+        model.setValue(StepSizeSpinnerModel.MIN_VALUE * 1000000);
+        Assert.assertEquals(0, model.getNextValue());
+        Assert.assertEquals(1000.0, model.getValue());
+    }
+}


### PR DESCRIPTION
By calling getNextValue an event will be fired which will cause a call to the same method again. This will be repeated untill the stack is full. Added a test and rewrote the code so that it won't call getNextValue().