### PR TITLE
Added feed speed units to the machine status panel

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -243,12 +243,8 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
             double feedRate, UnitUtils.Units units) throws Exception {
         logger.log(Level.INFO, "Adjusting manual location.");
 
-        // Format step size from spinner.
-        String formattedStepSize = Utils.formatter.format(stepSize);
-        String formattedFeedRate = Utils.formatter.format(feedRate);
-
-        String commandString = GcodeUtils.generateXYZ("G91G1", units,
-                formattedStepSize, formattedFeedRate, dirX, dirY, dirZ);
+        String commandString = GcodeUtils.generateJogCommand("G91G1", units,
+                stepSize, feedRate, dirX, dirY, dirZ);
 
         GcodeCommand command = createCommand(commandString);
         command.setTemporaryParserModalChange(true);

--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -243,7 +243,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
             double feedRate, UnitUtils.Units units) throws Exception {
         logger.log(Level.INFO, "Adjusting manual location.");
 
-        String commandString = GcodeUtils.generateJogCommand("G91G1", units,
+        String commandString = GcodeUtils.generateMoveCommand(GcodeUtils.unitCommand(units) + "G91G1",
                 stepSize, feedRate, dirX, dirY, dirZ);
 
         GcodeCommand command = createCommand(commandString);

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -182,6 +182,7 @@ public class GrblController extends AbstractController {
                             this.controllerStatus.getMachineCoord(),
                             this.controllerStatus.getWorkCoord(),
                             this.controllerStatus.getFeedSpeed(),
+                            this.controllerStatus.getFeedSpeedUnits(),
                             this.controllerStatus.getSpindleSpeed(),
                             this.controllerStatus.getOverrides(),
                             this.controllerStatus.getWorkCoordinateOffset(),

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -569,12 +569,8 @@ public class GrblController extends AbstractController {
     public void jogMachine(int dirX, int dirY, int dirZ, double stepSize, 
             double feedRate, Units units) throws Exception {
         if (capabilities.hasCapability(GrblCapabilitiesConstants.HARDWARE_JOGGING)) {
-            // Format step size from spinner.
-            String formattedStepSize = Utils.formatter.format(stepSize);
-            String formattedFeedRate = Utils.formatter.format(feedRate);
-
-            String commandString = GcodeUtils.generateXYZ("G91", units,
-                    formattedStepSize, formattedFeedRate, dirX, dirY, dirZ);
+            String commandString = GcodeUtils.generateJogCommand("G91", units,
+                    stepSize, feedRate, dirX, dirY, dirZ);
             GcodeCommand command = createCommand("$J=" + commandString);
             sendCommandImmediately(command);
         } else {

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -569,7 +569,7 @@ public class GrblController extends AbstractController {
     public void jogMachine(int dirX, int dirY, int dirZ, double stepSize, 
             double feedRate, Units units) throws Exception {
         if (capabilities.hasCapability(GrblCapabilitiesConstants.HARDWARE_JOGGING)) {
-            String commandString = GcodeUtils.generateJogCommand("G91", units,
+            String commandString = GcodeUtils.generateMoveCommand(GcodeUtils.unitCommand(units) + "G91",
                     stepSize, feedRate, dirX, dirY, dirZ);
             GcodeCommand command = createCommand("$J=" + commandString);
             sendCommandImmediately(command);

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -353,9 +353,13 @@ public class GrblUtils {
             OverridePercents overrides = null;
             EnabledPins pins = null;
             AccessoryStates accessoryStates = null;
-            Double feedSpeed = null;
-            Double spindleSpeed = null;
 
+            double feedSpeed = 0;
+            double spindleSpeed = 0;
+            if(lastStatus != null) {
+                feedSpeed = lastStatus.getFeedSpeed();
+                spindleSpeed = lastStatus.getSpindleSpeed();
+            }
             boolean isOverrideReport = false;
 
             // Parse out the status messages.
@@ -440,7 +444,7 @@ public class GrblUtils {
             }
 
             ControllerState state = getControllerStateFromStateString(stateString);
-            return new ControllerStatus(stateString, state, MPos, WPos, feedSpeed, spindleSpeed, overrides, WCO, pins, accessoryStates);
+            return new ControllerStatus(stateString, state, MPos, WPos, feedSpeed, reportingUnits, spindleSpeed, overrides, WCO, pins, accessoryStates);
         }
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import com.willwinder.universalgcodesender.firmware.IFirmwareSettings;
 import com.willwinder.universalgcodesender.firmware.tinyg.TinyGFirmwareSettings;
 import com.willwinder.universalgcodesender.gcode.TinyGGcodeCommandCreator;
+import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
@@ -116,6 +117,17 @@ public class TinyGController extends AbstractController {
     @Override
     protected void cancelSendBeforeEvent() throws Exception {
         pauseStreaming();
+    }
+
+    @Override
+    public void jogMachine(int dirX, int dirY, int dirZ, double stepSize, double feedRate, UnitUtils.Units units) throws Exception {
+        UnitUtils.Units targetUnits = UnitUtils.Units.getUnits(getCurrentGcodeState().units);
+        String commandString = GcodeUtils.generateJogCommand("G91G1", units, stepSize, feedRate, dirX, dirY, dirZ, targetUnits);
+
+        GcodeCommand command = createCommand(commandString);
+        command.setTemporaryParserModalChange(true);
+        sendCommandImmediately(command);
+        restoreParserModalState();
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -122,7 +122,9 @@ public class TinyGController extends AbstractController {
     @Override
     public void jogMachine(int dirX, int dirY, int dirZ, double stepSize, double feedRate, UnitUtils.Units units) throws Exception {
         UnitUtils.Units targetUnits = UnitUtils.Units.getUnits(getCurrentGcodeState().units);
-        String commandString = GcodeUtils.generateJogCommand("G91G1", units, stepSize, feedRate, dirX, dirY, dirZ, targetUnits);
+
+        double scale = UnitUtils.scaleUnits(units, targetUnits);
+        String commandString = GcodeUtils.generateMoveCommand("G91G1", stepSize * scale, feedRate * scale, dirX, dirY, dirZ);
 
         GcodeCommand command = createCommand(commandString);
         command.setTemporaryParserModalChange(true);

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
@@ -155,9 +155,11 @@ public class TinyGUtils {
             JsonObject statusResultObject = response.getAsJsonObject(FIELD_STATUS_REPORT);
 
             Position workCoord = lastControllerStatus.getWorkCoord();
+            UnitUtils.Units feedSpeedUnits = lastControllerStatus.getFeedSpeedUnits();
             if (hasNumericField(statusResultObject, FIELD_STATUS_REPORT_UNIT)) {
                 UnitUtils.Units units = statusResultObject.get(FIELD_STATUS_REPORT_UNIT).getAsInt() == 1 ? UnitUtils.Units.MM : UnitUtils.Units.INCH;
                 workCoord = new Position(workCoord.getX(), workCoord.getY(), workCoord.getZ(), units);
+                feedSpeedUnits = units;
             }
 
             if (hasNumericField(statusResultObject, FIELD_STATUS_REPORT_POSX)) {
@@ -228,7 +230,7 @@ public class TinyGUtils {
             ControllerStatus.AccessoryStates accessoryStates = lastControllerStatus.getAccessoryStates();
 
             ControllerStatus.OverridePercents overrides = new ControllerStatus.OverridePercents(overrideFeed, overrideRapid, overrideSpindle);
-            return new ControllerStatus(stateString, state, machineCoord, workCoord, feedSpeed, spindleSpeed, overrides, workCoordinateOffset, enabledPins, accessoryStates);
+            return new ControllerStatus(stateString, state, machineCoord, workCoord, feedSpeed, feedSpeedUnits, spindleSpeed, overrides, workCoordinateOffset, enabledPins, accessoryStates);
         }
 
         return lastControllerStatus;

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeUtils.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2018 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -18,6 +18,8 @@
  */
 package com.willwinder.universalgcodesender.gcode.util;
 
+import com.willwinder.universalgcodesender.Utils;
+import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 
 /**
@@ -82,6 +84,66 @@ public class GcodeUtils {
 
         if (feedRate != null) {
             sb.append("F").append(feedRate);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Generates a jog command given a base command. THe command will append the relative movement to be made for zero
+     * to all axises the given distance and feed rate. This method will generate the command and convert the distance
+     * and feed rate to the given target units.
+     *
+     * Ex. If the given distance is 1 inch and the target units is millimeters, the distance will be converted to
+     * 25.4mm.
+     *
+     * @param command the base command to use, ie: G91G1
+     * @param units the units that the distance and feed rate are given in
+     * @param distance the distance to move
+     * @param feedRate the feed rate to move with
+     * @param dirX 1 for positive direction, 0 for no movement, -1 for negative movement
+     * @param dirY 1 for positive direction, 0 for no movement, -1 for negative movement
+     * @param dirZ 1 for positive direction, 0 for no movement, -1 for negative movement
+     * @param targetUnits what target units should the command be converted to. Should be the current gcode state (G20 or G21)
+     * @return a string with the complete jog command
+     */
+    public static String generateJogCommand(String command, Units units, double distance, double feedRate, int dirX, int dirY, int dirZ, Units targetUnits) {
+        StringBuilder sb = new StringBuilder();
+
+        // Scale the feed rate and distance to the current coordinate units
+        double scale = UnitUtils.scaleUnits(units, targetUnits);
+        String convertedDistance = Utils.formatter.format(distance * scale);
+        String convertedFeedRate = Utils.formatter.format(feedRate * scale);
+
+        // Set command.
+        sb.append(command);
+
+        if (dirX != 0) {
+            sb.append("X");
+            if (dirX < 0) {
+                sb.append("-");
+            }
+            sb.append(convertedDistance);
+        }
+
+        if (dirY != 0) {
+            sb.append("Y");
+            if (dirY < 0) {
+                sb.append("-");
+            }
+            sb.append(convertedDistance);
+        }
+
+        if (dirZ != 0) {
+            sb.append("Z");
+            if (dirZ < 0) {
+                sb.append("-");
+            }
+            sb.append(convertedDistance);
+        }
+
+        if (convertedFeedRate != null) {
+            sb.append("F").append(convertedFeedRate);
         }
 
         return sb.toString();

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeUtils.java
@@ -40,59 +40,26 @@ public class GcodeUtils {
     }
 
     /**
+     * Generates a jog command given a base command. The command will be appended with the relative movement to be made
+     * for zero to all axises with the given distance and feed rate. This method will add the command to switch units
+     * to the given units. Remember to switch back to previous units after command finishes.
      *
-     * @param command Something like "G0"
-     * @param units Appends "G21" or "G20"
-     * @param distance The distance to use
-     * @param dirX Whether to append the X coord.
-     * @param dirY Whether to append the Y coord.
-     * @param dirZ Whether to append the Z coord.
+     * @param command the base command to use, ie: G91G1
+     * @param units the units that the distance and feed rate are given in. The unit such as "G21" or "G20" will be prepended before the jog command
+     * @param distance the distance to move
+     * @param dirX 1 for positive movement, 0 for no movement, -1 for negative movement
+     * @param dirY 1 for positive movement, 0 for no movement, -1 for negative movement
+     * @param dirZ 1 for positive movement, 0 for no movement, -1 for negative movement
      */
-    public static String generateXYZ(String command, Units units,
-            String distance, String feedRate, int dirX, int dirY, int dirZ) {
-        StringBuilder sb = new StringBuilder();
-
-      // Add units.
-        sb.append(unitCommand(units));
-
-        // Set command.
-        sb.append(command);
-
-        if (dirX != 0) {
-            sb.append("X");
-            if (dirX < 0) {
-                sb.append("-");
-            }
-            sb.append(distance);
-        }
-
-        if (dirY != 0) {
-            sb.append("Y");
-            if (dirY < 0) {
-                sb.append("-");
-            }
-            sb.append(distance);
-        }
-
-        if (dirZ != 0) {
-            sb.append("Z");
-            if (dirZ < 0) {
-                sb.append("-");
-            }
-            sb.append(distance);
-        }
-
-        if (feedRate != null) {
-            sb.append("F").append(feedRate);
-        }
-
-        return sb.toString();
+    public static String generateJogCommand(String command, Units units,
+                                            double distance, double feedRate, int dirX, int dirY, int dirZ) {
+        return generateJogCommand(unitCommand(units) + command, units, distance, feedRate, dirX, dirY, dirZ, units);
     }
 
     /**
-     * Generates a jog command given a base command. THe command will append the relative movement to be made for zero
-     * to all axises the given distance and feed rate. This method will generate the command and convert the distance
-     * and feed rate to the given target units.
+     * Generates a jog command given a base command. The command will be appended with the relative movement to be made
+     * for zero to all axises with the given distance and feed rate. This method will generate the command and convert the
+     * distance and feed rate to the given target units.
      *
      * Ex. If the given distance is 1 inch and the target units is millimeters, the distance will be converted to
      * 25.4mm.
@@ -101,9 +68,9 @@ public class GcodeUtils {
      * @param units the units that the distance and feed rate are given in
      * @param distance the distance to move
      * @param feedRate the feed rate to move with
-     * @param dirX 1 for positive direction, 0 for no movement, -1 for negative movement
-     * @param dirY 1 for positive direction, 0 for no movement, -1 for negative movement
-     * @param dirZ 1 for positive direction, 0 for no movement, -1 for negative movement
+     * @param dirX 1 for positive movement, 0 for no movement, -1 for negative movement
+     * @param dirY 1 for positive movement, 0 for no movement, -1 for negative movement
+     * @param dirZ 1 for positive movement, 0 for no movement, -1 for negative movement
      * @param targetUnits what target units should the command be converted to. Should be the current gcode state (G20 or G21)
      * @return a string with the complete jog command
      */

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeUtils.java
@@ -19,68 +19,47 @@
 package com.willwinder.universalgcodesender.gcode.util;
 
 import com.willwinder.universalgcodesender.Utils;
-import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 
 /**
- *
  * @author wwinder
  */
 public class GcodeUtils {
+
+    /**
+     * Generates a gcode command for switching units.
+     *
+     * @param units the units to switch to
+     * @return the gcode command to switch units.
+     */
     public static String unitCommand(Units units) {
-      // Change units.
-      switch(units) {
-        case MM:
-          return "G21";
-        case INCH:
-          return "G20";
-        default:
-          return "";
-      }
+        // Change units.
+        switch (units) {
+            case MM:
+                return "G21";
+            case INCH:
+                return "G20";
+            default:
+                return "";
+        }
     }
 
     /**
-     * Generates a jog command given a base command. The command will be appended with the relative movement to be made
-     * for zero to all axises with the given distance and feed rate. This method will add the command to switch units
-     * to the given units. Remember to switch back to previous units after command finishes.
+     * Generates a move command given a base command. The command will be appended with the relative movement to be made
+     * on the axises with the given distance and feed rate.
      *
-     * @param command the base command to use, ie: G91G1
-     * @param units the units that the distance and feed rate are given in. The unit such as "G21" or "G20" will be prepended before the jog command
-     * @param distance the distance to move
-     * @param dirX 1 for positive movement, 0 for no movement, -1 for negative movement
-     * @param dirY 1 for positive movement, 0 for no movement, -1 for negative movement
-     * @param dirZ 1 for positive movement, 0 for no movement, -1 for negative movement
+     * @param command  the base command to use, ie: G20G91G1 or G1
+     * @param distance the distance to move in the currently selected unit (G20 or G21)
+     * @param dirX     1 for positive movement, 0 for no movement, -1 for negative movement
+     * @param dirY     1 for positive movement, 0 for no movement, -1 for negative movement
+     * @param dirZ     1 for positive movement, 0 for no movement, -1 for negative movement
      */
-    public static String generateJogCommand(String command, Units units,
-                                            double distance, double feedRate, int dirX, int dirY, int dirZ) {
-        return generateJogCommand(unitCommand(units) + command, units, distance, feedRate, dirX, dirY, dirZ, units);
-    }
-
-    /**
-     * Generates a jog command given a base command. The command will be appended with the relative movement to be made
-     * for zero to all axises with the given distance and feed rate. This method will generate the command and convert the
-     * distance and feed rate to the given target units.
-     *
-     * Ex. If the given distance is 1 inch and the target units is millimeters, the distance will be converted to
-     * 25.4mm.
-     *
-     * @param command the base command to use, ie: G91G1
-     * @param units the units that the distance and feed rate are given in
-     * @param distance the distance to move
-     * @param feedRate the feed rate to move with
-     * @param dirX 1 for positive movement, 0 for no movement, -1 for negative movement
-     * @param dirY 1 for positive movement, 0 for no movement, -1 for negative movement
-     * @param dirZ 1 for positive movement, 0 for no movement, -1 for negative movement
-     * @param targetUnits what target units should the command be converted to. Should be the current gcode state (G20 or G21)
-     * @return a string with the complete jog command
-     */
-    public static String generateJogCommand(String command, Units units, double distance, double feedRate, int dirX, int dirY, int dirZ, Units targetUnits) {
+    public static String generateMoveCommand(String command, double distance, double feedRate, int dirX, int dirY, int dirZ) {
         StringBuilder sb = new StringBuilder();
 
         // Scale the feed rate and distance to the current coordinate units
-        double scale = UnitUtils.scaleUnits(units, targetUnits);
-        String convertedDistance = Utils.formatter.format(distance * scale);
-        String convertedFeedRate = Utils.formatter.format(feedRate * scale);
+        String convertedDistance = Utils.formatter.format(distance);
+        String convertedFeedRate = Utils.formatter.format(feedRate);
 
         // Set command.
         sb.append(command);

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
@@ -19,6 +19,7 @@
 package com.willwinder.universalgcodesender.listeners;
 
 import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.model.UnitUtils;
 
 /**
  *
@@ -35,6 +36,7 @@ public class ControllerStatus {
     private final EnabledPins pins;
     private final AccessoryStates accessoryStates;
     private final ControllerState state;
+    private final UnitUtils.Units feedSpeedUnits;
 
     /**
      * Baseline constructor. This data should always be present. Represents the
@@ -45,14 +47,14 @@ public class ControllerStatus {
      * @param workCoord controller work coordinates
      */
     public ControllerStatus(String stateString, ControllerState state, Position machineCoord, Position workCoord) {
-        this(stateString, state, machineCoord, workCoord, null, null, null, null, null, null);
+        this(stateString, state, machineCoord, workCoord, 0d, UnitUtils.Units.MM, 0d, null, null, null, null);
     }
 
     /**
      * Additional parameters
      */
     public ControllerStatus(String stateString, ControllerState state, Position machineCoord,
-                            Position workCoord, Double feedSpeed, Double spindleSpeed,
+                            Position workCoord, Double feedSpeed, UnitUtils.Units feedSpeedUnits, Double spindleSpeed,
                             OverridePercents overrides, Position workCoordinateOffset,
                             EnabledPins pins, AccessoryStates states) {
         this.stateString = stateString;
@@ -61,6 +63,7 @@ public class ControllerStatus {
         this.workCoord = workCoord;
         this.workCoordinateOffset = workCoordinateOffset;
         this.feedSpeed = feedSpeed;
+        this.feedSpeedUnits = feedSpeedUnits;
         this.spindleSpeed = spindleSpeed;
         this.overrides = overrides;
         this.pins = pins;
@@ -111,6 +114,10 @@ public class ControllerStatus {
 
     public AccessoryStates getAccessoryStates() {
         return accessoryStates;
+    }
+
+    public UnitUtils.Units getFeedSpeedUnits() {
+        return feedSpeedUnits;
     }
 
     public static class EnabledPins {

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
@@ -31,6 +31,7 @@ import static com.willwinder.universalgcodesender.model.Axis.*;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent;
+import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.uielements.components.RoundedPanel;
 import com.willwinder.universalgcodesender.uielements.components.WorkCoordinateTextField;
@@ -383,7 +384,7 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Cont
 
         // Use real-time values if available, otherwise show the target values.
         int feedSpeed = status.getFeedSpeed() != null
-                ? status.getFeedSpeed().intValue()
+                ? (int) (status.getFeedSpeed() * UnitUtils.scaleUnits(status.getFeedSpeedUnits(), backend.getSettings().getPreferredUnits()))
                 : (int) this.backend.getGcodeState().speed;
         this.feedValue.setText(Integer.toString(feedSpeed));
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -349,6 +349,7 @@ public class Settings {
             // Change
             setManualModeStepSize(manualModeStepSize * scaleUnits);
             setzJogStepSize(zJogStepSize * scaleUnits);
+            setJogFeedRate(Math.round(jogFeedRate * scaleUnits));
         }
     }
 

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2018 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -49,5 +49,16 @@ public class GcodeUtilsTest {
         result = GcodeUtils.generateXYZ("G91G0", UnitUtils.Units.MM, "10", "11", 0, -1, -1);
         assertEquals("G21G91G0Y-10Z-10F11", result);
     }
-    
+
+    @Test
+    public void generateJogCommandShouldConvertUnits() {
+        String result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.MM, 25.4, 254, 1, 1, 1, UnitUtils.Units.INCH);
+        assertEquals("Coordinates and feed rate should be converted from MM to Inches","G0X1Y1Z1F10", result);
+
+        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.INCH, 1, 10, 1, 1, 1, UnitUtils.Units.MM);
+        assertEquals("Coordinates and feed rate should be converted from Inches to MM","G0X25.4Y25.4Z25.4F254", result);
+
+        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.MM, 1, 10, 1, 0, 0, UnitUtils.Units.MM);
+        assertEquals("Coordinates and feed rate should be converted from MM to MM","G0X1F10", result);
+    }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeUtilsTest.java
@@ -19,7 +19,6 @@
 package com.willwinder.universalgcodesender.gcode;
 
 import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
-import com.willwinder.universalgcodesender.model.UnitUtils;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -28,37 +27,24 @@ import static org.junit.Assert.*;
  * @author wwinder
  */
 public class GcodeUtilsTest {
-    
-    /**
-     * Test of generateXYZ method, of class GcodeUtils.
-     */
+
     @Test
-    public void generateJogCommandShouldPrependWithUnitCommand() {
-        System.out.println("generateXYZ");
+    public void generateMoveCommand() {
         String result;
 
-        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.INCH, 10, 11, 1, 1, 1);
-        assertEquals("G20G0X10Y10Z10F11", result);
+        result = GcodeUtils.generateMoveCommand("G0", 10, 11, 1, 1, 1);
+        assertEquals("G0X10Y10Z10F11", result);
 
-        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.MM, 10, 11, 1, 1, 1);
-        assertEquals("G21G0X10Y10Z10F11", result);
+        result = GcodeUtils.generateMoveCommand("G0", 10, 11, 1, 1, 1);
+        assertEquals("G0X10Y10Z10F11", result);
 
-        result = GcodeUtils.generateJogCommand("G91G0", UnitUtils.Units.MM, 10, 11, 1, 0, 0);
-        assertEquals("G21G91G0X10F11", result);
+        result = GcodeUtils.generateMoveCommand("G91G0", 10, 11, 1, 0, 0);
+        assertEquals("G91G0X10F11", result);
 
-        result = GcodeUtils.generateJogCommand("G91G0", UnitUtils.Units.MM, 10, 11, 0, -1, -1);
-        assertEquals("G21G91G0Y-10Z-10F11", result);
-    }
+        result = GcodeUtils.generateMoveCommand("G91G0", 10, 11, 0, -1, -1);
+        assertEquals("G91G0Y-10Z-10F11", result);
 
-    @Test
-    public void generateJogCommandShouldConvertUnits() {
-        String result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.MM, 25.4, 254, 1, 1, 1, UnitUtils.Units.INCH);
-        assertEquals("Coordinates and feed rate should be converted from MM to Inches","G0X1Y1Z1F10", result);
-
-        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.INCH, 1, 10, 1, 1, 1, UnitUtils.Units.MM);
-        assertEquals("Coordinates and feed rate should be converted from Inches to MM","G0X25.4Y25.4Z25.4F254", result);
-
-        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.MM, 1, 10, 1, 0, 0, UnitUtils.Units.MM);
-        assertEquals("Coordinates and feed rate should be converted from MM to MM","G0X1F10", result);
+        result = GcodeUtils.generateMoveCommand("G1", 1.1, 11.1, 1, 0, -1);
+        assertEquals("G1X1.1Z-1.1F11.1", result);
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeUtilsTest.java
@@ -33,20 +33,20 @@ public class GcodeUtilsTest {
      * Test of generateXYZ method, of class GcodeUtils.
      */
     @Test
-    public void testGenerateXYZ() {
+    public void generateJogCommandShouldPrependWithUnitCommand() {
         System.out.println("generateXYZ");
         String result;
 
-        result = GcodeUtils.generateXYZ("G0", UnitUtils.Units.INCH, "10", "11", 1, 1, 1);
+        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.INCH, 10, 11, 1, 1, 1);
         assertEquals("G20G0X10Y10Z10F11", result);
 
-        result = GcodeUtils.generateXYZ("G0", UnitUtils.Units.MM, "10", "11", 1, 1, 1);
+        result = GcodeUtils.generateJogCommand("G0", UnitUtils.Units.MM, 10, 11, 1, 1, 1);
         assertEquals("G21G0X10Y10Z10F11", result);
 
-        result = GcodeUtils.generateXYZ("G91G0", UnitUtils.Units.MM, "10", "11", 1, 0, 0);
+        result = GcodeUtils.generateJogCommand("G91G0", UnitUtils.Units.MM, 10, 11, 1, 0, 0);
         assertEquals("G21G91G0X10F11", result);
 
-        result = GcodeUtils.generateXYZ("G91G0", UnitUtils.Units.MM, "10", "11", 0, -1, -1);
+        result = GcodeUtils.generateJogCommand("G91G0", UnitUtils.Units.MM, 10, 11, 0, -1, -1);
         assertEquals("G21G91G0Y-10Z-10F11", result);
     }
 

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
@@ -79,8 +79,9 @@ public class RendererInputHandler implements
         settings = s;
 
         gcodeModel = new GcodeModel(Localization.getString("platform.visualizer.renderable.gcode-model"));
-        sizeDisplay = new SizeDisplay(Localization.getString("platform.visualizer.renderable.gcode-model-size"));
         selection = new Selection(Localization.getString("platform.visualizer.renderable.selection"));
+        sizeDisplay = new SizeDisplay(Localization.getString("platform.visualizer.renderable.gcode-model-size"));
+        sizeDisplay.setUnits(settings.getPreferredUnits());
 
         gr.registerRenderable(gcodeModel);
         gr.registerRenderable(sizeDisplay);
@@ -133,6 +134,10 @@ public class RendererInputHandler implements
             }
 
             animator.resume();
+        }
+
+        if(cse.isSettingChangeEvent()) {
+            sizeDisplay.setUnits(settings.getPreferredUnits());
         }
     }
 
@@ -336,7 +341,6 @@ public class RendererInputHandler implements
      */
     @Override
     public void statusStringListener(ControllerStatus status) {
-        sizeDisplay.setUnits(status.getMachineCoord().getUnits());
         gcodeRenderer.setMachineCoordinate(status.getMachineCoord());
         gcodeRenderer.setWorkCoordinate(status.getWorkCoord());
     }


### PR DESCRIPTION
Added feed speed units to the controller status. These are used by the machine status panel to convert the feed speed units to the user preferences.  

When changing units in the jog panel it will now also convert the feed rate settings.

When jogging in TinyG the coordinate units G20/G21 are no longer changed. The coordinates for the jog command is converted from the user preferences unit to the controller units. Fixes/workaround for the issue synthetos/g2#374

Also added the preferred units to the visualiser, addresses the issue #650 and #978 

Fixes #1010 