### PR TITLE
Feature/tinyg

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractCommunicator.java
@@ -51,29 +51,21 @@ public abstract class AbstractCommunicator {
         COMMAND_SENT,
         COMMAND_SKIPPED,
         RAW_RESPONSE,
-        CONSOLE_MESSAGE,
-        PAUSED,
-        VERBOSE_CONSOLE_MESSAGE
+        PAUSED
     }
     // Callback interfaces
     private ArrayList<SerialCommunicatorListener> commandEventListeners;
-    private ArrayList<SerialCommunicatorListener> commConsoleListeners;
-    private ArrayList<SerialCommunicatorListener> commVerboseConsoleListeners;
     private ArrayList<SerialCommunicatorListener> commRawResponseListener;
     private HashMap<SerialCommunicatorEvent, ArrayList<SerialCommunicatorListener>> eventMap;
 
     public AbstractCommunicator() {
         this.commandEventListeners       = new ArrayList<>();
-        this.commConsoleListeners        = new ArrayList<>();
-        this.commVerboseConsoleListeners = new ArrayList<>();
         this.commRawResponseListener     = new ArrayList<>();
 
         this.eventMap = new HashMap<>();
         eventMap.put(COMMAND_SENT,            commandEventListeners);
         eventMap.put(COMMAND_SKIPPED,         commandEventListeners);
         eventMap.put(PAUSED,                  commandEventListeners);
-        eventMap.put(CONSOLE_MESSAGE,         commConsoleListeners);
-        eventMap.put(VERBOSE_CONSOLE_MESSAGE, commVerboseConsoleListeners);
         eventMap.put(RAW_RESPONSE,            commRawResponseListener);
     }
     
