### PR TITLE
Jog commands acts as lines in visualizer

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractCommunicator.java
@@ -41,7 +41,6 @@ public abstract class AbstractCommunicator {
     private static final Logger logger = Logger.getLogger(AbstractCommunicator.class.getName());
 
     protected Connection conn;
-    private int commandCounter = 0;
 
     // Allow events to be sent from same thread for unit tests.
     private boolean launchEventsInDispatchThread = true;
@@ -146,10 +145,6 @@ public abstract class AbstractCommunicator {
         conn.closePort();
     }
 
-    protected int getNextCommandId() {
-        return this.commandCounter++;
-    }
-    
     /** Getters & Setters. */
     abstract public String getLineTerminator();
     

--- a/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
@@ -178,7 +178,6 @@ public abstract class BufferedCommunicator extends AbstractCommunicator {
         }
 
         if (nextCommand != null) {
-            nextCommand.setCommandNumber(getNextCommandId());
             if (nextCommand.getCommandString().endsWith("\n")) {
                 nextCommand.setCommand(nextCommand.getCommandString().trim());
             }


### PR DESCRIPTION
This fixes the issue #411. 

Don't keep track of the number of commands sent in the `AbstractController` and don't overwrite the command number in `BufferedCommunicator`. The command numbering are handled by the `GcodeStreamReader`.

All commands handled outside a command stream and queued with  `BufferedCommunicator.queueStringForComm` will get command number -1 which would indicate that it isn't apart of a file stream.