### PR TITLE
Resume operation after soft reset

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
@@ -139,7 +139,11 @@ public abstract class BufferedCommunicator extends AbstractCommunicator {
                 commandStream == null ? 0 : commandStream.getNumRowsRemaining();
         return this.activeCommandList.size() + streamingCount;
     }
-    
+
+    public int numBufferedCommands() {
+        return commandBuffer.size();
+    }
+
     // Helper for determining if commands should be throttled.
     private boolean allowMoreCommands() {
         if (this.singleStepModeEnabled) {
@@ -271,6 +275,7 @@ public abstract class BufferedCommunicator extends AbstractCommunicator {
         this.commandBuffer.clear();
         this.activeCommandList.clear();
         this.sentBufferSize = 0;
+        this.sendPaused = false;
     }
 
     /**

--- a/ugs-core/test/com/willwinder/universalgcodesender/BufferedCommunicatorTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/BufferedCommunicatorTest.java
@@ -425,6 +425,27 @@ public class BufferedCommunicatorTest {
         assertEquals("The second command should be from the stream", "G0\n", commandCaptor.getAllValues().get(1));
     }
 
+    @Test
+    public void softResetShouldClearBuffersAndResumeOperation() {
+        // Given
+        Connection connection = mock(Connection.class);
+        instance.setConnection(connection);
+        asl.add(new GcodeCommand("G0"));
+        cb.add("G0");
+
+        instance.pauseSend();
+        assertTrue(instance.isPaused());
+        assertEquals(1, instance.numActiveCommands());
+        assertEquals(1, instance.numBufferedCommands());
+
+        // When
+        instance.softReset();
+
+        // Then
+        assertFalse("The communicator should resume operation after a reset", instance.isPaused());
+        assertEquals("There should be no active commands", 0, instance.numActiveCommands());
+        assertEquals("There should be no buffered manual commands", 0, instance.numBufferedCommands());
+    }
 
     public class BufferedCommunicatorImpl extends BufferedCommunicator {
         BufferedCommunicatorImpl(LinkedBlockingDeque<String> cb, LinkedBlockingDeque<GcodeCommand> asl) {


### PR DESCRIPTION
Possible fix for #759 and #944 - After a soft reset the buffered communicator will clear the paused flag to false. Also added tests to make sure the buffers are cleared.