### PR TITLE
split pendant gCode on semicolon to allow multiple commands in a single request

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
@@ -27,6 +27,9 @@ public class MacroHelper {
     /**
      * Process and send a custom gcode string.
      * 
+     * Not safe to run in the AWT Event Dispatching thread, be sure to use
+     * EventQueue.invokeLater() if running in response to a GUI event.
+     * 
      * Interactive substitutions can be made with special characters:
      *   %machine_x% - The machine X location
      *   %machine_y% - The machine Y location
@@ -39,25 +42,21 @@ public class MacroHelper {
      * @param str 
      * @param backend 
      */
-    public static void executeCustomGcode(final String str, BackendAPI backend) {
+    public static void executeCustomGcode(final String str, BackendAPI backend) throws Exception {
         if (str == null) {
             return;
         }
         String command = MacroHelper.substituteValues(str, backend);
         command = command.replaceAll("(\\r\\n|\\n\\r|\\r|\\n)", "");
         final String[] parts = command.split(";");
-        EventQueue.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    for (String cmd : parts) {
-                        backend.sendGcodeCommand(cmd);
-                    }
-                } catch (Exception ex) {
-                    GUIHelpers.displayErrorDialog(ex.getMessage());
-                }
-            }
-        });
+
+        /* 
+         * specifically NOT catching exceptions on gCode commands, let them pass to the invoking method
+         * so the error handling is aligned to the UI that triggered it (i.e. GUI button press versus Pendant UI http request)
+         */
+		for (String cmd : parts) {
+			backend.sendGcodeCommand(cmd);
+		}
     }
     
     /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
@@ -54,9 +54,9 @@ public class MacroHelper {
          * specifically NOT catching exceptions on gCode commands, let them pass to the invoking method
          * so the error handling is aligned to the UI that triggered it (i.e. GUI button press versus Pendant UI http request)
          */
-		for (String cmd : parts) {
-			backend.sendGcodeCommand(cmd);
-		}
+        for (String cmd : parts) {
+            backend.sendGcodeCommand(cmd);
+        }
     }
     
     /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
@@ -184,7 +184,9 @@ public class PendantUI implements ControllerListener {
                         case "CANCEL_FILE":
                             break;
                         default:
-                            mainWindow.sendGcodeCommand(gCode);
+                        	for (String cmd : gCode.split(";")) {
+                        		mainWindow.sendGcodeCommand(cmd);
+                        	}
                             break;
                     }
                 } else {

--- a/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
@@ -185,12 +185,12 @@ public class PendantUI implements ControllerListener {
                         case "CANCEL_FILE":
                             break;
                         default:
-                        	try {
-                        		MacroHelper.executeCustomGcode(gCode, mainWindow);
-                        	} catch (Exception ex) {
-                        		System.err.println("pendant failed executing gCode [" + gCode + "]");
-                        		ex.printStackTrace();
-                        	}
+                            try {
+                                MacroHelper.executeCustomGcode(gCode, mainWindow);
+                            } catch (Exception ex) {
+                        	    System.err.println("pendant failed executing gCode [" + gCode + "]");
+                        	    ex.printStackTrace();
+                            }
                             break;
                     }
                 } else {

--- a/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.util.resource.Resource;
 import com.google.gson.Gson;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
+import com.willwinder.universalgcodesender.MacroHelper;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
@@ -184,8 +185,11 @@ public class PendantUI implements ControllerListener {
                         case "CANCEL_FILE":
                             break;
                         default:
-                        	for (String cmd : gCode.split(";")) {
-                        		mainWindow.sendGcodeCommand(cmd);
+                        	try {
+                        		MacroHelper.executeCustomGcode(gCode, mainWindow);
+                        	} catch (Exception ex) {
+                        		System.err.println("pendant failed executing gCode [" + gCode + "]");
+                        		ex.printStackTrace();
                         	}
                             break;
                     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroActionPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroActionPanel.java
@@ -22,6 +22,7 @@ import com.willwinder.universalgcodesender.MacroHelper;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.types.Macro;
+import com.willwinder.universalgcodesender.utils.GUIHelpers;
 import com.willwinder.universalgcodesender.utils.Settings;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang3.StringUtils;
@@ -160,8 +161,17 @@ public class MacroActionPanel extends JPanel implements UGSEventListener {
     }
 
     private void customGcodeButtonActionPerformed(int macroIndex) {
-        Macro m = backend.getSettings().getMacro(macroIndex);
-        MacroHelper.executeCustomGcode(m.getGcode(), backend);
+        Macro macro = backend.getSettings().getMacro(macroIndex);
+        EventQueue.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    MacroHelper.executeCustomGcode(macro.getGcode(), backend);
+                } catch (Exception ex) {
+                    GUIHelpers.displayErrorDialog(ex.getMessage());
+                }
+            }
+        });
     }
 
     private void updateCustomGcodeControls(boolean enabled) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroPanel.java
@@ -29,6 +29,8 @@ import com.willwinder.universalgcodesender.utils.Settings;
 import net.miginfocom.swing.MigLayout;
 
 import javax.swing.*;
+
+import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
@@ -160,7 +162,16 @@ public class MacroPanel extends JPanel implements UGSEventListener {
 
     private void customGcodeButtonActionPerformed(int i) {
         Macro macro = backend.getSettings().getMacro(i);
-        MacroHelper.executeCustomGcode(macro.getGcode(), backend);
+        EventQueue.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    MacroHelper.executeCustomGcode(macro.getGcode(), backend);
+                } catch (Exception ex) {
+                    GUIHelpers.displayErrorDialog(ex.getMessage());
+                }
+            }
+        });
     }
 
     private void updateCustomGcodeControls(boolean enabled) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/MacroHelperTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/MacroHelperTest.java
