### PR TITLE
Update Kotlin 1.1.51 → 1.2.30, drop proprietary import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
     <ugs.maven-compiler-plugin.version>3.6.1</ugs.maven-compiler-plugin.version>
     <ugs.jvm.version>1.8</ugs.jvm.version>
-    <ugs.kotlin.version>1.1.51</ugs.kotlin.version>
+    <ugs.kotlin.version>1.2.30</ugs.kotlin.version>
 
     <!-- supposidly this was needed for the kotlin plugin -->
     <!--

--- a/ugs-platform/DowelModule/src/main/java/com/willwinder/ugs/platform/dowel/DowelGenerator.kt
+++ b/ugs-platform/DowelModule/src/main/java/com/willwinder/ugs/platform/dowel/DowelGenerator.kt
@@ -24,7 +24,6 @@ import com.willwinder.universalgcodesender.model.UnitUtils
 import java.io.PrintWriter
 import java.util.Date
 import javax.vecmath.Point3d
-import sun.misc.Version
 
 /*
 


### PR DESCRIPTION
Hi!

I just tried to build this project from source, on Ubuntu 18.04 & OpenJDK (`version "10.0.1" 2018-04-17`).

It wasn't one-shot success, but with two tiny changes and disabled tests (`mvn package -DskipTests=true`) it worked.

Please consider merging; this makes the build green for me. I've dropped a single line with an unused Sun-specific import, and raised the Kotlin version in `pom.xml` because of a [compiler bug][•].

[•]: https://youtrack.jetbrains.com/issue/KT-21303

The Kotlin's *internal compiler error* looks like this (if anyone would search it):
```
[INFO] Reactor Summary:
[INFO]
[INFO] ugs-parent ......................................... SUCCESS [  0.185 s]
[INFO] ugs-core ........................................... SUCCESS [  8.535 s]
[INFO] ugs-platform-parent ................................ SUCCESS [  2.428 s]
[INFO] ugs-platform-branding .............................. SUCCESS [  4.469 s]
[INFO] ugs-platform-ugslib ................................ SUCCESS [ 30.314 s]
[INFO] ugs-platform-ugscore ............................... SUCCESS [ 18.515 s]
[INFO] ugs-platform-visualizer ............................ SUCCESS [  1.507 s]
[INFO] ugs-platform-plugin-workflow ....................... SUCCESS [  0.862 s]
[INFO] ugs-platform-gcode-editor .......................... SUCCESS [  7.578 s]
[INFO] ugs-platform-surfacescanner ........................ SUCCESS [  1.033 s]
[INFO] ProbeModule ........................................ SUCCESS [  1.140 s]
[INFO] DowelModule ........................................ FAILURE [ 10.303 s]
[INFO] GcodeTools ......................................... SKIPPED
[INFO] ugs-platform-plugin-jog ............................ SKIPPED
[INFO] ugs-platform-plugin-setup-wizard ................... SKIPPED
[INFO] ugs-platform-welcome-page .......................... SKIPPED
[INFO] ugs-platform-app ................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:27 min
[INFO] Finished at: 2018-08-06T20:07:34+03:00
[INFO] Final Memory: 49M/170M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:1.1.51:compile (compile) on project DowelModule: Compilation failure
[ERROR] java.lang.ArrayIndexOutOfBoundsException: 450
[ERROR] ⇥       at org.jetbrains.org.objectweb.asm.ClassReader.readUnsignedShort(ClassReader.java:2464)
[ERROR] ⇥       at org.jetbrains.org.objectweb.asm.ClassReader.readUTF8(ClassReader.java:2525)
[ERROR] ⇥       at org.jetbrains.org.objectweb.asm.ClassReader.readModule(ClassReader.java:761)
[ERROR] ⇥       at org.jetbrains.org.objectweb.asm.ClassReader.accept(ClassReader.java:646)
[ERROR] ⇥       at org.jetbrains.org.objectweb.asm.ClassReader.accept(ClassReader.java:507)
[ERROR] ⇥       at org.jetbrains.kotlin.resolve.jvm.modules.JavaModuleInfo$Companion.read(JavaModuleInfo.kt:67)
[ERROR] ⇥       at org.jetbrains.kotlin.cli.jvm.modules.CliJavaModuleFinder.findSystemModule(CliJavaModuleFinder.kt:44)
[ERROR] ⇥       at org.jetbrains.kotlin.cli.jvm.modules.CliJavaModuleFinder.access$findSystemModule(CliJavaModuleFinder.kt:25)
[ERROR] ⇥       at org.jetbrains.kotlin.cli.jvm.modules.CliJavaModuleFinder$systemModules$1.invoke(CliJavaModuleFinder.kt:37)
[ERROR] ⇥       at org.jetbrains.kotlin.cli.jvm.modules.CliJavaModuleFinder$systemModules$1.invoke(CliJavaModuleFinder.kt:25)
[ERROR] ⇥       at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:148)
[ERROR] ⇥       at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:108)
[ERROR] ⇥       at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:132)
[ERROR] ⇥       at kotlin.sequences.FlatteningSequence$iterator$1.ensureItemIterator(Sequences.kt:253)
[ERROR] ⇥       at kotlin.sequences.FlatteningSequence$iterator$1.hasNext(Sequences.kt:240)
[ERROR] ⇥       at kotlin.sequences.SequencesKt___SequencesKt.none(_Sequences.kt:1239)
[ERROR] ⇥       at org.jetbrains.kotlin.cli.jvm.compiler.ClasspathRootsResolver.addModularRoots(ClasspathRootsResolver.kt:180)
[ERROR] ⇥       at org.jetbrains.kotlin.cli.jvm.compiler.ClasspathRootsResolver.convertClasspathRoots(ClasspathRootsResolver.kt:97)
[ERROR] ⇥       at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.<init>(KotlinCoreEnvironment.kt:215)
[ERROR] ⇥       [...]
```

Perhaps I'll try to look into why the tests won't go as well, but that's for later.

Thanks for your amazing work!