### PR TITLE
Remove old jog control component

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -43,7 +43,7 @@ public class Settings {
     private String portRate = "115200";
     private boolean manualModeEnabled = false;
     private double manualModeStepSize = 1;
-    private boolean useZStepSize = false;
+    private boolean useZStepSize = true;
     private double zJogStepSize = 1;
     private double jogFeedRate = 10;
     private boolean scrollWindowEnabled = true;

--- a/ugs-core/test/com/willwinder/universalgcodesender/utils/SettingsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/utils/SettingsTest.java
@@ -63,7 +63,7 @@ public class SettingsTest {
         assertFalse(target.isSingleStepMode());
         assertEquals(Double.valueOf(200), Double.valueOf(target.getStatusUpdateRate()));
         assertTrue(target.isStatusUpdatesEnabled());
-        assertFalse(target.useZStepSize());
+        assertTrue(target.useZStepSize());
         assertFalse(target.isVerboseOutputEnabled());
         assertNotNull(target.getVisualizerWindowSettings());
         assertEquals(Double.valueOf(1), Double.valueOf(target.getzJogStepSize()));

--- a/ugs-platform/ugs-platform-plugin-jog/src/main/java/com/willwinder/ugs/nbp/jog/JogTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-jog/src/main/java/com/willwinder/ugs/nbp/jog/JogTopComponent.java
@@ -53,8 +53,8 @@ import javax.swing.JPopupMenu;
         preferredID = "JogTopComponent"
 )
 @TopComponent.Registration(
-        mode = "top_left",
-        openAtStartup = false)
+        mode = "middle_left",
+        openAtStartup = true)
 @ActionID(
         category = JogTopComponent.CATEGORY,
         id = JogTopComponent.ACTION_ID)

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/JogControlTopComponent.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/JogControlTopComponent.java
@@ -38,12 +38,7 @@ import org.openide.windows.WindowManager;
 @TopComponent.Description(
         preferredID = "JogControlTopComponent",
         //iconBase="SET/PATH/TO/ICON/HERE", 
-        persistenceType = TopComponent.PERSISTENCE_ALWAYS
-)
-@TopComponent.Registration(mode = "middle_left", openAtStartup = false)
-@TopComponent.OpenActionRegistration(
-        displayName = "<Not localized:JogControlTopComponent>",
-        preferredID = "JogControlTopComponent"
+        persistenceType = TopComponent.PERSISTENCE_NEVER
 )
 public final class JogControlTopComponent extends TopComponent {
     public JogControlTopComponent() {

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/JogControlTopComponent.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/JogControlTopComponent.java
@@ -28,18 +28,19 @@ import java.awt.BorderLayout;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.windows.TopComponent;
+import org.openide.windows.WindowManager;
 
 /**
- * Top component which displays something.
+ * Old jog controller
+ *
+ * @deprecated This jog controller is deprecated and should be replaced by the new jog module.
  */
 @TopComponent.Description(
         preferredID = "JogControlTopComponent",
         //iconBase="SET/PATH/TO/ICON/HERE", 
         persistenceType = TopComponent.PERSISTENCE_ALWAYS
 )
-@TopComponent.Registration(mode = "middle_left", openAtStartup = true)
-@ActionID(category = LocalizingService.JogControlCategory, id = LocalizingService.JogControlActionId)
-@ActionReference(path = LocalizingService.JogControlWindowPath)
+@TopComponent.Registration(mode = "middle_left", openAtStartup = false)
 @TopComponent.OpenActionRegistration(
         displayName = "<Not localized:JogControlTopComponent>",
         preferredID = "JogControlTopComponent"
@@ -56,6 +57,13 @@ public final class JogControlTopComponent extends TopComponent {
     public void componentOpened() {
         setName(LocalizingService.JogControlTitle);
         setToolTipText(LocalizingService.JogControlTooltip);
+
+        // Try to load the new jog module
+        TopComponent jogTopComponent = WindowManager.getDefault().findTopComponent("JogTopComponent");
+        if(jogTopComponent != null && !jogTopComponent.isOpened()) {
+            jogTopComponent.open();
+            close();
+        }
     }
 
     @Override


### PR DESCRIPTION
Activated the new jog module by default. Also activated separate step settings for XY  and Z by default.

If we remove the old module it would have the side effect that old users will have the old jog controller completely removed without having the new activated. So I added a check for when the old module is loaded, it will try to load the new then close it self. 

We need to keep the old module a couple of months to make sure people have transitioned to the new before we can remove it.

Fixes #1089