@@ -28,7 +28,11 @@ public class MacroHelperTest {
         System.out.println("executeCustomGcode");
         String str = "";
         BackendAPI backend = null;
-        MacroHelper.executeCustomGcode(str, backend);
+        try {
+        	MacroHelper.executeCustomGcode(str, backend);
+        } catch (Exception ex) {
+        	// guaranteed NullPointerException because of null backend passed into MacroHelper.substituteValues()
+        }
         // TODO review the generated test code and remove the default call to fail.
         fail("The test case is a prototype.");
     }

--- a/ugs-core/test/com/willwinder/universalgcodesender/pendantui/PendantUITest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/pendantui/PendantUITest.java
@@ -43,8 +43,17 @@ public class PendantUITest {
 	public void testStart() throws Exception {
 
         // This is what we're about to do...
-        // 1. Send a command
-        mockBackend.sendGcodeCommand("MyGcode");
+        /* 1. Send two gcode commands via a single http request "G91;G90"
+         * expect it to result in two separate calls to sendGcodeCommand, one for each gCode command
+         * and because we call substituteValues(), it'll also call updateSystemState
+         */
+		mockBackend.updateSystemState(EasyMock.anyObject(SystemStateBean.class));
+		EasyMock.expect(EasyMock.expectLastCall()).once();
+
+		mockBackend.sendGcodeCommand("G91");
+        EasyMock.expect(EasyMock.expectLastCall()).once();
+        
+        mockBackend.sendGcodeCommand("G90");
         EasyMock.expect(EasyMock.expectLastCall()).once();
 
         // 2. Commands
@@ -97,7 +106,7 @@ public class PendantUITest {
         assertTrue(indexPage.contains("$(function()"));
 
         // 1. Send a command
-        getResponse(url+"/sendGcode?gCode=MyGcode");
+        getResponse(url+"/sendGcode?gCode=G91%3BG90");
         // 2. Send commands
         getResponse(url+"/sendGcode?gCode=$H");
         getResponse(url+"/sendGcode?gCode=$X");

--- a/ugs-core/test/com/willwinder/universalgcodesender/pendantui/PendantUITest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/pendantui/PendantUITest.java
@@ -47,14 +47,14 @@ public class PendantUITest {
          * expect it to result in two separate calls to sendGcodeCommand, one for each gCode command
          * and because we call substituteValues(), it'll also call updateSystemState
          */
-		mockBackend.updateSystemState(EasyMock.anyObject(SystemStateBean.class));
-		EasyMock.expect(EasyMock.expectLastCall()).once();
+	    mockBackend.updateSystemState(EasyMock.anyObject(SystemStateBean.class));
+	    EasyMock.expect(EasyMock.expectLastCall()).once();
 
-		mockBackend.sendGcodeCommand("G91");
-        EasyMock.expect(EasyMock.expectLastCall()).once();
-        
-        mockBackend.sendGcodeCommand("G90");
-        EasyMock.expect(EasyMock.expectLastCall()).once();
+	    mockBackend.sendGcodeCommand("G91");
+	    EasyMock.expect(EasyMock.expectLastCall()).once();
+
+	    mockBackend.sendGcodeCommand("G90");
+	    EasyMock.expect(EasyMock.expectLastCall()).once();
 
         // 2. Commands
         mockBackend.performHomingCycle();

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
@@ -97,17 +97,17 @@ public final class MacroService {
         public void actionPerformed(ActionEvent e) {
             Macro macro = settings.getMacro(macroIdx);
             if (macro != null && macro.getGcode() != null) {
-				EventQueue.invokeLater(new Runnable() {
-					@Override
-					public void run() {
-						try {
-							MacroHelper.executeCustomGcode(macro.getGcode(), backend);
-						} catch (Exception ex) {
-							GUIHelpers.displayErrorDialog(ex.getMessage());
-							Exceptions.printStackTrace(ex);
-						}
-					}
-				});
+                EventQueue.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            MacroHelper.executeCustomGcode(macro.getGcode(), backend);
+                        } catch (Exception ex) {
+                            GUIHelpers.displayErrorDialog(ex.getMessage());
+                            Exceptions.printStackTrace(ex);
+                        }
+                    }
+                });
             }
         }
 

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
@@ -24,7 +24,10 @@ import com.willwinder.universalgcodesender.MacroHelper;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.types.Macro;
+import com.willwinder.universalgcodesender.utils.GUIHelpers;
 import com.willwinder.universalgcodesender.utils.Settings;
+
+import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,13 +95,19 @@ public final class MacroService {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            Macro m = settings.getMacro(macroIdx);
-            try {
-                if (m != null && m.getGcode() != null) {
-                    MacroHelper.executeCustomGcode(m.getGcode(), backend);
-                }
-            } catch (Exception ex) {
-                Exceptions.printStackTrace(ex);
+            Macro macro = settings.getMacro(macroIdx);
+            if (macro != null && macro.getGcode() != null) {
+				EventQueue.invokeLater(new Runnable() {
+					@Override
+					public void run() {
+						try {
+							MacroHelper.executeCustomGcode(macro.getGcode(), backend);
+						} catch (Exception ex) {
+							GUIHelpers.displayErrorDialog(ex.getMessage());
+							Exceptions.printStackTrace(ex);
+						}
+					}
+				});
             }
         }
 


### PR DESCRIPTION
this matches the behavior for how macros handle embedded semicolon