### PR TITLE
Feature/import export settings

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/FirmwareSettingUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/FirmwareSettingUtils.java
@@ -27,15 +27,12 @@ public class FirmwareSettingUtils {
     /**
      * Imports firmware settings from a settings file. Displays a popup with a question if the file should be imported.
      *
-     * @param settingsFile the file containing a JSON with {@link FirmwareSettingsFile}
+     * @param settingsFile     the file containing a JSON with {@link FirmwareSettingsFile}
      * @param firmwareSettings the firmware settings to update
      */
     public static void importSettings(File settingsFile, IFirmwareSettings firmwareSettings) {
         try {
-            String json = FileUtils.readFileToString(settingsFile);
-            Gson gson = new Gson();
-            FirmwareSettingsFile firmwareSettingsFile = gson.fromJson(json, FirmwareSettingsFile.class);
-
+            FirmwareSettingsFile firmwareSettingsFile = readSettings(settingsFile);
             String message = Localization.getString("firmware.settings.importSettings") + "\n\n  " +
                     Localization.getString("firmware.settings.importSettingsName") + ": " + firmwareSettingsFile.getName() + "\n  " +
                     Localization.getString("firmware.settings.importSettingsDate") + ": " + firmwareSettingsFile.getDate() + "\n  " +
@@ -58,7 +55,7 @@ public class FirmwareSettingUtils {
      * {@link FirmwareSettingsFile}
      *
      * @param settingsFile the file to write the settings to.
-     * @param controller the controller to get the firmware settings from
+     * @param controller   the controller to get the firmware settings from
      */
     public static void exportSettings(final File settingsFile, IController controller) {
         File file = settingsFile;
@@ -84,5 +81,18 @@ public class FirmwareSettingUtils {
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Couldn't write the settings file " + settingsFile.getAbsolutePath(), e);
         }
+    }
+
+    /**
+     * Reads a file and parses it to a firmware settings file
+     *
+     * @param settingsFile the file containing a JSON with {@link FirmwareSettingsFile}
+     * @return the firmware settings together with its meta data
+     * @throws IOException if the settings file couldn't be read or parsed
+     */
+    public static FirmwareSettingsFile readSettings(File settingsFile) throws IOException {
+        String json = FileUtils.readFileToString(settingsFile);
+        Gson gson = new Gson();
+        return gson.fromJson(json, FirmwareSettingsFile.class);
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/helpers/ThemeColors.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/helpers/ThemeColors.java
@@ -25,10 +25,13 @@ public class ThemeColors {
     // Daryl's UI color scheme, compatible with Darcula and most light grey-ish LAF's
     public static final Color VERY_DARK_GREY = new Color(42, 44, 45);
     public static final Color GREY = new Color(128, 128, 128);
+    public static final Color LIGHT_GREY = new Color(201, 201, 201);;
     public static final Color ORANGE = new Color(255, 151, 11);
     public static final Color GREEN = new Color(0, 201, 0);
     public static final Color LIGHT_GREEN = new Color(106, 194, 89);
     public static final Color LIGHT_BLUE = new Color(5, 212, 255);
+    public static final Color VERY_LIGHT_BLUE_GREY = new Color(236, 252, 255);
+
     public static final Color DARK_BLUE_GREY = new Color(44, 65, 70);
     public static final Color MED_BLUE_GREY = new Color(47, 93, 103);
     public static final Color LIGHT_BLUE_GREY = new Color(65, 129, 143);

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/AbstractWizardPanel.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/AbstractWizardPanel.java
@@ -24,9 +24,11 @@ import org.openide.WizardDescriptor;
 import org.openide.util.HelpCtx;
 
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -48,6 +50,11 @@ public abstract class AbstractWizardPanel implements WizardDescriptor.Finishable
      * The panel to display
      */
     private final JPanel panel;
+
+    /**
+     * The panel to display
+     */
+    private final Component rootComponent;
 
     /**
      * A set of listeners
@@ -76,9 +83,12 @@ public abstract class AbstractWizardPanel implements WizardDescriptor.Finishable
 
         this.backend = backend;
         this.name = name;
-
         this.panel = new JPanel(new MigLayout(layoutConstraints));
-        this.panel.setName(name);
+
+        JScrollPane scrollPane = new JScrollPane(this.panel);
+        scrollPane.setBorder(null);
+        scrollPane.setName(name);
+        this.rootComponent = scrollPane;
     }
 
     public JPanel getPanel() {
@@ -87,7 +97,7 @@ public abstract class AbstractWizardPanel implements WizardDescriptor.Finishable
 
     @Override
     public Component getComponent() {
-        return panel;
+        return rootComponent;
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/AbstractWizardPanel.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/AbstractWizardPanel.java
@@ -28,7 +28,6 @@ import javax.swing.JScrollPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/WizardStarter.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/WizardStarter.java
@@ -19,6 +19,7 @@
 package com.willwinder.ugs.nbp.setupwizard;
 
 import com.willwinder.ugs.nbp.setupwizard.panels.WizardPanelConnection;
+import com.willwinder.ugs.nbp.setupwizard.panels.WizardPanelImportSettings;
 import com.willwinder.ugs.nbp.setupwizard.panels.WizardPanelHardLimits;
 import com.willwinder.ugs.nbp.setupwizard.panels.WizardPanelHoming;
 import com.willwinder.ugs.nbp.setupwizard.panels.WizardPanelMotorWiring;
@@ -75,6 +76,7 @@ public class WizardStarter {
     private static List<AbstractWizardPanel> createWizardStepPanels(BackendAPI backend) {
         List<AbstractWizardPanel> panels = new ArrayList<>();
         panels.add(new WizardPanelConnection(backend));
+        panels.add(new WizardPanelImportSettings(backend));
         panels.add(new WizardPanelMotorWiring(backend));
         panels.add(new WizardPanelStepCalibration(backend));
         panels.add(new WizardPanelHardLimits(backend));

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelConnection.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelConnection.java
@@ -199,14 +199,21 @@ public class WizardPanelConnection extends AbstractWizardPanel implements UGSEve
     }
 
     private void refreshComponents() {
+        String selectedFirmware = getBackend().getSettings().getFirmwareVersion();
         firmwareCombo.removeAllItems();
         FirmwareUtils.getFirmwareList().forEach(firmwareCombo::addItem);
+        firmwareCombo.setSelectedItem(selectedFirmware);
 
         setValid(getBackend().isConnected() && getBackend().getController().getCapabilities().hasSetupWizardSupport());
         labelPort.setVisible(!getBackend().isConnected());
+
         portCombo.setVisible(!getBackend().isConnected());
+        portCombo.setSelectedItem(getBackend().getSettings().getPort());
+
         labelBaud.setVisible(!getBackend().isConnected());
         baudCombo.setVisible(!getBackend().isConnected());
+        baudCombo.setSelectedItem(getBackend().getSettings().getPortRate());
+
         labelFirmware.setVisible(!getBackend().isConnected());
         firmwareCombo.setVisible(!getBackend().isConnected());
         connectButton.setVisible(!getBackend().isConnected());

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelImportSettings.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelImportSettings.java
@@ -1,0 +1,184 @@
+package com.willwinder.ugs.nbp.setupwizard.panels;
+
+import com.willwinder.ugs.nbp.setupwizard.AbstractWizardPanel;
+import com.willwinder.universalgcodesender.firmware.FirmwareSettingUtils;
+import com.willwinder.universalgcodesender.firmware.FirmwareSettingsException;
+import com.willwinder.universalgcodesender.firmware.FirmwareSettingsFile;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import com.willwinder.universalgcodesender.uielements.components.FirmwareSettingsFileTypeFilter;
+import com.willwinder.universalgcodesender.uielements.components.RoundedPanel;
+import com.willwinder.universalgcodesender.uielements.helpers.ThemeColors;
+import com.willwinder.universalgcodesender.utils.ThreadHelper;
+import net.miginfocom.swing.MigLayout;
+import org.openide.util.ImageUtilities;
+
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import java.awt.Font;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A settings step for importing settings
+ *
+ * @author Joacim Breiler
+ */
+public class WizardPanelImportSettings extends AbstractWizardPanel {
+
+    private static final Logger LOGGER = Logger.getLogger(WizardPanelImportSettings.class.getSimpleName());
+    private JLabel labelDescription;
+    private JLabel labelNameValue;
+    private JLabel labelCreatedBy;
+    private JLabel labelCreatedByValue;
+    private JLabel labelDate;
+    private JLabel labelDateValue;
+    private JLabel labelFirmware;
+    private JLabel labelFirmwareValue;
+    private JLabel labelSettingsImported;
+    private JButton buttonOpen;
+    private JButton buttonImport;
+    private FirmwareSettingsFile firmwareSettingsFile;
+    private RoundedPanel fileInfoPanel;
+
+    public WizardPanelImportSettings(BackendAPI backend) {
+        super(backend, "Import settings", false);
+
+        initComponents();
+        initLayout();
+        loadSettingsFile(null);
+    }
+
+    private void initLayout() {
+        JPanel panel = new JPanel(new MigLayout("wrap 1, fillx, inset 0, gap 5, hidemode 3"));
+        panel.add(labelDescription, "gapbottom 5, spanx");
+        panel.add(buttonOpen, "gaptop 5, gapbottom 10, wmin 200, hmin 36, spanx");
+
+        fileInfoPanel.setLayout(new MigLayout("wrap 2, fillx, inset 20, gap 5, hidemode 3", "[20%][80%]"));
+        fileInfoPanel.add(labelNameValue, "gapleft 10, gapbottom 10, spanx");
+        fileInfoPanel.add(labelFirmware, "gapleft 10, grow");
+        fileInfoPanel.add(labelFirmwareValue);
+        fileInfoPanel.add(labelCreatedBy, "gapleft 10, grow");
+        fileInfoPanel.add(labelCreatedByValue);
+        fileInfoPanel.add(labelDate, "gapleft 10, grow");
+        fileInfoPanel.add(labelDateValue);
+        fileInfoPanel.add(buttonImport, "gaptop 10, growx, spanx, hmin 36");
+        panel.add(fileInfoPanel, "wmin 400, gapleft 2, spanx");
+        panel.add(labelSettingsImported, "gaptop 20, grow");
+
+        getPanel().add(panel, "grow");
+        setValid(true);
+    }
+
+    private void initComponents() {
+        labelDescription = new JLabel("<html><body>" +
+                "<p>If your machine came with a configuration file or if you previously made a backup of your settings you can load them here. Otherwise click next to continue.</p>" +
+                "</body></html>");
+
+        fileInfoPanel = new RoundedPanel(8);
+        fileInfoPanel.setBackground(ThemeColors.VERY_LIGHT_BLUE_GREY);
+        fileInfoPanel.setForeground(ThemeColors.LIGHT_GREY);
+
+        labelNameValue = new JLabel("");
+        labelNameValue.setFont(labelNameValue.getFont().deriveFont(Font.BOLD, 16));
+
+        labelFirmware = new JLabel("Firmware:", JLabel.RIGHT);
+        labelFirmware.setFont(labelFirmware.getFont().deriveFont(Font.BOLD));
+        labelFirmwareValue = new JLabel("");
+
+        labelCreatedBy = new JLabel("Created by:", JLabel.RIGHT);
+        labelCreatedBy.setFont(labelCreatedBy.getFont().deriveFont(Font.BOLD));
+        labelCreatedByValue = new JLabel("");
+
+        labelDate = new JLabel("Date:", JLabel.RIGHT);
+        labelDate.setFont(labelDate.getFont().deriveFont(Font.BOLD));
+        labelDateValue = new JLabel("");
+
+        labelSettingsImported = new JLabel("<html><body>" +
+                "<h3>Finished imported settings</h3>" +
+                "<p>Please continue to verify your configuration using the following steps.</p>" +
+                "</body></html>");
+        labelSettingsImported.setVerticalAlignment(SwingConstants.CENTER);
+        labelSettingsImported.setIcon(ImageUtilities.loadImageIcon("icons/checked32.png", false));
+
+        buttonOpen = new JButton("Open settings file...");
+        buttonOpen.addActionListener(event -> {
+            JFileChooser fileChooser = FirmwareSettingsFileTypeFilter.getSettingsFileChooser();
+            int returnVal = fileChooser.showOpenDialog(new JFrame());
+            if (returnVal == JFileChooser.APPROVE_OPTION) {
+                loadSettingsFile(fileChooser.getSelectedFile());
+            }
+        });
+
+        buttonImport = new JButton("Import settings");
+        buttonImport.addActionListener(event -> importSettings());
+    }
+
+    private void importSettings() {
+        String message = "Are you sure you want to overwrite the current firmware settings?";
+        int result = JOptionPane.showConfirmDialog(this.getComponent(), message,
+                "Overwrite firmware settings?", JOptionPane.YES_NO_OPTION);
+        if (result == JOptionPane.OK_OPTION) {
+            try {
+                getBackend().getController().getFirmwareSettings().setSettings(firmwareSettingsFile.getSettings());
+            } catch (FirmwareSettingsException e) {
+                LOGGER.log(Level.SEVERE, "Couldn't set firmware settings", e);
+            }
+            labelSettingsImported.setVisible(true);
+        }
+
+        loadSettingsFile(null);
+    }
+
+    private void loadSettingsFile(File file) {
+        if (file == null) {
+            firmwareSettingsFile = null;
+        } else {
+            try {
+                firmwareSettingsFile = FirmwareSettingUtils.readSettings(file);
+            } catch (IOException e) {
+                JOptionPane.showMessageDialog(this.getComponent(), "Couldn't read settings file: " + e.getMessage(), "Error while reading settings file", JOptionPane.ERROR_MESSAGE);
+                firmwareSettingsFile = null;
+            }
+        }
+        showSettingsInformation();
+    }
+
+    private void showSettingsInformation() {
+        // Wait until we show the information so that the user notices that something happened
+        ThreadHelper.invokeLater(() -> {
+            boolean showSettingsInformation = false;
+            if (firmwareSettingsFile != null) {
+                showSettingsInformation = true;
+                labelNameValue.setText(firmwareSettingsFile.getName());
+                labelFirmwareValue.setText(firmwareSettingsFile.getFirmwareName());
+                labelCreatedByValue.setText(firmwareSettingsFile.getCreatedBy());
+                labelDateValue.setText(firmwareSettingsFile.getDate());
+            }
+
+            fileInfoPanel.setVisible(showSettingsInformation);
+        }, 500);
+    }
+
+    @Override
+    public void initialize() {
+        loadSettingsFile(null);
+        labelSettingsImported.setVisible(false);
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return getBackend().isConnected() &&
+                getBackend().getController().getCapabilities().hasSetupWizardSupport();
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelImportSettings.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelImportSettings.java
@@ -8,6 +8,7 @@ import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.uielements.components.FirmwareSettingsFileTypeFilter;
 import com.willwinder.universalgcodesender.uielements.components.RoundedPanel;
 import com.willwinder.universalgcodesender.uielements.helpers.ThemeColors;
+import com.willwinder.universalgcodesender.utils.GUIHelpers;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import net.miginfocom.swing.MigLayout;
 import org.openide.util.ImageUtilities;
@@ -143,7 +144,7 @@ public class WizardPanelImportSettings extends AbstractWizardPanel {
             try {
                 firmwareSettingsFile = FirmwareSettingUtils.readSettings(file);
             } catch (IOException e) {
-                JOptionPane.showMessageDialog(this.getComponent(), "Couldn't read settings file: " + e.getMessage(), "Error while reading settings file", JOptionPane.ERROR_MESSAGE);
+                GUIHelpers.displayErrorDialog("Couldn't read settings file: " + e.getMessage(), true);
                 firmwareSettingsFile = null;
             }
         }


### PR DESCRIPTION
Added a step in the setup wizard for importing settings. This to make it easier for CNC manufacturers to have their customers setup their machines.

Select a settings file:
![screen shot 2018-06-12 at 10 45 40](https://user-images.githubusercontent.com/8962024/41279862-ddc6b106-6e2d-11e8-9c16-c4b9355eb4da.png)

Display the meta data. The title "Exported settings" comes from the file and could instead be the name for the CNC machine.
![screen shot 2018-06-12 at 10 45 53](https://user-images.githubusercontent.com/8962024/41279872-e1ddb6cc-6e2d-11e8-85f4-988025d52388.png)

Verify to overwrite the settings
![screen shot 2018-06-12 at 10 46 05](https://user-images.githubusercontent.com/8962024/41279880-e5e48ce6-6e2d-11e8-8203-25a5c051ae9f.png)

A confirmation that the settings has been imported
![screen shot 2018-06-12 at 10 46 14](https://user-images.githubusercontent.com/8962024/41279886-eb070974-6e2d-11e8-9763-a0d802379b43.png)
