### PR TITLE
Bugfix/command line

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -649,7 +649,7 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     
     @Override
     public boolean canPause() {
-        return this.controller != null && !isIdle() && !isPaused();
+        return this.controller != null && isConnected() && !isIdle() && !isPaused();
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/CommandTextArea.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/CommandTextArea.java
@@ -26,8 +26,6 @@ import static com.willwinder.universalgcodesender.utils.GUIHelpers.displayErrorD
 import java.awt.KeyEventDispatcher;
 import java.awt.KeyboardFocusManager;
 import java.awt.event.ActionEvent;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/CommandPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/CommandPanel.java
@@ -1,5 +1,5 @@
 /*
-    Copywrite 2016-2017 Will Winder
+    Copyright 2016-2018 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -36,7 +36,7 @@ import javax.swing.*;
 import javax.swing.text.DefaultCaret;
 
 public class CommandPanel extends JPanel implements UGSEventListener, ControllerListener {
-    private final int consoleSize = 1024 * 1024;
+    private static final int CONSOLE_SIZE = 1024 * 1024;
 
     private final BackendAPI backend;
 
@@ -76,11 +76,12 @@ public class CommandPanel extends JPanel implements UGSEventListener, Controller
     private void initComponents() {
         consoleTextArea.setEditable(false);
         consoleTextArea.setColumns(20);
-        consoleTextArea.setDocument(new LengthLimitedDocument(consoleSize));
+        consoleTextArea.setDocument(new LengthLimitedDocument(CONSOLE_SIZE));
         consoleTextArea.setRows(5);
         consoleTextArea.setMaximumSize(new java.awt.Dimension(32767, 32767));
         consoleTextArea.setMinimumSize(new java.awt.Dimension(0, 0));
         scrollPane.setViewportView(consoleTextArea);
+        commandLabel.setEnabled(backend.isIdle());
 
         scrollWindowMenuItem.addActionListener(e -> checkScrollWindow());
 
@@ -98,6 +99,10 @@ public class CommandPanel extends JPanel implements UGSEventListener, Controller
     public void UGSEvent(UGSEvent evt) {
         if (evt.isSettingChangeEvent()) {
             loadSettings();
+        }
+
+        if (evt.isStateChangeEvent()) {
+            commandLabel.setEnabled(backend.isIdle());
         }
     }
 


### PR DESCRIPTION
Fixes the problem with issue #1019.

It will now save the focus state of the command text field an refocus once it's enabled again.
Also fixed a small issue where the left and right arrow keys weren't usable.