### PR TITLE
Update error codes

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -486,6 +486,9 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
 
     @Override
     public GcodeCommand getActiveCommand() {
+        if (activeCommands.isEmpty()) {
+            return null;
+        }
         return activeCommands.get(0);
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -127,10 +127,13 @@ public class GrblController extends AbstractController {
                             return input;
                     }
 
-                    if (shortString)
+                    if (lookupParts == null) {
+                        return "(" + input + ") An unknown error has occurred";
+                    } else if (shortString ) {
                         return input + " (" + lookupParts[1] + ")";
-                    else 
+                    } else {
                         return "(" + input + ") " + lookupParts[2];
+                    }
                 }
             }
         }

--- a/ugs-core/src/resources/grbl/error_codes_en_US.csv
+++ b/ugs-core/src/resources/grbl/error_codes_en_US.csv
@@ -15,6 +15,7 @@
 14,Line length exceeded,Build info or startup line exceeded EEPROM line length limit. Line not stored.
 15,Travel exceeded,Jog target exceeds machine travel. Jog command has been ignored.
 16,Invalid jog command,Jog command has no '=' or contains prohibited g-code.
+17,Setting disabled,Laser mode requires PWM output.
 20,Unsupported command,Unsupported or invalid g-code command found in block.
 21,Modal group violation,More than one g-code command from same modal group found in block.
 22,Undefined feed rate,Feed rate has not yet been set or is undefined.
@@ -33,3 +34,4 @@
 35,Invalid gcode ID:35,G2 and G3 arcs require at least one in-plane offset word.
 36,Invalid gcode ID:36,Unused value words found in block.
 37,Invalid gcode ID:37,G43.1 dynamic tool length offset is not assigned to configured tool length axis.
+38,Invalid gcode ID:38,Tool number greater than max supported value.


### PR DESCRIPTION
I dug into the issue #867 and found that the error is caused by a NPE from the lookupCode method that checks the error_codes_en_US.csv:
```java
java.lang.NullPointerException
	at com.willwinder.universalgcodesender.GrblController.lookupCode(GrblController.java:133)
	at com.willwinder.universalgcodesender.GrblController.rawResponseHandler(GrblController.java:174)
	at com.willwinder.universalgcodesender.GrblControllerTest.rawResponseHandlerWithUnknownErrorShouldWriteGenericMessageToConsole(GrblControllerTest.java:1220)
	...
```

Normally when an error occur the command is marked as completed using the method `this.commandComplete(processed);`, but instead the error is handled by the try/catch which doesn't complete the command.

```java
else if (GrblUtils.isOkErrorAlarmResponse(response)) {
    if (GrblUtils.isAlarmResponse(response)) {
        //this is not updating the state to Alarm in the GUI, and the alarm is no longer being processed
        // TODO: Find a builder library.
        this.controllerStatus = new ControllerStatus(
                lookupCode(response, true), 
                this.controllerStatus.getMachineCoord(),
                this.controllerStatus.getWorkCoord(),
                this.controllerStatus.getFeedSpeed(),
                this.controllerStatus.getSpindleSpeed(),
                this.controllerStatus.getOverrides(),
                this.controllerStatus.getWorkCoordinateOffset(),
                this.controllerStatus.getEnabledPins(),
                this.controllerStatus.getAccessoryStates());
        dispatchStatusString(this.controllerStatus);
        dispatchStateChange(COMM_IDLE);
    }

    GcodeCommand command = this.getActiveCommand();
    processed =
            String.format(Localization.getString("controller.exception.sendError"),
                    command.getCommandString(),
                    lookupCode(response, false)).replaceAll("\\.\\.", "\\.");
    this.errorMessageForConsole(processed + "\n");
    this.commandComplete(processed);
    processed = "";
}
```