### PR TITLE
Handle streaming errors in the communicatorPausedOnError callback.

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -735,6 +735,8 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
             }
             else {
                 this.pauseStreaming();
+                // In check mode there is no state transition, so we need to manually make the notification.
+                this.dispatchStateChange(COMM_SENDING_PAUSED);
             }
         } catch (Exception ignored) {
             logger.log(Level.SEVERE, "Couldn't set the state to paused.");

--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -804,11 +804,6 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
      * that the stream is complete once the last command has finished.
      */
     public void commandComplete(String response) throws UnexpectedCommand {
-        // Auto-paused while we weren't streaming, resume the comm.
-        if (!isStreaming() && !isPaused() && comm.isPaused()) {
-            comm.resumeSend();
-        }
-
         if (this.activeCommands.isEmpty()) {
             throw new UnexpectedCommand(
                     Localization.getString("controller.exception.unexpectedCommand"));

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -722,13 +722,6 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
 
     @Override
     public void commandComplete(GcodeCommand command) {
-        if (command.isError() && isSendingFile() && !this.isPaused()) {
-            try {
-                this.pauseResume();
-            } catch (Exception e) {
-                GUIHelpers.displayErrorDialog(e.getLocalizedMessage());
-            }
-        }
     }
 
     @Override

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -39,9 +39,7 @@ import org.junit.Ignore;
 
 import static com.willwinder.universalgcodesender.AbstractControllerTest.tempDir;
 import static com.willwinder.universalgcodesender.GrblUtils.GRBL_PAUSE_COMMAND;
-import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_CHECK;
-import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_IDLE;
-import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_SENDING;
+import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -1377,7 +1375,7 @@ public class GrblControllerTest {
         gc.rawResponseHandler("error:1");
 
         // Then
-        assertEquals(gc.getControlState(), ControlState.COMM_CHECK);
+        assertEquals(gc.getControlState(), COMM_CHECK);
         assertFalse(gc.isPaused());
         verify(communicator, times(1)).resumeSend();
     }
@@ -1400,9 +1398,9 @@ public class GrblControllerTest {
         gc.rawResponseHandler("error:1");
 
         // Then
-        assertEquals(gc.getControlState(), ControlState.COMM_CHECK);
+        assertEquals(gc.getControlState(), COMM_CHECK);
         assertFalse(gc.isPaused());
         verify(communicator, times(1)).sendByteImmediately(GRBL_PAUSE_COMMAND);
-        verify(controllerListener, times(1)).controlStateChange(ControlState.COMM_SENDING_PAUSED);
+        verify(controllerListener, times(1)).controlStateChange(COMM_SENDING_PAUSED);
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -38,6 +38,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 
 import static com.willwinder.universalgcodesender.AbstractControllerTest.tempDir;
+import static com.willwinder.universalgcodesender.GrblUtils.GRBL_PAUSE_COMMAND;
 import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_CHECK;
 import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_IDLE;
 import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_SENDING;
@@ -1361,5 +1362,47 @@ public class GrblControllerTest {
         assertTrue(instance.isIdle());
         assertTrue(instance.isIdleEvent());
         assertEquals(COMM_CHECK, instance.getControlState());
+    }
+
+    @Test
+    public void errorInCheckModeNotSending() throws Exception {
+        // Given
+        AbstractCommunicator communicator = mock(AbstractCommunicator.class);
+        GrblController gc = new GrblController(communicator);
+        gc.rawResponseHandler("Grbl 1.1f"); // We will assume that we are using version Grbl 1.0 with streaming support
+        gc.rawResponseHandler("<Check|MPos:0.000,0.000,0.000|FS:0,0|Pn:XYZ>");
+
+        // When
+        gc.communicatorPausedOnError();
+        gc.rawResponseHandler("error:1");
+
+        // Then
+        assertEquals(gc.getControlState(), ControlState.COMM_CHECK);
+        assertFalse(gc.isPaused());
+        verify(communicator, times(1)).resumeSend();
+    }
+
+    @Test
+    public void errorInCheckModeSending() throws Exception {
+        // Given
+        AbstractCommunicator communicator = mock(AbstractCommunicator.class);
+        ControllerListener controllerListener = mock(ControllerListener.class);
+        GrblController gc = new GrblController(communicator);
+        gc.addListener(controllerListener);
+        gc.rawResponseHandler("Grbl 1.1f"); // We will assume that we are using version Grbl 1.0 with streaming support
+        gc.rawResponseHandler("<Check|MPos:0.000,0.000,0.000|FS:0,0|Pn:XYZ>");
+        doReturn(true).when(communicator).isCommOpen();
+
+        // When
+        gc.queueCommand(new GcodeCommand("G0 X10"));
+        gc.beginStreaming();
+        gc.communicatorPausedOnError();
+        gc.rawResponseHandler("error:1");
+
+        // Then
+        assertEquals(gc.getControlState(), ControlState.COMM_CHECK);
+        assertFalse(gc.isPaused());
+        verify(communicator, times(1)).sendByteImmediately(GRBL_PAUSE_COMMAND);
+        verify(controllerListener, times(1)).controlStateChange(ControlState.COMM_SENDING_PAUSED);
     }
 }


### PR DESCRIPTION
Handle streaming errors in the `communicatorPausedOnError` callback. Now that the controller is notified directly about communicator errors, the handling can be simplified quite a bit. It seems to work properly.