@@ -155,15 +147,11 @@ public abstract class AbstractCommunicator {
     /* ****************** */
     void setListenAll(SerialCommunicatorListener scl) {
         this.addCommandEventListener(scl);
-        this.addCommConsoleListener(scl);
-        this.addCommVerboseConsoleListener(scl);
         this.addCommRawResponseListener(scl);
     }
 
     public void removeListenAll(SerialCommunicatorListener scl) {
         this.removeCommandEventListener(scl);
-        this.removeCommConsoleListener(scl);
-        this.removeCommVerboseConsoleListener(scl);
         this.removeCommRawResponseListener(scl);
     }
 
@@ -177,26 +165,6 @@ public abstract class AbstractCommunicator {
         this.commandEventListeners.remove(scl);
     }
 
-    private void addCommConsoleListener(SerialCommunicatorListener scl) {
-        if (!this.commConsoleListeners.contains(scl)) {
-            this.commConsoleListeners.add(scl);
-        }
-    }
-
-    private void removeCommConsoleListener(SerialCommunicatorListener scl) {
-        this.commConsoleListeners.remove(scl);
-    }
-
-    private void addCommVerboseConsoleListener(SerialCommunicatorListener scl) {
-        if (!this.commVerboseConsoleListeners.contains(scl)) {
-            this.commVerboseConsoleListeners.add(scl);
-        }
-    }
-
-    private void removeCommVerboseConsoleListener(SerialCommunicatorListener scl) {
-        this.commVerboseConsoleListeners.remove(scl);
-    }
-
     private void addCommRawResponseListener(SerialCommunicatorListener scl) {
         if (!this.commRawResponseListener.contains(scl)) {
             this.commRawResponseListener.add(scl);
@@ -205,28 +173,6 @@ public abstract class AbstractCommunicator {
 
     private void removeCommRawResponseListener(SerialCommunicatorListener scl) {
         this.commRawResponseListener.remove(scl);
-    }
-
-    // Helper for the console listener.              
-    protected void sendMessageToConsoleListener(String msg) {
-        this.sendMessageToConsoleListener(msg, false);
-    }
-    
-    protected void sendMessageToConsoleListener(String msg, boolean verbose) {
-        // Exit early if there are no listeners.
-        if (this.commConsoleListeners == null) {
-            return;
-        }
-        
-        SerialCommunicatorEvent verbosity;
-        if (!verbose) {
-            verbosity = SerialCommunicatorEvent.CONSOLE_MESSAGE;
-        }
-        else {
-            verbosity = SerialCommunicatorEvent.VERBOSE_CONSOLE_MESSAGE;
-        }
-        
-        dispatchListenerEvents(verbosity, msg);
     }
     
     /**
@@ -270,14 +216,6 @@ public abstract class AbstractCommunicator {
             case COMMAND_SKIPPED:
                 for (SerialCommunicatorListener scl : sclList)
                     scl.commandSkipped(command);
-                break;
-            case CONSOLE_MESSAGE:
-                for (SerialCommunicatorListener scl : sclList)
-                    scl.messageForConsole(string);
-                break;
-            case VERBOSE_CONSOLE_MESSAGE:
-                for (SerialCommunicatorListener scl : sclList)
-                    scl.verboseMessageForConsole(string);
                 break;
             case RAW_RESPONSE:
                 for (SerialCommunicatorListener scl : sclList)

--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -25,13 +25,14 @@ import com.willwinder.universalgcodesender.gcode.GcodeState;
 import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
-import com.willwinder.universalgcodesender.listeners.ControllerListener.MessageType;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.SerialCommunicatorListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent.ControlState;
 import com.willwinder.universalgcodesender.model.UnitUtils;
+import com.willwinder.universalgcodesender.services.MessageService;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.GcodeStreamReader;
 import org.apache.commons.lang3.StringUtils;
@@ -64,6 +65,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
 
     // These abstract objects are initialized in concrete class.
     protected final AbstractCommunicator comm;
+    protected MessageService messageService;
     protected GcodeCommandCreator commandCreator;
 
     // Outside influence
@@ -380,8 +382,8 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
         if (isCommOpen()) {
             this.openCommAfterEvent();
 
-            this.messageForConsole(
-                   "**** Connected to " + port + " @ " + portRate + " baud ****\n");
+            this.dispatchConsoleMessage(MessageType.INFO,
+                    "**** Connected to " + port + " @ " + portRate + " baud ****\n");
         }
                 
         return isCommOpen();
@@ -396,7 +398,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
         
         this.closeCommBeforeEvent();
         
-        this.messageForConsole("**** Connection closed ****\n");
+        this.dispatchConsoleMessage(MessageType.INFO,"**** Connection closed ****\n");
         
         // I was noticing odd behavior, such as continuing to send 'ok's after
         // closing and reopening the comm port.
@@ -615,7 +617,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
     
     @Override
     public void pauseStreaming() throws Exception {
-        this.messageForConsole("\n**** Pausing file transfer. ****\n\n");
+        this.dispatchConsoleMessage(MessageType.INFO,"\n**** Pausing file transfer. ****\n\n");
         pauseStreamingEvent();
         this.comm.pauseSend();
         this.setCurrentState(COMM_SENDING_PAUSED);
@@ -627,7 +629,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
     
     @Override
     public void resumeStreaming() throws Exception {
-        this.messageForConsole("\n**** Resuming file transfer. ****\n\n");
+        this.dispatchConsoleMessage(MessageType.INFO, "\n**** Resuming file transfer. ****\n\n");
         resumeStreamingEvent();
         this.comm.resumeSend();
         this.setCurrentState(COMM_SENDING);
@@ -658,7 +660,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
 
     @Override
     public void cancelSend() throws Exception {
-        this.messageForConsole("\n**** Canceling file transfer. ****\n\n");
+        this.dispatchConsoleMessage(MessageType.INFO, "\n**** Canceling file transfer. ****\n\n");
 
         cancelSendBeforeEvent();
         
@@ -720,7 +722,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
                 com.willwinder.universalgcodesender.Utils.
                         formattedMillis(this.getSendDuration());
 
-        this.messageForConsole("\n**** Finished sending file in "+duration+" ****\n\n");
+        this.dispatchConsoleMessage(MessageType.INFO,"\n**** Finished sending file in "+duration+" ****\n\n");
         this.streamStopWatch.stop();
         this.isStreaming = false;
         dispatchStreamComplete(filename, success);        
@@ -739,6 +741,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
             dispatchCommandCommment(command.getComment());
         }
         dispatchCommandSent(command);
+        dispatchConsoleMessage(MessageType.INFO, ">>> " + StringUtils.trimToEmpty(command.getCommandString()) + "\n");
     }
 
     @Override
@@ -810,7 +813,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
             }
         }
         message.append("\n");
-        this.messageForConsole(message.toString());
+        this.dispatchConsoleMessage(MessageType.INFO, message.toString());
         command.setResponse("<skipped by application>");
         command.setSkipped(true);
         dispatchCommandSkipped(command);
@@ -845,21 +848,6 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
 
         dispatchCommandComplete(command);
         checkStreamFinished();
-    }
-    
-    @Override
-    public void messageForConsole(String msg) {
-        dispatchConsoleMessage(MessageType.INFO, msg);
-    }
-    
-    @Override
-    public void verboseMessageForConsole(String msg) {
-        dispatchConsoleMessage(MessageType.VERBOSE, msg);
-    }
-    
-    @Override
-    public void errorMessageForConsole(String msg) {
-        dispatchConsoleMessage(MessageType.ERROR, msg);
     }
 
     @Override
@@ -897,10 +885,10 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
     }
     
     protected void dispatchConsoleMessage(MessageType type, String message) {
-        if (listeners != null) {
-            for (ControllerListener c : listeners) {
-                c.messageForConsole(type, message);
-            }
+        if (messageService != null) {
+            messageService.dispatchMessage(type, message);
+        } else {
+            logger.warning("No message service is assigned, so the message could not be delivered: " + type + ": " + message);
         }
     }
     
@@ -1044,6 +1032,11 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void setMessageService(MessageService messageService) {
+        this.messageService = messageService;
     }
 
     public class UnexpectedCommand extends Exception {

--- a/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
@@ -225,10 +225,7 @@ public abstract class BufferedCommunicator extends AbstractCommunicator {
             
             this.activeCommandList.add(command);
             this.sentBufferSize += (commandString.length() + 1);
-        
-            // Command already has a newline attached.
-            this.sendMessageToConsoleListener(">>> " + commandString + "\n");
-            
+
             try {
                 this.sendingCommand(commandString);
                 conn.sendStringToComm(commandString + "\n");

--- a/ugs-core/src/com/willwinder/universalgcodesender/ExperimentalWindow.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/ExperimentalWindow.java
@@ -16,12 +16,12 @@
     You should have received a copy of the GNU General Public License
     along with UGS.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -263,6 +263,9 @@ public class ExperimentalWindow extends JFrame implements ControllerListener, UG
         visualizerPanel = new VisualizerPanel(backend);
         connectionPanel = new ConnectionPanelGroup(backend, jogService);
         commandPanel = new CommandPanel(backend);
+        backend.addUGSEventListener(commandPanel);
+        backend.addMessageListener(commandPanel);
+
         mainMenuBar = new JMenuBar();
         settingsMenu = new JMenu();
         grblConnectionSettingsMenuItem = new javax.swing.JMenuItem();
@@ -502,11 +505,6 @@ public class ExperimentalWindow extends JFrame implements ControllerListener, UG
 
     @Override
     public void probeCoordinates(Position p) {
-
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
 
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/IController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/IController.java
@@ -19,7 +19,6 @@
 package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.connection.ConnectionDriver;
-import com.willwinder.universalgcodesender.gcode.GcodeCommandCreator;
 import com.willwinder.universalgcodesender.gcode.GcodeState;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
@@ -29,6 +28,7 @@ import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.firmware.IFirmwareSettings;
 import com.willwinder.universalgcodesender.model.Axis;
+import com.willwinder.universalgcodesender.services.MessageService;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.GcodeStreamReader;
 
@@ -55,6 +55,13 @@ public interface IController {
      * @param listener to be removed
      */
     void removeListener(ControllerListener listener);
+
+    /**
+     * Assigns a message service to be used for writing messages to the console
+     *
+     * @param messageService the central message service
+     */
+    void setMessageService(MessageService messageService);
 
     /*
     Actions
@@ -116,7 +123,6 @@ public interface IController {
     void setStatusUpdateRate(int rate);
     int getStatusUpdateRate();
     
-    GcodeCommandCreator getCommandCreator();
     long getJobLengthEstimate(File gcodeFile);
     
     /*

--- a/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -26,6 +26,8 @@
 package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.connection.ConnectionFactory;
+import com.willwinder.universalgcodesender.listeners.MessageListener;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.uielements.components.GcodeFileTypeFilter;
 import com.willwinder.universalgcodesender.uielements.panels.ConnectionSettingsPanel;

--- a/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -1,11 +1,5 @@
 /*
- * MainWindow.java
- *
- * Created on Jun 26, 2012, 3:04:38 PM
- */
-
-/*
-    Copywrite 2012-2018 Will Winder
+    Copyright 2012-2018 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -82,6 +76,7 @@ import javax.swing.text.DefaultEditorKit;
 import org.apache.commons.lang3.SystemUtils;
 
 /**
+ * Main window for Universal Gcode Sender Classic
  *
  * @author wwinder
  */
@@ -89,9 +84,9 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
     private static final Logger logger = Logger.getLogger(MainWindow.class.getName());
 
     private PendantUI pendantUI;
-    public Settings settings;
+    private Settings settings;
     
-    BackendAPI backend;
+    private BackendAPI backend;
     
     // My Variables
     private javax.swing.JFileChooser fileChooser;
@@ -102,9 +97,9 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
     private List<String> manualCommandHistory;
 
     // Other windows
-    VisualizerWindow vw = null;
-    String gcodeFile = null;
-    String processedGcodeFile = null;
+    private VisualizerWindow vw = null;
+    private String gcodeFile = null;
+    private String processedGcodeFile = null;
     
     // Duration timer
     private Timer timer;

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -24,6 +24,7 @@ import com.willwinder.universalgcodesender.gcode.TinyGGcodeCommandCreator;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.Overrides;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.firmware.DefaultFirmwareSettings;
@@ -135,11 +136,11 @@ public class TinyGController extends AbstractController {
         }
         
         if (TinyGUtils.isRestartingResponse(jo)) {
-            this.messageForConsole("[restarting] " + response + "\n");
+            this.dispatchConsoleMessage(MessageType.INFO,"[restarting] " + response + "\n");
         }
         else if (TinyGUtils.isReadyResponse(jo)) {  
             //this.messageForConsole("Got version: " + TinyGUtils.getVersion(jo) + "\n");
-            this.messageForConsole("[ready] " + response + "\n");
+            this.dispatchConsoleMessage(MessageType.INFO,"[ready] " + response + "\n");
         }
         else if (TinyGUtils.isStatusResponse(jo)) {
             TinyGUtils.StatusResult result = TinyGUtils.updateStatus(jo);
@@ -153,15 +154,15 @@ public class TinyGController extends AbstractController {
             try {
                 this.commandComplete(response);
             } catch (Exception e) {
-                this.errorMessageForConsole(Localization.getString("controller.error.response")
+                this.dispatchConsoleMessage(MessageType.ERROR,Localization.getString("controller.error.response")
                         + " <" + response + ">: " + e.getMessage());
             }
 
-            this.messageForConsole(response + "\n");
+            this.dispatchConsoleMessage(MessageType.INFO,response + "\n");
         }
         else {
             // Display any unhandled messages
-            this.messageForConsole("[unhandled message] " + response + "\n");
+            this.dispatchConsoleMessage(MessageType.INFO,"[unhandled message] " + response + "\n");
         }
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/GrblFirmwareSettings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/GrblFirmwareSettings.java
@@ -418,21 +418,6 @@ public class GrblFirmwareSettings implements SerialCommunicatorListener, IFirmwa
         serialCommunicatorDelegate.communicatorPausedOnError();
     }
 
-    @Override
-    public void messageForConsole(String msg) {
-        serialCommunicatorDelegate.messageForConsole(msg);
-    }
-
-    @Override
-    public void verboseMessageForConsole(String msg) {
-        serialCommunicatorDelegate.verboseMessageForConsole(msg);
-    }
-
-    @Override
-    public void errorMessageForConsole(String msg) {
-        serialCommunicatorDelegate.errorMessageForConsole(msg);
-    }
-
     /*
      * IFirmwareSettingsListener
      */

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/GrblFirmwareSettingsSerialCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/GrblFirmwareSettingsSerialCommunicator.java
@@ -265,19 +265,4 @@ public class GrblFirmwareSettingsSerialCommunicator implements SerialCommunicato
     public void communicatorPausedOnError() {
 
     }
-
-    @Override
-    public void messageForConsole(String msg) {
-
-    }
-
-    @Override
-    public void verboseMessageForConsole(String msg) {
-
-    }
-
-    @Override
-    public void errorMessageForConsole(String msg) {
-
-    }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerListener.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerListener.java
@@ -18,7 +18,6 @@
  */
 package com.willwinder.universalgcodesender.listeners;
 
-import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent.ControlState;
@@ -72,28 +71,7 @@ public interface ControllerListener {
      * Probe coordinates received.
      */
     void probeCoordinates(Position p);
-    
-    enum MessageType {
-        VERBOSE("verbose"),
-        INFO("info"),
-        ERROR("error");
 
-        private final String key;
-
-        MessageType(String key) {
-            this.key = key;
-        }
-
-        public String getLocalizedString() {
-            return Localization.getString(key);
-        }
-    }
-
-    /**
-     * A console message from the controller.
-     */
-    void messageForConsole(MessageType type, String msg);
-    
     /**
      * Controller status information.
      */

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/MessageListener.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/MessageListener.java
@@ -1,0 +1,39 @@
+/*
+    Copyright 2018 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+import com.willwinder.universalgcodesender.services.MessageService;
+
+/**
+ * An interface for a message listener which can be used to listen for console messages.
+ * Register this listener using {@link MessageService#addListener(MessageListener)}
+ * and it will receive all messages dispatched to be written to the console.
+ *
+ * @author Joacim Breiler
+ */
+public interface MessageListener {
+
+    /**
+     * This method will be called when a new message is received to be written to the console.
+     *
+     * @param messageType the type of message to be written
+     * @param message     the message to be written to the console
+     */
+    void onMessage(MessageType messageType, String message);
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/MessageType.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/MessageType.java
@@ -1,0 +1,42 @@
+/*
+    Copyright 2018 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+import com.willwinder.universalgcodesender.i18n.Localization;
+
+/**
+ * A type for describing a message verbosity.
+ *
+ * @author wwinder
+ */
+public enum MessageType {
+    VERBOSE("verbose"),
+    INFO("info"),
+    ERROR("error");
+
+    private final String key;
+
+    MessageType(String key) {
+        this.key = key;
+    }
+
+    public String getLocalizedString() {
+        return Localization.getString(key);
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/SerialCommunicatorListener.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/SerialCommunicatorListener.java
@@ -55,25 +55,4 @@ public interface SerialCommunicatorListener {
      * processing of commands.
      */
     void communicatorPausedOnError();
-
-    /**
-     * A message to be displayed in the console
-     *
-     * @param msg a text message
-     */
-    void messageForConsole(String msg);
-
-    /**
-     * A verbose message to be displayed in the console.
-     *
-     * @param msg a text message
-     */
-    void verboseMessageForConsole(String msg);
-
-    /**
-     * An error message to be displayed in the console
-     *
-     * @param msg a text message
-     */
-    void errorMessageForConsole(String msg);
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
@@ -21,6 +21,8 @@ package com.willwinder.universalgcodesender.model;
 
 import com.willwinder.universalgcodesender.IController;
 import com.willwinder.universalgcodesender.gcode.GcodeParser;
+import com.willwinder.universalgcodesender.listeners.MessageListener;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.Settings;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
@@ -105,5 +107,11 @@ public interface BackendAPI extends BackendAPIReadOnly {
     IController getController();
     void applySettingsToController(Settings settings, IController controller) throws Exception;
 
-    void sendMessageForConsole(String msg);
+    /**
+     * Dispatch a message with the given type to all registered message listeners using {@link MessageListener#onMessage(MessageType, String)}
+     *
+     * @param messageType the type of message to be printed
+     * @param message the message to be written
+     */
+    void dispatchMessage(MessageType messageType, String message);
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPIReadOnly.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPIReadOnly.java
@@ -19,6 +19,7 @@
 package com.willwinder.universalgcodesender.model;
 
 import com.willwinder.universalgcodesender.gcode.GcodeState;
+import com.willwinder.universalgcodesender.listeners.MessageListener;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStateListener;
 import com.willwinder.universalgcodesender.utils.Settings;
@@ -73,6 +74,19 @@ public interface BackendAPIReadOnly {
      */
     void removeControllerListener(ControllerListener listener);
 
+    /**
+     * Adds a listener that will receive all messages that should be written to the console
+     *
+     * @param listener the listener to be added
+     */
+    void addMessageListener(MessageListener listener);
+
+    /**
+     * Removes a listener for console messages
+     *
+     * @parame listener the listener to be removed
+     */
+    void removeMessageListener(MessageListener listener);
 
     // Config options
     File getGcodeFile();

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -19,7 +19,6 @@
 package com.willwinder.universalgcodesender.model;
 
 import com.google.common.io.Files;
-import com.willwinder.universalgcodesender.AbstractController;
 import com.willwinder.universalgcodesender.IController;
 import com.willwinder.universalgcodesender.Utils;
 import com.willwinder.universalgcodesender.connection.ConnectionFactory;
@@ -29,9 +28,11 @@ import com.willwinder.universalgcodesender.gcode.GcodeStats;
 import com.willwinder.universalgcodesender.gcode.processors.*;
 import com.willwinder.universalgcodesender.gcode.util.GcodeParserUtils;
 import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.MessageListener;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStateListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.UGSEvent.ControlState;
 import com.willwinder.universalgcodesender.model.UGSEvent.EventType;
@@ -40,6 +41,7 @@ import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.pendantui.SystemStateBean;
 import com.willwinder.universalgcodesender.firmware.FirmwareSetting;
 import com.willwinder.universalgcodesender.firmware.IFirmwareSettingsListener;
+import com.willwinder.universalgcodesender.services.MessageService;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.*;
 import com.willwinder.universalgcodesender.utils.Settings.FileStats;
@@ -63,9 +65,11 @@ import java.util.regex.Pattern;
  *
  * @author wwinder
  */
-public class GUIBackend implements BackendAPI, ControllerListener, SettingChangeListener, IFirmwareSettingsListener {
+public class GUIBackend implements BackendAPI, ControllerListener, SettingChangeListener, IFirmwareSettingsListener, MessageListener {
     private static final Logger logger = Logger.getLogger(GUIBackend.class.getName());
     private static final String NEW_LINE = "\n    ";
+
+    private final MessageService messageService = new MessageService();
 
     private IController controller = null;
     private Settings settings = null;
@@ -94,6 +98,7 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
 
     public GUIBackend() {
         scheduleTimers();
+        messageService.addListener(this);
     }
 
     private void scheduleTimers() {
@@ -171,9 +176,20 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
         }
     }
 
+    @Override
+    public void addMessageListener(MessageListener listener) {
+        this.messageService.addListener(listener);
+    }
+
+    @Override
+    public void removeMessageListener(MessageListener listener) {
+        this.messageService.removeListener(listener);
+    }
+
     //////////////////
     // GUI API
     //////////////////
+
     @Override
     public void preprocessAndExportToFile(File f) throws Exception {
         preprocessAndExportToFile(this.gcp, this.getGcodeFile(), f);
@@ -228,6 +244,7 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
         updateWithFirmware(firmware);
 
         this.controller = fetchControllerFromFirmware(firmware);
+        this.controller.setMessageService(messageService);
         applySettings(settings);
 
         this.controller.addListener(this);
@@ -811,12 +828,8 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     }
 
     @Override
-    public void sendMessageForConsole(String msg) {
-        if (controller != null ) {
-            controller.messageForConsole(msg);
-        } else {
-            //should still send!  Controller probably shouldn't ever be null.
-        }
+    public void dispatchMessage(MessageType messageType, String message) {
+        messageService.dispatchMessage(messageType, message);
     }
 
     @Override
@@ -941,5 +954,12 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     @Override
     public void onUpdatedFirmwareSetting(FirmwareSetting setting) {
         this.sendUGSEvent(new UGSEvent(EventType.FIRMWARE_SETTING_EVENT), false);
+    }
+
+    @Override
+    public void onMessage(MessageType messageType, String message) {
+        if (messageType == MessageType.ERROR) {
+            GUIHelpers.displayErrorDialog(message);
+        }
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -800,7 +800,6 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
         // Apply settings settings to controller.
 
         try {
-            controller.getCommandCreator();
             controller.setSingleStepMode(settings.isSingleStepMode());
             controller.setStatusUpdatesEnabled(settings.isStatusUpdatesEnabled());
             controller.setStatusUpdateRate(settings.getStatusUpdateRate());

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -769,13 +769,6 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     }
 
     @Override
-    public void messageForConsole(MessageType type, String msg) {
-        if (type == MessageType.ERROR) {
-            GUIHelpers.displayErrorDialog(msg);
-        }
-    }
-
-    @Override
     public void statusStringListener(ControllerStatus status) {
         this.activeState = status.getStateString();
         this.machineCoord = status.getMachineCoord();

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -67,7 +67,7 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     private static final Logger logger = Logger.getLogger(GUIBackend.class.getName());
     private static final String NEW_LINE = "\n    ";
 
-    private AbstractController controller = null;
+    private IController controller = null;
     private Settings settings = null;
     private Position machineCoord = null;
     private Position workCoord = null;
@@ -242,8 +242,8 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
         }
     }
 
-    protected AbstractController fetchControllerFromFirmware(String firmware) throws Exception {
-        Optional<AbstractController> c = FirmwareUtils.getControllerFor(firmware);
+    protected IController fetchControllerFromFirmware(String firmware) throws Exception {
+        Optional<IController> c = FirmwareUtils.getControllerFor(firmware);
         if (!c.isPresent()) {
             throw new Exception("Unable to create handler for: " + firmware);
         }

--- a/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/pendantui/PendantUI.java
@@ -364,10 +364,6 @@ public class PendantUI implements ControllerListener {
     }
 
     @Override
-    public void messageForConsole(MessageType type, String msg) {
-    }
-
-    @Override
     public void statusStringListener(ControllerStatus status) {
         // TODO Auto-generated method stub
         

--- a/ugs-core/src/com/willwinder/universalgcodesender/services/MessageService.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/services/MessageService.java
@@ -1,0 +1,73 @@
+/*
+    Copyright 2018 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.services;
+
+import com.willwinder.universalgcodesender.listeners.MessageListener;
+import com.willwinder.universalgcodesender.listeners.MessageType;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A service for handling message listeners and for dispatching messages to them.
+ *
+ * @author Joacim Breiler
+ */
+public class MessageService {
+
+    /**
+     * A set of message listeners
+     */
+    private final Set<MessageListener> listeners;
+
+    /**
+     * Default constructor
+     */
+    public MessageService() {
+        this.listeners = new HashSet<>();
+    }
+
+    /**
+     * Dispatches a message to all message listeners.
+     *
+     * @param messageType the verbosity of the message
+     * @param message the message text to be written
+     */
+    public void dispatchMessage(MessageType messageType, String message) {
+        listeners.forEach(listener -> listener.onMessage(messageType, message));
+    }
+
+    /**
+     * Adds a new listener for console messages
+     *
+     * @param messageListener the message listener to add
+     */
+    public void addListener(MessageListener messageListener) {
+        listeners.add(messageListener);
+    }
+
+    /**
+     * Removes a message listener
+     *
+     * @param messageListener the message listener to remove
+     */
+    public void removeListener(MessageListener messageListener) {
+        listeners.remove(messageListener);
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/PendantMenu.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/PendantMenu.java
@@ -19,6 +19,7 @@
 package com.willwinder.universalgcodesender.uielements.components;
 
 import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.pendantui.PendantUI;
 import com.willwinder.universalgcodesender.pendantui.PendantURLBean;
@@ -61,7 +62,7 @@ public class PendantMenu extends JMenu {
     private void startPendantServerButtonActionPerformed() {
         Collection<PendantURLBean> results = this.pendantUI.start();
         for (PendantURLBean result : results) {
-            backend.sendMessageForConsole("Pendant URL: " + result.getUrlString());
+            backend.dispatchMessage(MessageType.INFO, "Pendant URL: " + result.getUrlString());
         }
         startServer.setEnabled(false);
         stopServer.setEnabled(true);
@@ -70,7 +71,7 @@ public class PendantMenu extends JMenu {
 
     private void stopPendantServerButtonActionPerformed() {
         this.pendantUI.stop();
-        backend.sendMessageForConsole("Pendant stopped");
+        this.backend.dispatchMessage(MessageType.INFO, "Pendant stopped");
         this.startServer.setEnabled(true);
         this.stopServer.setEnabled(false);
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/JogPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/JogPanel.java
@@ -21,7 +21,6 @@ package com.willwinder.universalgcodesender.uielements.jog;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/JogPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/jog/JogPanel.java
@@ -21,6 +21,7 @@ package com.willwinder.universalgcodesender.uielements.jog;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -239,11 +240,6 @@ public class JogPanel extends JPanel implements UGSEventListener, ControllerList
 
     @Override
     public void commandComplete(GcodeCommand command) {
-
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
 
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionPanelGroup.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionPanelGroup.java
@@ -22,7 +22,6 @@ import com.willwinder.universalgcodesender.connection.ConnectionFactory;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionPanelGroup.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionPanelGroup.java
@@ -22,6 +22,7 @@ import com.willwinder.universalgcodesender.connection.ConnectionFactory;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -216,11 +217,6 @@ public class ConnectionPanelGroup extends JPanel implements UGSEventListener, Co
 
     @Override
     public void probeCoordinates(Position p) {
-
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
 
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverridesPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverridesPanel.java
@@ -25,20 +25,14 @@ import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus.AccessoryStates;
-import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.Overrides;
 import com.willwinder.universalgcodesender.model.Position;
-import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_DISCONNECTED;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.event.ActionEvent;
-import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import net.miginfocom.swing.MigLayout;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;
@@ -47,7 +41,14 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.UIManager;
-import net.miginfocom.swing.MigLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_DISCONNECTED;
 
 /**
  *

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverridesPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverridesPanel.java
@@ -25,6 +25,7 @@ import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus.AccessoryStates;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -280,10 +281,6 @@ public final class OverridesPanel extends JPanel implements UGSEventListener, Co
 
     @Override
     public void probeCoordinates(Position p) {
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/SendStatusPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/SendStatusPanel.java
@@ -22,7 +22,6 @@ import com.willwinder.universalgcodesender.Utils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/SendStatusPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/SendStatusPanel.java
@@ -22,6 +22,7 @@ import com.willwinder.universalgcodesender.Utils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -260,10 +261,6 @@ public class SendStatusPanel extends JPanel implements UGSEventListener, Control
 
     @Override
     public void probeCoordinates(Position p) {
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/toolbars/SendStatusLine.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/toolbars/SendStatusLine.java
@@ -22,6 +22,7 @@
 package com.willwinder.universalgcodesender.uielements.toolbars;
 
 import com.willwinder.universalgcodesender.Utils;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
@@ -29,7 +30,7 @@ import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent;
-import static com.willwinder.universalgcodesender.model.UGSEvent.ControlState.COMM_SENDING;
+
 import static com.willwinder.universalgcodesender.model.UGSEvent.FileState.FILE_LOADED;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.GUIHelpers;
@@ -180,10 +181,6 @@ public class SendStatusLine extends JLabel implements UGSEventListener, Controll
 
     @Override
     public void probeCoordinates(Position p) {
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/toolbars/SendStatusLine.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/toolbars/SendStatusLine.java
@@ -1,8 +1,5 @@
-/**
- * A component which should be embedded in a status bar.
- */
 /*
-    Copywrite 2016-2017 Will Winder
+    Copyright 2016-2018 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -22,26 +19,27 @@
 package com.willwinder.universalgcodesender.uielements.toolbars;
 
 import com.willwinder.universalgcodesender.Utils;
-import com.willwinder.universalgcodesender.listeners.MessageType;
-import com.willwinder.universalgcodesender.model.Alarm;
-import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
+import com.willwinder.universalgcodesender.model.Alarm;
+import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent;
-
-import static com.willwinder.universalgcodesender.model.UGSEvent.FileState.FILE_LOADED;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.GUIHelpers;
 import com.willwinder.universalgcodesender.utils.GcodeStreamReader;
+
+import javax.swing.JLabel;
+import javax.swing.Timer;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
-import javax.swing.JLabel;
-import javax.swing.Timer;
+
+import static com.willwinder.universalgcodesender.model.UGSEvent.FileState.FILE_LOADED;
 
 /**
+ * A component which should be embedded in a status bar.
  *
  * @author wwinder
  */

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/ControllerSettings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/ControllerSettings.java
@@ -23,8 +23,8 @@ package com.willwinder.universalgcodesender.utils;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.willwinder.universalgcodesender.AbstractController;
 import com.willwinder.universalgcodesender.GrblController;
+import com.willwinder.universalgcodesender.IController;
 import com.willwinder.universalgcodesender.LoopBackCommunicator;
 import com.willwinder.universalgcodesender.SmoothieController;
 import com.willwinder.universalgcodesender.TinyGController;
@@ -107,7 +107,7 @@ public class ControllerSettings {
      *     "args": null
      * }
      */
-    public AbstractController getController() {
+    public IController getController() {
         //String controllerName = controllerConfig.get("name").getAsString();
         String controllerName = this.Controller.name;
         CONTROLLER controller = CONTROLLER.fromString(controllerName);

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/FirmwareUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/FirmwareUtils.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.willwinder.universalgcodesender.AbstractController;
+import com.willwinder.universalgcodesender.IController;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import java.io.BufferedReader;
 import java.io.File;
@@ -125,23 +126,11 @@ public class FirmwareUtils {
      * @param firmware
      * @return 
      */
-    public static Optional<AbstractController> getControllerFor(String firmware) {
+    public static Optional<IController> getControllerFor(String firmware) {
         if (!configFiles.containsKey(firmware)) {
             return Optional.empty();
         }
 
-        /*
-        ConfigLoader config = new Gson().fromJson(new FileReader(configFiles.get(firmware).configFile), ConfigLoader.class);
-        File f = configFiles.get(firmware).configFile;
-        File next = new File(f.getParent(), f.getName() + ".out");
-        try (FileWriter fileWriter = new FileWriter(next)) {
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
-             fileWriter.write(gson.toJson(config, ConfigLoader2.class));
-        } catch (IOException ex) {
-            logger.log(Level.SEVERE, null, ex);
-        }
-        System.out.println("Have config: " + config.toString());
-        */
         return Optional.of(configFiles.get(firmware).loader.getController());
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerPanel.java
@@ -22,7 +22,6 @@ package com.willwinder.universalgcodesender.visualizer;
 import com.jogamp.opengl.util.FPSAnimator;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerPanel.java
@@ -22,6 +22,7 @@ package com.willwinder.universalgcodesender.visualizer;
 import com.jogamp.opengl.util.FPSAnimator;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -123,11 +124,6 @@ public class VisualizerPanel extends JPanel implements ControllerListener, UGSEv
     public void probeCoordinates(Position p) {
     }
 
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
-        //throw new UnsupportedOperationException("Not supported yet.");
-    }
-    
     @Override
     public void postProcessData(int numRows) {
         // Visualizer doesn't care.

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerWindow.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerWindow.java
@@ -29,16 +29,16 @@ import com.jogamp.opengl.util.FPSAnimator;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.types.WindowSettings;
+
+import javax.swing.JFrame;
 import java.awt.Dimension;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
-import javax.swing.JFrame;
 
 /**
  *

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerWindow.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerWindow.java
@@ -29,6 +29,7 @@ import com.jogamp.opengl.util.FPSAnimator;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent;
@@ -161,11 +162,6 @@ implements ControllerListener, WindowListener {
 
     @Override
     public void probeCoordinates(Position p) {
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
-        //throw new UnsupportedOperationException("Not supported yet.");
     }
     
     @Override

--- a/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
@@ -138,7 +138,7 @@ public class AbstractControllerTest {
     private void openInstanceExpectUtility(String port, int portRate, boolean handleStateChange) throws Exception {
         instance.openCommAfterEvent();
         expect(expectLastCall()).anyTimes();
-        mockMessageService.dispatchMessage(anyObject(), EasyMock.anyString());
+        mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall()).anyTimes();
         expect(mockCommunicator.openCommPort(ConnectionDriver.JSSC, port, portRate)).andReturn(true).once();
         expect(instance.isCommOpen()).andReturn(false).once();

--- a/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
@@ -24,6 +24,7 @@ import com.willwinder.universalgcodesender.gcode.GcodeCommandCreator;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.model.UGSEvent;
 import com.willwinder.universalgcodesender.model.UnitUtils;
+import com.willwinder.universalgcodesender.services.MessageService;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.GcodeStreamReader;
 import com.willwinder.universalgcodesender.utils.GcodeStreamTest;
@@ -68,6 +69,7 @@ public class AbstractControllerTest {
     
     private final static AbstractCommunicator mockCommunicator = EasyMock.createMock(AbstractCommunicator.class);
     private final static ControllerListener mockListener = EasyMock.createMock(ControllerListener.class);
+    private final static MessageService mockMessageService = EasyMock.createMock(MessageService.class);
     private final static GcodeCommandCreator gcodeCreator = new GcodeCommandCreator();
 
     private Settings settings = new Settings();
@@ -107,6 +109,7 @@ public class AbstractControllerTest {
         f.set(niceInstance, gcodeCreator);
         
         instance.addListener(mockListener);
+        instance.setMessageService(mockMessageService);
     }
 
     @BeforeClass
@@ -123,9 +126,9 @@ public class AbstractControllerTest {
     public void setUp() throws Exception {
         // AbstractCommunicator calls a function on mockCommunicator that I
         // don't want to deal with.
-        reset(mockCommunicator, mockListener);
+        reset(mockCommunicator, mockListener, mockMessageService);
         init();
-        reset(mockCommunicator, mockListener);
+        reset(mockCommunicator, mockListener, mockMessageService);
     }
 
 
@@ -135,7 +138,7 @@ public class AbstractControllerTest {
     private void openInstanceExpectUtility(String port, int portRate, boolean handleStateChange) throws Exception {
         instance.openCommAfterEvent();
         expect(expectLastCall()).anyTimes();
-        mockListener.messageForConsole(anyObject(), EasyMock.anyString());
+        mockMessageService.dispatchMessage(anyObject(), EasyMock.anyString());
         expect(expectLastCall()).anyTimes();
         expect(mockCommunicator.openCommPort(ConnectionDriver.JSSC, port, portRate)).andReturn(true).once();
         expect(instance.isCommOpen()).andReturn(false).once();
@@ -190,7 +193,7 @@ public class AbstractControllerTest {
 
         instance.openCommAfterEvent();
         expect(expectLastCall()).once();
-        mockListener.messageForConsole(anyObject(), anyString());
+        mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall()).once();
         expect(mockCommunicator.openCommPort(ConnectionDriver.JSSC, port, portRate)).andReturn(true).once();
         replay(instance, mockCommunicator, mockListener);
@@ -230,7 +233,7 @@ public class AbstractControllerTest {
         expect(expectLastCall()).once();
 
         // Message for open and close.
-        mockListener.messageForConsole(anyObject(), anyString());
+        mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall()).times(2);
         expect(mockCommunicator.openCommPort(ConnectionDriver.JSSC, port, baud)).andReturn(true).once();
         mockCommunicator.closeCommPort();
@@ -635,7 +638,7 @@ public class AbstractControllerTest {
 
         // Setup test with commands sent by communicator waiting on response.
         testCommandSent();
-        reset(instance, mockCommunicator, mockListener);
+        reset(instance, mockCommunicator, mockListener, mockMessageService);
         expect(instance.handlesAllStateChangeEvents()).andReturn(true).anyTimes();
 
         // Make sure the events are triggered.
@@ -646,7 +649,7 @@ public class AbstractControllerTest {
         mockListener.commandComplete(capture(gc2));
         expect(expectLastCall());
         expect(expectLastCall());
-        mockListener.messageForConsole(anyObject(), anyString());
+        mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall());
         mockListener.fileStreamComplete("queued commands", true);
         mockListener.controlStateChange(UGSEvent.ControlState.COMM_IDLE);

--- a/ugs-core/test/com/willwinder/universalgcodesender/BufferedCommunicatorTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/BufferedCommunicatorTest.java
@@ -1,5 +1,5 @@
 /*
-    Copywrite 2015-2016 Will Winder
+    Copyright 2015-2018 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -132,8 +132,6 @@ public class BufferedCommunicatorTest {
 
         // Check events and connection:
         // console message, connection stream, sent event
-        mockScl.messageForConsole(EasyMock.anyString());
-        EasyMock.expect(EasyMock.expectLastCall()).times(2);
         mockConnection.sendStringToComm(input + "\n");
         EasyMock.expect(EasyMock.expectLastCall()).times(2);
         mockScl.commandSent(EasyMock.<GcodeCommand>anyObject());
@@ -154,9 +152,6 @@ public class BufferedCommunicatorTest {
         String[] inputs = {"input1", "input2"};
 
         for (String i : inputs) {
-            mockScl.messageForConsole(EasyMock.anyString());
-            EasyMock.expect(EasyMock.expectLastCall());
-
             mockConnection.sendStringToComm(i + "\n");
             EasyMock.expect(EasyMock.expectLastCall());
 
@@ -194,9 +189,6 @@ public class BufferedCommunicatorTest {
         String input = "input";
 
         // Setup 2 active commands.
-        mockScl.messageForConsole(EasyMock.anyString());
-        EasyMock.expect(EasyMock.expectLastCall()).times(2);
-
         mockConnection.sendStringToComm(input + "\n");
         EasyMock.expect(EasyMock.expectLastCall()).times(2);
 

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerMockTests.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerMockTests.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -50,7 +52,7 @@ public class GrblControllerMockTests {
     gc.rawResponseListener("$10=100");
 
     ArgumentCaptor<String> consoleMessageCaptor = ArgumentCaptor.forClass(String.class);
-    verify(gc, times(1)).messageForConsole(consoleMessageCaptor.capture());
+    verify(gc, times(1)).dispatchConsoleMessage(any(), consoleMessageCaptor.capture());
     assertThat(consoleMessageCaptor.getValue(), containsString(description));
   }
 

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -20,9 +20,11 @@ package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.AbstractController.UnexpectedCommand;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.mockobjects.MockGrblCommunicator;
 import com.willwinder.universalgcodesender.model.UGSEvent.ControlState;
 import com.willwinder.universalgcodesender.model.UnitUtils;
+import com.willwinder.universalgcodesender.services.MessageService;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.GUIHelpers;
 
@@ -1029,26 +1031,32 @@ public class GrblControllerTest {
      * Test of messageForConsole method, of class GrblController.
      */
     @Test
-    public void testMessageForConsole() {
-        System.out.println("messageForConsole");
-        String msg = "";
+    public void testDispatchConsoleInfoMessage() {
+        String msg = "test message";
         GrblController instance = new GrblController(mgc);
-        instance.messageForConsole(msg);
 
-        // TODO: Test that this triggers a listener event.
+        MessageService messageService = mock(MessageService.class);
+        instance.setMessageService(messageService);
+
+        instance.dispatchConsoleMessage(MessageType.INFO, msg);
+
+        verify(messageService, times(1)).dispatchMessage(MessageType.INFO, msg);
     }
 
     /**
      * Test of verboseMessageForConsole method, of class GrblController.
      */
     @Test
-    public void testVerboseMessageForConsole() {
-        System.out.println("verboseMessageForConsole");
-        String msg = "";
+    public void testDispatchConsoleVerboseMessage() {
+        String msg = "test message";
         GrblController instance = new GrblController(mgc);
-        instance.verboseMessageForConsole(msg);
+
+        MessageService messageService = mock(MessageService.class);
+        instance.setMessageService(messageService);
+
+        instance.dispatchConsoleMessage(MessageType.VERBOSE, msg);
         
-        // TODO: Test that this triggers a listener event.
+        verify(messageService, times(1)).dispatchMessage(MessageType.VERBOSE, msg);
     }
 
     /**
@@ -1208,21 +1216,20 @@ public class GrblControllerTest {
         instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
         instance.commandSent(new GcodeCommand("G0"));
 
-        ControllerListener controllerListener = mock(ControllerListener.class);
-        instance.addListener(controllerListener);
+        MessageService messageService = mock(MessageService.class);
+        instance.setMessageService(messageService);
 
         // When
         instance.rawResponseHandler("error:1");
 
         //Then
         String genericErrorMessage = "Error while processing response <error:1>\n";
-        verify(controllerListener, times(0)).messageForConsole(ControllerListener.MessageType.ERROR, genericErrorMessage);
+        verify(messageService, times(0)).dispatchMessage(MessageType.ERROR, genericErrorMessage);
 
         String errorMessage = "An error was detected while sending 'G0': (error:1) G-code words consist of a letter and a value. Letter was not found. Streaming has been paused.\n";
-        verify(controllerListener).messageForConsole(ControllerListener.MessageType.ERROR, errorMessage);
+        verify(messageService).dispatchMessage(MessageType.ERROR, errorMessage);
 
-        verify(controllerListener, times(1)).messageForConsole(any(), anyString());
-        instance.removeListener(controllerListener);
+        verify(messageService, times(1)).dispatchMessage(any(), anyString());
 
         assertFalse(instance.getActiveCommand().isPresent());
     }
@@ -1236,17 +1243,16 @@ public class GrblControllerTest {
         instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
         instance.commandSent(new GcodeCommand("G21"));
 
-        ControllerListener controllerListener = mock(ControllerListener.class);
-        instance.addListener(controllerListener);
+        MessageService messageService = mock(MessageService.class);
+        instance.setMessageService(messageService);
 
         // When
         instance.rawResponseHandler("error:18");
 
         // Then
         String genericErrorMessage = "An error was detected while sending 'G21': (error:18) An unknown error has occurred. Streaming has been paused.\n";
-        verify(controllerListener, times(1)).messageForConsole(ControllerListener.MessageType.ERROR, genericErrorMessage);
-        verify(controllerListener, times(1)).messageForConsole(any(), anyString());
-        instance.removeListener(controllerListener);
+        verify(messageService, times(1)).dispatchMessage(MessageType.ERROR, genericErrorMessage);
+        verify(messageService, times(1)).dispatchMessage(any(), anyString());
 
         assertFalse(instance.getActiveCommand().isPresent());
     }
@@ -1259,17 +1265,16 @@ public class GrblControllerTest {
         instance.setUnitsCode("G21");
         instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
 
-        ControllerListener controllerListener = mock(ControllerListener.class);
-        instance.addListener(controllerListener);
+        MessageService messageService = mock(MessageService.class);
+        instance.setMessageService(messageService);
 
         // When
         instance.rawResponseHandler("error:1");
 
         // Then
         String genericErrorMessage = "An unexpected error was detected: (error:1) G-code words consist of a letter and a value. Letter was not found.\n";
-        verify(controllerListener, times(1)).messageForConsole(ControllerListener.MessageType.INFO, genericErrorMessage);
-        verify(controllerListener, times(1)).messageForConsole(any(), anyString());
-        instance.removeListener(controllerListener);
+        verify(messageService, times(1)).dispatchMessage(MessageType.INFO, genericErrorMessage);
+        verify(messageService, times(1)).dispatchMessage(any(), anyString());
 
         assertFalse(instance.getActiveCommand().isPresent());
     }

--- a/ugs-platform/ugs-platform-plugin-jog/src/main/java/com/willwinder/ugs/nbp/jog/JogTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-jog/src/main/java/com/willwinder/ugs/nbp/jog/JogTopComponent.java
@@ -189,11 +189,6 @@ public final class JogTopComponent extends TopComponent implements UGSEventListe
     }
 
     @Override
-    public void messageForConsole(MessageType type, String msg) {
-
-    }
-
-    @Override
     public void statusStringListener(ControllerStatus status) {
 
     }

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/actions/PendantAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/actions/PendantAction.java
@@ -20,6 +20,7 @@ package com.willwinder.ugs.nbp.core.actions;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.pendantui.PendantUI;
 import com.willwinder.universalgcodesender.pendantui.PendantURLBean;
@@ -92,9 +93,9 @@ public class PendantAction extends AbstractAction {
                     new ImageIcon(result.getQrCodeJpg(), "QR Code"),
                     JLabel.CENTER),
                     "al center");
-            backend.sendMessageForConsole("Pendant URL: " + result.getUrlString());
+            backend.dispatchMessage(MessageType.INFO, "Pendant URL: " + result.getUrlString());
 
-            this.backend.addControllerListener(pendantUI);
+            backend.addControllerListener(pendantUI);
 
             JOptionPane.showMessageDialog(null,panel,"Pendant Address",JOptionPane.PLAIN_MESSAGE);
 

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/console/SerialConsoleTopComponent.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/console/SerialConsoleTopComponent.java
@@ -44,16 +44,31 @@ import org.openide.windows.TopComponent;
 )
 public final class SerialConsoleTopComponent extends TopComponent {
 
+    private final CommandPanel commandPanel;
+    private final BackendAPI backend;
+
     public SerialConsoleTopComponent() {
-        BackendAPI backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+        backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+        commandPanel = new CommandPanel(backend);
         this.setLayout(new BorderLayout());
-        this.add(new CommandPanel(backend), BorderLayout.CENTER);
+        this.add(commandPanel, BorderLayout.CENTER);
     }
 
     @Override
     public void componentOpened() {
+        super.componentOpened();
         setName(LocalizingService.SerialConsoleTitle);
         setToolTipText(LocalizingService.SerialConsoleTooltip);
+
+        backend.addUGSEventListener(commandPanel);
+        backend.addMessageListener(commandPanel);
+    }
+
+    @Override
+    protected void componentClosed() {
+        super.componentClosed();
+        backend.removeUGSEventListener(commandPanel);
+        backend.removeMessageListener(commandPanel);
     }
 
     public void writeProperties(java.util.Properties p) {

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
@@ -29,6 +29,7 @@ import com.willwinder.ugs.nbm.visualizer.renderables.SizeDisplay;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.Position;
@@ -376,10 +377,6 @@ public class RendererInputHandler implements
 
     @Override
     public void probeCoordinates(Position p) {
-    }
-
-    @Override
-    public void messageForConsole(MessageType type, String msg) {
     }
 
     @Override

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
@@ -1,8 +1,5 @@
-/**
- * Process all the listeners and call methods in the renderer.
- */
 /*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2018 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -21,15 +18,14 @@
  */
 package com.willwinder.ugs.nbm.visualizer;
 
-import com.willwinder.ugs.nbm.visualizer.shared.GcodeRenderer;
 import com.jogamp.opengl.util.FPSAnimator;
 import com.willwinder.ugs.nbm.visualizer.renderables.GcodeModel;
 import com.willwinder.ugs.nbm.visualizer.renderables.Selection;
 import com.willwinder.ugs.nbm.visualizer.renderables.SizeDisplay;
+import com.willwinder.ugs.nbm.visualizer.shared.GcodeRenderer;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.Position;
@@ -38,6 +34,9 @@ import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.Settings;
 import com.willwinder.universalgcodesender.utils.Settings.FileStats;
+
+import javax.swing.SwingUtilities;
+import javax.vecmath.Point3d;
 import java.awt.Point;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -50,10 +49,9 @@ import java.awt.event.MouseWheelListener;
 import java.awt.event.WindowListener;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
-import javax.swing.SwingUtilities;
-import javax.vecmath.Point3d;
 
 /**
+ * Process all the listeners and call methods in the renderer.
  *
  * @author wwinder
  */


### PR DESCRIPTION
I wanted to make one change in this PR, to make GUIBackend use the IController in favour for the AbstractController. 

The reason for this was that I tried implementing the Marlin protocol and I had a hard time getting it to work using the AbstractController. Once I switched to implement a bare IController it was easier. There are a lot of goodies in the AbstractController and I will probably end up using it in the end. But I believe that by using interfaces the contract will be more clear between the GUI and the controllers.

For instance there were places in the higher level code that used the AbstractController:s implementation of SerialCommunicatorListener for sending messages the console. This felt wrong because the console is the GUI:s business. As I can see it there were two options, I could either let the IController define the same method and extending the contract with `IController#messageForConsole` or I could extract that functionality to its own service `MessageService`.

I choose the MessageService, which now should be responsible for dispatching all console messages. There is now no need for the message methods in `SerialCommunicatorListener` can now be removed.

There is one downside to this and that is that the MessageService needs to be registered to the controller. This could probably better be solved in the future using a factory or an init method in the controller.