### PR TITLE
Controller state

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -21,6 +21,7 @@ package com.willwinder.universalgcodesender;
 import com.willwinder.universalgcodesender.gcode.GcodeCommandCreator;
 import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
 import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.model.Overrides;
 import com.willwinder.universalgcodesender.model.Position;
@@ -68,7 +69,7 @@ public class GrblController extends AbstractController {
     // Polling state
     private int outstandingPolls = 0;
     private Timer positionPollTimer = null;  
-    private ControllerStatus controllerStatus = new ControllerStatus("Idle", new Position(0,0,0,Units.MM), new Position(0,0,0,Units.MM));
+    private ControllerStatus controllerStatus = new ControllerStatus("Idle", ControllerState.IDLE, new Position(0,0,0,Units.MM), new Position(0,0,0,Units.MM));
 
     // Canceling state
     private Boolean isCanceling = false;     // Set for the position polling thread.
@@ -171,8 +172,11 @@ public class GrblController extends AbstractController {
                 if (GrblUtils.isAlarmResponse(response)) {
                     //this is not updating the state to Alarm in the GUI, and the alarm is no longer being processed
                     // TODO: Find a builder library.
+                    String stateString = lookupCode(response, true);
+                    ControllerState state = GrblUtils.getControllerStateFromStateString(stateString);
                     this.controllerStatus = new ControllerStatus(
-                            lookupCode(response, true), 
+                            stateString,
+                            state,
                             this.controllerStatus.getMachineCoord(),
                             this.controllerStatus.getWorkCoord(),
                             this.controllerStatus.getFeedSpeed(),

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -330,7 +330,7 @@ public class GrblController extends AbstractController {
     @Override
     protected void isReadyToStreamCommandsEvent() throws Exception {
         isReadyToSendCommandsEvent();
-        if (this.controllerStatus != null && this.controllerStatus.getStateString().equals("Alarm")) {
+        if (this.controllerStatus != null && this.controllerStatus.getState() == ControllerState.ALARM) {
             throw new Exception(Localization.getString("grbl.exception.Alarm"));
         }
     }
@@ -353,7 +353,7 @@ public class GrblController extends AbstractController {
 
         // If we're canceling a "jog" just send the door hold command.
         if (capabilities.hasJogging() && controllerStatus != null &&
-                "jog".equalsIgnoreCase(controllerStatus.getStateString())) {
+                controllerStatus.getState() == ControllerState.JOG) {
             this.comm.sendByteImmediately(GrblUtils.GRBL_JOG_CANCEL_COMMAND);
         }
         // Otherwise, check if we can get fancy with a soft reset.

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -326,7 +326,7 @@ public class GrblController extends AbstractController {
     @Override
     protected void isReadyToStreamCommandsEvent() throws Exception {
         isReadyToSendCommandsEvent();
-        if (this.controllerStatus != null && this.controllerStatus.getState().equals("Alarm")) {
+        if (this.controllerStatus != null && this.controllerStatus.getStateString().equals("Alarm")) {
             throw new Exception(Localization.getString("grbl.exception.Alarm"));
         }
     }
@@ -349,7 +349,7 @@ public class GrblController extends AbstractController {
 
         // If we're canceling a "jog" just send the door hold command.
         if (capabilities.hasJogging() && controllerStatus != null &&
-                "jog".equalsIgnoreCase(controllerStatus.getState())) {
+                "jog".equalsIgnoreCase(controllerStatus.getStateString())) {
             this.comm.sendByteImmediately(GrblUtils.GRBL_JOG_CANCEL_COMMAND);
         }
         // Otherwise, check if we can get fancy with a soft reset.
@@ -391,7 +391,7 @@ public class GrblController extends AbstractController {
             return super.getControlState();
         }
 
-        String state = this.controllerStatus == null ? "" : StringUtils.defaultString(this.controllerStatus.getState());
+        String state = this.controllerStatus == null ? "" : StringUtils.defaultString(this.controllerStatus.getStateString());
         switch(state.toLowerCase()) {
             case "jog":
             case "run":
@@ -649,7 +649,7 @@ public class GrblController extends AbstractController {
         }
 
         ControlState before = getControlState();
-        String beforeState = controllerStatus == null ? "" : controllerStatus.getState();
+        String beforeState = controllerStatus == null ? "" : controllerStatus.getStateString();
 
         controllerStatus = GrblUtils.getStatusFromStatusString(
                 controllerStatus, string, capabilities, getFirmwareSettings().getReportingUnits());
@@ -660,7 +660,7 @@ public class GrblController extends AbstractController {
         }
 
         // GRBL 1.1 jog complete transition
-        if (StringUtils.equals(beforeState, "Jog") && controllerStatus.getState().equals("Idle")) {
+        if (StringUtils.equals(beforeState, "Jog") && controllerStatus.getStateString().equals("Idle")) {
             this.comm.cancelSend();
         }
 
@@ -679,15 +679,15 @@ public class GrblController extends AbstractController {
             if (attemptsRemaining > 0 && lastLocation != null) {
                 attemptsRemaining--;
                 // If the machine goes into idle, we no longer need to cancel.
-                if (this.controllerStatus.getState().equals("Idle") || this.controllerStatus.getState().equalsIgnoreCase("Check")) {
+                if (this.controllerStatus.getStateString().equals("Idle") || this.controllerStatus.getStateString().equalsIgnoreCase("Check")) {
                     isCanceling = false;
 
                     // Make sure the GUI gets updated
                     this.dispatchStateChange(getControlState());
                 }
                 // Otherwise check if the machine is Hold/Queue and stopped.
-                else if ((this.controllerStatus.getState().equals("Hold")
-                        || this.controllerStatus.getState().equals("Queue"))
+                else if ((this.controllerStatus.getStateString().equals("Hold")
+                        || this.controllerStatus.getStateString().equals("Queue"))
                         && lastLocation.equals(this.controllerStatus.getMachineCoord())) {
                     try {
                         this.issueSoftReset();

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -23,6 +23,7 @@
 
 package com.willwinder.universalgcodesender;
 
+import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus.OverridePercents;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus.AccessoryStates;
@@ -299,12 +300,15 @@ public class GrblUtils {
             final Capabilities version, Units reportingUnits) {
         // Legacy status.
         if (!version.hasCapability(GrblCapabilitiesConstants.V1_FORMAT)) {
+            String stateString = getStateFromStatusString(status, version);
+            ControllerState state = getControllerStateFromStateString(stateString);
             return new ControllerStatus(
-                getStateFromStatusString(status, version),
-                getMachinePositionFromStatusString(status, version, reportingUnits),
-                getWorkPositionFromStatusString(status, version, reportingUnits));
+                    stateString,
+                    state,
+                    getMachinePositionFromStatusString(status, version, reportingUnits),
+                    getWorkPositionFromStatusString(status, version, reportingUnits));
         } else {
-            String state = "";
+            String stateString = "";
             Position MPos = null;
             Position WPos = null;
             Position WCO = null;
@@ -322,9 +326,9 @@ public class GrblUtils {
                 if (part.startsWith("<")) {
                     int idx = part.indexOf(':');
                     if (idx == -1)
-                        state = part.substring(1);
+                        stateString = part.substring(1);
                     else
-                        state = part.substring(1, idx);
+                        stateString = part.substring(1, idx);
                 }
                 else if (part.startsWith("MPos:")) {
                     MPos = GrblUtils.getPositionFromStatusString(status, machinePattern, reportingUnits);
@@ -398,7 +402,8 @@ public class GrblUtils {
                 }
             }
 
-            return new ControllerStatus(state, MPos, WPos, feedSpeed, spindleSpeed, overrides, WCO, pins, accessoryStates); 
+            ControllerState state = getControllerStateFromStateString(stateString);
+            return new ControllerStatus(stateString, state, MPos, WPos, feedSpeed, spindleSpeed, overrides, WCO, pins, accessoryStates);
         }
     }
 
@@ -422,7 +427,32 @@ public class GrblUtils {
 
         return retValue;
     }
-    
+
+    public static ControllerState getControllerStateFromStateString(String stateString) {
+        switch (stateString.toLowerCase()) {
+            case "jog":
+                return ControllerState.JOG;
+            case "run":
+                return ControllerState.RUN;
+            case "hold":
+                return ControllerState.HOLD;
+            case "door":
+                return ControllerState.DOOR;
+            case "home":
+                return ControllerState.HOME;
+            case "idle":
+                return ControllerState.IDLE;
+            case "alarm":
+                return ControllerState.ALARM;
+            case "check":
+                return ControllerState.CHECK;
+            case "sleep":
+                return ControllerState.SLEEP;
+            default:
+                return ControllerState.UNKNOWN;
+        }
+    }
+
     static Pattern mmPattern = Pattern.compile(".*:\\d+\\.\\d\\d\\d,.*");
     static protected Units getUnitsFromStatusString(final String status, final Capabilities version) {
         if (version.hasCapability(GrblCapabilitiesConstants.REAL_TIME)) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -2013,8 +2013,8 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
             return;
         }
 
-        this.activeStateValueLabel.setText( status.getState() );
-        this.setStatusColorForState( status.getState() );
+        this.activeStateValueLabel.setText( status.getStateString() );
+        this.setStatusColorForState( status.getStateString() );
 
         if (status.getMachineCoord() != null) {
             this.machinePositionXValueLabel.setText( Utils.formatter.format(status.getMachineCoord().x) + status.getMachineCoord().getUnits().abbreviation );

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerState.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerState.java
@@ -1,0 +1,17 @@
+package com.willwinder.universalgcodesender.listeners;
+
+/**
+ * The different states a controller can have
+ */
+public enum ControllerState {
+    ALARM,
+    HOLD,
+    DOOR,
+    RUN,
+    JOG,
+    CHECK,
+    IDLE,
+    HOME,
+    SLEEP,
+    UNKNOWN
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerState.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerState.java
@@ -1,17 +1,79 @@
+/*
+    Copyright 2018 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.universalgcodesender.listeners;
 
 /**
- * The different states a controller can have
+ * The different states of a controller.
+ *
+ * @author Joacim Breiler
  */
 public enum ControllerState {
+    /**
+     * When an serious error has occured on the controller. This occurs when a limit switch
+     * has been triggered or if an operation would make the machine travel beyond soft limits.
+     * This types of errors often requires a controller reset.
+     */
     ALARM,
+
+    /**
+     * When the machine controller is paused.
+     */
     HOLD,
+
+    /**
+     * When the machine door is open
+     */
     DOOR,
+
+    /**
+     * When the machine controller is processing commands
+     */
     RUN,
+
+    /**
+     * When the machine controller is jogging
+     */
     JOG,
+
+    /**
+     * When the machine controller is in a check mode to parse commands without moving
+     * the machine.
+     */
     CHECK,
+
+    /**
+     * When the machine controller is in idle mode.
+     */
     IDLE,
+
+    /**
+     * When the machine controller is performing a homing sequence
+     */
     HOME,
+
+    /**
+     * When the machine is in sleep mode
+     */
     SLEEP,
+
+    /**
+     * When the machine is in an unknown state
+     */
     UNKNOWN
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
@@ -34,26 +34,29 @@ public class ControllerStatus {
     private final OverridePercents overrides;
     private final EnabledPins pins;
     private final AccessoryStates accessoryStates;
+    private final ControllerState state;
 
     /**
      * Baseline constructor. This data should always be present. Represents the
      * controller status.
      * @param stateString controller state, i.e. idle/hold/running
+     * @param state controller state, i.e. {@link ControllerState#IDLE}/{@link ControllerState#HOLD}/{@link ControllerState#RUN}
      * @param machineCoord controller machine coordinates
      * @param workCoord controller work coordinates
      */
-    public ControllerStatus(String stateString, Position machineCoord, Position workCoord) {
-        this(stateString, machineCoord, workCoord, null, null, null, null, null, null);
+    public ControllerStatus(String stateString, ControllerState state, Position machineCoord, Position workCoord) {
+        this(stateString, state, machineCoord, workCoord, null, null, null, null, null, null);
     }
 
     /**
      * Additional parameters
      */
-    public ControllerStatus(String stateString, Position machineCoord,
+    public ControllerStatus(String stateString, ControllerState state, Position machineCoord,
                             Position workCoord, Double feedSpeed, Double spindleSpeed,
                             OverridePercents overrides, Position workCoordinateOffset,
                             EnabledPins pins, AccessoryStates states) {
         this.stateString = stateString;
+        this.state = state;
         this.machineCoord = machineCoord;
         this.workCoord = workCoord;
         this.workCoordinateOffset = workCoordinateOffset;
@@ -72,6 +75,10 @@ public class ControllerStatus {
      */
     public String getStateString() {
         return stateString;
+    }
+
+    public ControllerState getState() {
+        return state;
     }
 
     public Position getMachineCoord() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
@@ -70,7 +70,7 @@ public class ControllerStatus {
     /**
      * Returns the controller state as a string.
      *
-     * @deprecated because different controllers have different state strings it's unsafe to build logic using these strings
+     * @deprecated because different controllers have different state strings it's unsafe to build logic using these strings. Use {@link ControllerStatus#getState()} instead.
      * @return the state as a string
      */
     public String getStateString() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
@@ -25,7 +25,7 @@ import com.willwinder.universalgcodesender.model.Position;
  * @author wwinder
  */
 public class ControllerStatus {
-    private final String state;
+    private final String stateString;
     private final Position machineCoord;
     private final Position workCoord;
     private final Position workCoordinateOffset;
@@ -38,22 +38,22 @@ public class ControllerStatus {
     /**
      * Baseline constructor. This data should always be present. Represents the
      * controller status.
-     * @param state controller state, i.e. idle/hold/running
+     * @param stateString controller state, i.e. idle/hold/running
      * @param machineCoord controller machine coordinates
      * @param workCoord controller work coordinates
      */
-    public ControllerStatus(String state, Position machineCoord, Position workCoord) {
-        this(state, machineCoord, workCoord, null, null, null, null, null, null);
+    public ControllerStatus(String stateString, Position machineCoord, Position workCoord) {
+        this(stateString, machineCoord, workCoord, null, null, null, null, null, null);
     }
 
     /**
      * Additional parameters
      */
-    public ControllerStatus(String state, Position machineCoord,
-            Position workCoord, Double feedSpeed, Double spindleSpeed,
-            OverridePercents overrides, Position workCoordinateOffset,
-            EnabledPins pins, AccessoryStates states) {
-        this.state = state;
+    public ControllerStatus(String stateString, Position machineCoord,
+                            Position workCoord, Double feedSpeed, Double spindleSpeed,
+                            OverridePercents overrides, Position workCoordinateOffset,
+                            EnabledPins pins, AccessoryStates states) {
+        this.stateString = stateString;
         this.machineCoord = machineCoord;
         this.workCoord = workCoord;
         this.workCoordinateOffset = workCoordinateOffset;
@@ -64,8 +64,14 @@ public class ControllerStatus {
         this.accessoryStates = states;
     }
 
-    public String getState() {
-        return state;
+    /**
+     * Returns the controller state as a string.
+     *
+     * @deprecated because different controllers have different state strings it's unsafe to build logic using these strings
+     * @return the state as a string
+     */
+    public String getStateString() {
+        return stateString;
     }
 
     public Position getMachineCoord() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -743,7 +743,7 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
 
     @Override
     public void statusStringListener(ControllerStatus status) {
-        this.activeState = status.getState();
+        this.activeState = status.getStateString();
         this.machineCoord = status.getMachineCoord();
         this.workCoord = status.getWorkCoord();
         this.lastResponse = System.currentTimeMillis();

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
@@ -20,6 +20,7 @@ package com.willwinder.universalgcodesender.uielements.panels;
 
 import com.willwinder.universalgcodesender.gcode.GcodeState;
 import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStateListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus.EnabledPins;
@@ -305,13 +306,13 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Cont
 
         if (!backend.isConnected()) {
             // Clear out the status color.
-            this.updateStatePanel("");
+            this.updateStatePanel(ControllerState.UNKNOWN);
             resetStatePinComponents();
         }
     }
 
     private void onControllerStatusReceived(ControllerStatus status) {
-        this.updateStatePanel(status.getStateString());
+        this.updateStatePanel(status.getState());
         resetStatePinComponents();
 
         if (status.getEnabledPins() != null) {
@@ -382,30 +383,30 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Cont
         }
     }
 
-    private void updateStatePanel(String state) {
+    private void updateStatePanel(ControllerState state) {
 
         if (backend.getSettings().isDisplayStateColor()) {
             Color background = ThemeColors.GREY;
-            String text = state;
-            if (state.toLowerCase().startsWith("alarm")) {
+            String text = state.name();
+            if (state == ControllerState.ALARM) {
                 text = Localization.getString("mainWindow.status.alarm");
                 background = ThemeColors.RED;
-            } else if (state.equalsIgnoreCase("Hold")) {
+            } else if (state == ControllerState.HOLD) {
                 text = Localization.getString("mainWindow.status.hold");
                 background = ThemeColors.ORANGE;
-            } else if (state.toLowerCase().startsWith("door")) {
+            } else if (state == ControllerState.DOOR) {
                 text = Localization.getString("mainWindow.status.door");
                 background = ThemeColors.ORANGE;
-            } else if (state.equalsIgnoreCase("Run")) {
+            } else if (state == ControllerState.RUN) {
                 text = Localization.getString("mainWindow.status.run");
                 background = ThemeColors.GREEN;
-            } else if (state.equalsIgnoreCase("Jog")) {
+            } else if (state == ControllerState.JOG) {
                 text = Localization.getString("mainWindow.status.jog");
                 background = ThemeColors.GREEN;
-            } else if (state.equalsIgnoreCase("Check")) {
+            } else if (state == ControllerState.CHECK) {
                 text = Localization.getString("mainWindow.status.check");
                 background = ThemeColors.LIGHT_BLUE;
-            } else if (state.equalsIgnoreCase("Idle")) {
+            } else if (state == ControllerState.IDLE) {
                 text = Localization.getString("mainWindow.status.idle");
                 background = ThemeColors.GREY;
             }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
@@ -311,7 +311,7 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Cont
     }
 
     private void onControllerStatusReceived(ControllerStatus status) {
-        this.updateStatePanel(status.getState());
+        this.updateStatePanel(status.getStateString());
         resetStatePinComponents();
 
         if (status.getEnabledPins() != null) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -433,7 +433,7 @@ public class GrblUtilsTest {
 
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
 
-        assertEquals("Idle", controllerStatus.getState());
+        assertEquals("Idle", controllerStatus.getStateString());
 
         assertEquals(new Position(1.1,2.2,3.3, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
         assertEquals(new Position(4.4,5.5,6.6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());


### PR DESCRIPTION
Added a ControllerState-enum with all states that should be supported by the GUI. These states will live alongside the controller state string until all usages have been replaced which will be done gradually to make sure no serious regressions is introduced. The old state string has been deprecated.

The MachineStatus-panel and isolated parts of GrblController are now using the new enum.
