### PR TITLE
Adjusted the expression handler

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -177,15 +177,17 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
      */
     @Override
     public void resetCoordinatesToZero() throws Exception {
-        throw new Exception(Localization.getString("controller.exception.reset"));
+        setWorkPosition(Axis.X, 0);
+        setWorkPosition(Axis.Y, 0);
+        setWorkPosition(Axis.Z, 0);
     }
     
     /**
      * Reset given machine coordinate to zero at the current location.
      */
     @Override
-    public void resetCoordinateToZero(final Axis coord) throws Exception {
-        throw new Exception(Localization.getString("controller.exception.reset"));
+    public void resetCoordinateToZero(final Axis axis) throws Exception {
+        setWorkPosition(axis, 0);
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -459,9 +459,9 @@ public class GrblController extends AbstractController {
     }
     
     @Override
-    public void resetCoordinateToZero(final Axis coord) throws Exception {
+    public void resetCoordinateToZero(final Axis axis) throws Exception {
         if (this.isCommOpen()) {
-            String gcode = GrblUtils.getResetCoordToZeroCommand(coord, this.grblVersion, this.grblVersionLetter);
+            String gcode = GrblUtils.getResetCoordToZeroCommand(axis, this.grblVersion, this.grblVersionLetter);
             if (!"".equals(gcode)) {
                 GcodeCommand command = createCommand(gcode);
                 this.sendCommandImmediately(command);

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -19,6 +19,7 @@
 
 package com.willwinder.universalgcodesender;
 
+import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus.OverridePercents;
@@ -41,7 +42,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author wwinder
  */
 public class GrblUtils {
-    private static final DecimalFormat decimalFormatter = new DecimalFormat("0.0000");
+    private static final DecimalFormat decimalFormatter = new DecimalFormat("0.0000", Localization.dfs);
 
     // Note: 5 characters of this buffer reserved for real time commands.
     public static final int GRBL_RX_BUFFER_SIZE= 123;

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
@@ -78,12 +78,14 @@ public interface BackendAPI extends BackendAPIReadOnly {
 
     /**
      * Sets the work position for a given axis to a position defined by an mathimatical
-     * expression. If the expression begins with /, *, + or - the current position is
-     * prepended.
+     * expression. The character '#' will be replaced by the current work position. If the
+     * expression starts with '/' or '*' the expression will be prepended with the current
+     * work position.
      *
      * Examples:
      *   20 * 2 + 0.05
-     *   / 2
+     *   # / 2
+     *   * 2
      *
      * @param axis the axis to set
      * @param expression the mathimatical expression to use

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -821,9 +821,10 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     @Override
     public void setWorkPositionUsingExpression(final Axis axis, final String expression) throws Exception {
         String expr = StringUtils.trimToEmpty(expression);
+        expr = expr.replaceAll("#", String.valueOf(getWorkPosition().get(axis)));
 
         // If the expression starts with a mathimatical operation add the original position
-        if (StringUtils.startsWithAny(expr, "/", "*", "-", "+")) {
+        if (StringUtils.startsWithAny(expr, "/", "*")) {
             double value = getWorkPosition().get(axis);
             expr = value + " " + expr;
         }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/WorkCoordinateTextField.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/WorkCoordinateTextField.java
@@ -57,6 +57,13 @@ public class WorkCoordinateTextField extends JTextField implements KeyListener, 
 
         addFocusListener(this);
         addKeyListener(this);
+
+        // TODO add I18N
+        setToolTipText("<html><body>" +
+                "<p><b>Displays and sets the work position<b/></p>" +
+                "<p>Exact positions or simple expressions can be used where<br/>" +
+                "the character <b>'#'</b> will be replaced with the current work position.</p>" +
+                "</body></html>");
     }
 
     @Override

--- a/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
@@ -380,6 +380,8 @@ public class GUIBackendTest {
     public void setWorkPositionWithValueExpressionShouldSetPosition() throws Exception {
         // Given
         instance.connect(FIRMWARE, PORT, BAUD_RATE);
+        ControllerStatus status = new ControllerStatus("idle", ControllerState.IDLE, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(11, 11,11, UnitUtils.Units.MM));
+        instance.statusStringListener(status);
 
         // When
         instance.setWorkPositionUsingExpression(Axis.X, "10.1");
@@ -392,12 +394,28 @@ public class GUIBackendTest {
     public void setWorkPositionWithExpressionShouldSetPosition() throws Exception {
         // Given
         instance.connect(FIRMWARE, PORT, BAUD_RATE);
+        ControllerStatus status = new ControllerStatus("idle", ControllerState.IDLE, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(11, 11,11, UnitUtils.Units.MM));
+        instance.statusStringListener(status);
 
         // When
         instance.setWorkPositionUsingExpression(Axis.Y, "10.1 * 10");
 
         // Then
         verify(controller, times(1)).setWorkPosition(Axis.Y, 101);
+    }
+
+    @Test
+    public void setWorkPositionWithExpressionShouldSetNegativePosition() throws Exception {
+        // Given
+        instance.connect(FIRMWARE, PORT, BAUD_RATE);
+        ControllerStatus status = new ControllerStatus("idle", ControllerState.IDLE, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(11, 11,11, UnitUtils.Units.MM));
+        instance.statusStringListener(status);
+
+        // When
+        instance.setWorkPositionUsingExpression(Axis.Y, "-10.1");
+
+        // Then
+        verify(controller, times(1)).setWorkPosition(Axis.Y, -10.1);
     }
 
     @Test
@@ -408,7 +426,7 @@ public class GUIBackendTest {
         instance.statusStringListener(status);
 
         // When
-        instance.setWorkPositionUsingExpression(Axis.Y, " + 10");
+        instance.setWorkPositionUsingExpression(Axis.Y, "# + 10");
 
         // Then
         verify(controller, times(1)).setWorkPosition(Axis.Y, 21);
@@ -422,12 +440,25 @@ public class GUIBackendTest {
         instance.statusStringListener(status);
 
         // When
-        instance.setWorkPositionUsingExpression(Axis.Z, " * 10");
+        instance.setWorkPositionUsingExpression(Axis.Z, "# * 10");
 
         // Then
         verify(controller, times(1)).setWorkPosition(Axis.Z, 110);
     }
 
+    @Test
+    public void setWorkPositionWithMultiplicationExpressionWithoutValue() throws Exception {
+        // Given
+        instance.connect(FIRMWARE, PORT, BAUD_RATE);
+        ControllerStatus status = new ControllerStatus("idle", ControllerState.IDLE, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(11, 11,11, UnitUtils.Units.MM));
+        instance.statusStringListener(status);
+
+        // When
+        instance.setWorkPositionUsingExpression(Axis.Z, "* 10");
+
+        // Then
+        verify(controller, times(1)).setWorkPosition(Axis.Z, 110);
+    }
 
     @Test
     public void setWorkPositionWithDivisionExpression() throws Exception {
@@ -437,7 +468,21 @@ public class GUIBackendTest {
         instance.statusStringListener(status);
 
         // When
-        instance.setWorkPositionUsingExpression(Axis.Z, " / 10");
+        instance.setWorkPositionUsingExpression(Axis.Z, "# / 10");
+
+        // Then
+        verify(controller, times(1)).setWorkPosition(Axis.Z, 1.1);
+    }
+
+    @Test
+    public void setWorkPositionWithDivisionExpressionWithoutValue() throws Exception {
+        // Given
+        instance.connect(FIRMWARE, PORT, BAUD_RATE);
+        ControllerStatus status = new ControllerStatus("idle", ControllerState.IDLE, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(11, 11,11, UnitUtils.Units.MM));
+        instance.statusStringListener(status);
+
+        // When
+        instance.setWorkPositionUsingExpression(Axis.Z, "/ 10");
 
         // Then
         verify(controller, times(1)).setWorkPosition(Axis.Z, 1.1);
@@ -451,7 +496,7 @@ public class GUIBackendTest {
         instance.statusStringListener(status);
 
         // When
-        instance.setWorkPositionUsingExpression(Axis.X, " - 10");
+        instance.setWorkPositionUsingExpression(Axis.X, "# - 10");
 
         // Then
         verify(controller, times(1)).setWorkPosition(Axis.X, 1);


### PR DESCRIPTION
 It does not prepend the current work position when expression starts with + or -. The operations for * and / doesn't collide with anything so they are still usable. Added the '#' that will be replaced with the current work position.

Examples:
 * `# + 10` (adds ten to the current work position
 * `* 10` (multiplies the current work position by ten)
 * `-10`(sets the current work position to negative ten)

Addresses the issue where negative values can't be set #1004 
Original feature request #977 

![set_work_coords mov](https://user-images.githubusercontent.com/8962024/38600339-1fb04d8e-3d64-11e8-9c05-768fca6c1070.gif)