### PR TITLE
Tcpdriver

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/Connection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/Connection.java
@@ -41,6 +41,9 @@ public interface Connection {
      * Example with a serial port using the JSerialComm driver and baud rate 115200
      * jserialcomm://tty.usbmodem1421:115200
      *
+     * Example with a TCP port using TCPConnection driver to example.com and port 9001
+     * tcp://example.com:9001
+     *
      * @param uri the connection uri for the hardware to connect to
      */
     void setUri(String uri);

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/ConnectionDriver.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/ConnectionDriver.java
@@ -25,7 +25,8 @@ package com.willwinder.universalgcodesender.connection;
  */
 public enum ConnectionDriver {
     JSERIALCOMM("JSerialComm", "jserialcomm://"),
-    JSSC("JSSC", "jssc://");
+    JSSC("JSSC", "jssc://"),
+    TCP("TCP", "tcp://");
 
     private final String prettyName;
     private final String protocol;

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/ConnectionFactory.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/ConnectionFactory.java
@@ -63,6 +63,8 @@ public class ConnectionFactory {
             return Optional.of(new JSerialCommConnection());
         } else if (connectionDriver == ConnectionDriver.JSSC) {
             return Optional.of(new JSSCConnection());
+        } else if (connectionDriver == ConnectionDriver.TCP) {
+            return Optional.of(new TCPConnection());
         }
         return Optional.empty();
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.ArrayList;
 
 /**
- * A serial connection object implementing the connection API.
+ * A TCP connection object implementing the connection API.
  *
  * @author Adam Carmicahel <carneeki@carneeki.net>
  */
@@ -56,20 +56,20 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 		} catch (Exception e) {
 			throw new ConnectionException("Couldn't parse connection string " + uri, e);
 		}
-	}
 
-	@Override
-	public boolean openPort() throws Exception {
 		if (StringUtils.isEmpty(host)) {
 			throw new ConnectionException("Empty host in connection string.");
 		}
 		if ((port < 1) || (port > 65535)) {
 			throw new ConnectionException("Please ensure port is a port number between 1 and 65535.");
 		}
+	}
 
+	@Override
+	public boolean openPort() throws Exception {
 		responseMessageHandler = new ResponseMessageHandler();
 
-		try{
+		try {
 			client = new Socket(host, port);
 		} catch( BindException e) {
 			throw new ConnectionException("Could not bind a local port.");

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -80,14 +80,13 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 		} catch (SocketException e) {
 			e.printStackTrace();
 		}
+		if (client == null) {
+			throw new ConnectionException("Socket unable to connect.");
+		}
 
 		bufOut = client.getOutputStream();
 		inStream = new InputStreamReader(client.getInputStream());
 		bufIn = new BufferedReader(inStream);
-
-		if (client == null) {
-			throw new ConnectionException("Socket unable to connect.");
-		}
 
 		// start thread so replies can be handled
 		replyThread = new Thread(this);
@@ -102,11 +101,8 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 			try {
 				replyThread.interrupt();
 				client.close();
-
-				if (client.isConnected()) {
-					replyThread.interrupt();
-					client.close();
-				}
+			} catch (SocketException e) {
+				// ignore socketexception if connection was broken early
 			} finally {
 				client = null;
 			}

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -1,0 +1,154 @@
+/*
+	Copyright 2015-2018 Will Winder
+
+	This file is part of Universal Gcode Sender (UGS).
+
+	UGS is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	UGS is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with UGS. If not, see <http://www.gnu.org/licenses/>.
+*/
+package com.willwinder.universalgcodesender.connection;
+
+import java.nio.channels.SocketChannel;
+import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.net.*;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+
+/**
+ * A serial connection object implementing the connection API.
+ *
+ * @author wwinder
+ */
+public class TCPConnection extends AbstractConnection implements Runnable {
+
+	private String host;
+	private int port;
+
+	// General variables
+	private SocketChannel client;
+	private ByteBuffer bufIn;
+	private ByteBuffer bufOut;
+	private Thread replyThread;
+	private ResponseMessageHandler responseMessageHandler;
+
+	@Override
+	public void setUri(String uri) {
+		try {
+			host = StringUtils.substringBetween(uri, ConnectionDriver.TCP.getProtocol(), ":");
+			port = Integer.valueOf(StringUtils.substringAfterLast(uri, ":"));
+		} catch (Exception e) {
+			throw new ConnectionException("Couldn't parse connection string " + uri, e);
+		}
+	}
+
+	// TODO: ask about renaming the openPort() method to openConnection()
+	@Override
+	public boolean openPort() throws Exception {
+		if (StringUtils.isEmpty(host)) {
+			throw new ConnectionException("Empty host in connection string.");
+		}
+		if ((port >= 1) && (port <= 65535)) {
+			throw new ConnectionException("Please ensure port is a port number between 1 and 65535.");
+		}
+
+		responseMessageHandler = new ResponseMessageHandler();
+
+		try{
+			client = SocketChannel.open(new InetSocketAddress(InetAddress.getByName(host), port));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		bufOut = ByteBuffer.allocate(256);
+		bufIn = ByteBuffer.allocate(256);
+
+		if (client == null) {
+			throw new ConnectionException("Socket unable to connect.");
+		}
+
+		// start thread so replies can be handled
+		replyThread = new Thread(this);
+		replyThread.start();
+
+		return client.isConnected();
+	}
+
+	// TODO: ask about renaming the openPort() method to openConnection()
+	@Override
+	public void closePort() throws Exception {
+		if (client != null) {
+			try {
+				replyThread.stop();
+				client.close();
+
+				if (client.isConnected()) {
+					replyThread.stop();
+					client.close();
+				}
+			} finally {
+				client = null;
+			}
+		}
+	}
+
+	@Override
+	public boolean isOpen() {
+		return client != null && client.isConnected();
+	}
+
+	/**
+	 * Sends a command to remote host.
+	 * @param command Command to be sent to serial device.
+	 */
+	public void sendStringToComm(String command) throws Exception {
+		bufOut.put(command.getBytes());
+		client.write(bufOut);
+		bufOut.clear();
+	}
+
+	/**
+	 * Immediately sends a byte, used for real-time commands.
+	 */
+	public void sendByteImmediately(byte b) throws Exception {
+		bufOut.put(b);
+		client.write(bufOut);
+		bufOut.clear();
+	}
+
+	/**
+	 * Reads data from the remote host.
+	 */
+	public void run() {
+		try {
+			if(client.read(bufIn) != 0)
+			{
+				responseMessageHandler.handleResponse(bufIn.toString(),comm);
+			}
+		} catch ( Exception e ) {
+			e.printStackTrace();
+			System.exit(-1);
+		}
+	}
+
+	// TODO: maybe implement this better?
+	@Override
+	public List<String> getPortNames() {
+		ArrayList<String> retval = new ArrayList<String>();
+		return retval;
+	}
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -126,9 +126,12 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 		try {
 			bufOut.write(command.getBytes());
 			bufOut.flush();
-		} catch (Exception e) {
-			e.printStackTrace();
+		} catch (SocketException e) {
 			closePort(); // very likely we got disconnected, attempt to disconnect gracefully
+			throw e;
+		} catch (IOException e) {
+			closePort(); // very likely we got disconnected, attempt to disconnect gracefully
+			throw e;
 		}
 	}
 
@@ -139,9 +142,12 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 		try {
 			bufOut.write(b);
 			bufOut.flush();
-		} catch (Exception e) {
-			e.printStackTrace();
+		} catch (SocketException e) {
 			closePort(); // very likely we got disconnected, attempt to disconnect gracefully
+			throw e;
+		} catch (IOException e) {
+			closePort(); // very likely we got disconnected, attempt to disconnect gracefully
+			throw e;
 		}
 	}
 
@@ -150,8 +156,7 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 	 */
 	public void run() {
 		String resp;
-		boolean keep_running = true; // loop terminates if false
-		while(!Thread.interrupted() && !client.isClosed() && keep_running)
+		while(!Thread.interrupted() && !client.isClosed())
 		{
 			try {
 				if(inStream.ready() && (resp = bufIn.readLine()) != null) {
@@ -159,11 +164,12 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 				}
 			} catch (SocketException e) {
 				e.printStackTrace();
-				keep_running = false; // terminate thread if disconnected
-									  // TODO: at some point, reconnecting should be considered
+				return; // terminate thread if disconnected
+						//TODO: at some point, reconnecting should be considered
 			} catch (IOException e) {
 				e.printStackTrace();
-				keep_running = false; // terminate thread if we cannot get data out of inStream
+				return; // terminate thread if disconnected
+						//TODO: at some point, reconnecting should be considered
 			}
 		}
 	}

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -111,7 +111,7 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 
 	@Override
 	public boolean isOpen() {
-		return (client != null) && (client.isConnected());
+		return (client != null) && (!client.isClosed());
 	}
 
 	/**
@@ -136,7 +136,7 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 	 */
 	public void run() {
 		String resp;
-		while(!Thread.interrupted() && client.isConnected())
+		while(!Thread.interrupted() && !client.isClosed())
 		{
 			try {
 				while(inStream.ready() && (resp = bufIn.readLine()) != null) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -116,7 +116,7 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 
 	/**
 	 * Sends a command to remote host.
-	 * @param command Command to be sent to serial device.
+	 * @param command Command to be sent to remote host.
 	 */
 	public void sendStringToComm(String command) throws Exception {
 		bufOut.write(command.getBytes());
@@ -132,14 +132,14 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 	}
 
 	/**
-	 * Reads data from the remote host.
+	 * Thread to accept data from remote host, and pass it to responseHandler
 	 */
 	public void run() {
 		String resp;
 		while(!Thread.interrupted() && !client.isClosed())
 		{
 			try {
-				while(inStream.ready() && (resp = bufIn.readLine()) != null) {
+				if(inStream.ready() && (resp = bufIn.readLine()) != null) {
 					responseMessageHandler.handleResponse(resp + "\n", comm);
 				}
 			} catch (SocketException e) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -71,7 +71,13 @@ public class TCPConnection extends AbstractConnection implements Runnable {
 
 		try{
 			client = new Socket(host, port);
-		} catch (IOException e) {
+		} catch( BindException e) {
+			throw new ConnectionException("Could not bind a local port.");
+		} catch( NoRouteToHostException e) {
+			throw new ConnectionException("No route to host. The remote host may not be running, blocked by a firewall, or disconnected.");
+		} catch( PortUnreachableException e) {
+			throw new ConnectionException("The port is unreachable on the remote host. The server may not be running, or blocked by a firewall.");
+		} catch (SocketException e) {
 			e.printStackTrace();
 		}
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -72,11 +72,11 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 		try {
 			client = new Socket(host, port);
 		} catch( BindException e) {
-			throw new ConnectionException("Could not bind a local port.");
+			throw new ConnectionException("Could not bind a local port.", e);
 		} catch( NoRouteToHostException e) {
-			throw new ConnectionException("No route to host. The remote host may not be running, blocked by a firewall, or disconnected.");
-		} catch( PortUnreachableException e) {
-			throw new ConnectionException("The port is unreachable on the remote host. The server may not be running, or blocked by a firewall.");
+			throw new ConnectionException("No route to host. The remote host may not be running, blocked by a firewall, or disconnected.", e);
+		} catch( ConnectException e) {
+			throw new ConnectionException("The port is unreachable on the remote host. The server may not be running, or blocked by a firewall.", e);
 		} catch (SocketException e) {
 			e.printStackTrace();
 		}
@@ -156,6 +156,7 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 	 * TODO: Currently returns an empty list. Finding and enumerating all
 	 *       possible hosts on a network does not seem like a good idea. Ask
 	 *       @winder if an empty list is acceptable.
+	 * Example URI: tcp://examplehost.local/9001
 	 */
 	@Override
 	public List<String> getPortNames() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
  *
  * @author wwinder
  */
-public class TCPConnection extends AbstractConnection implements Runnable {
+public class TCPConnection extends AbstractConnection implements Runnable, Connection {
 
 	private String host;
 	private int port;
@@ -126,7 +126,6 @@ public class TCPConnection extends AbstractConnection implements Runnable {
 	 * @param command Command to be sent to serial device.
 	 */
 	public void sendStringToComm(String command) throws Exception {
-		System.out.println("SEND: " + command);
 		bufOut.write(command.getBytes());
 		bufOut.flush();
 	}
@@ -146,8 +145,7 @@ public class TCPConnection extends AbstractConnection implements Runnable {
 		String resp;
 		try {
 			while( (resp = bufIn.readLine()) != null) {
-				System.out.println("RCVD: " + resp);
-				responseMessageHandler.handleResponse(resp, comm);
+				responseMessageHandler.handleResponse(resp + "\n", comm);
 			}
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/TCPConnection.java
@@ -77,9 +77,8 @@ public class TCPConnection extends AbstractConnection implements Runnable, Conne
 			throw new ConnectionException("No route to host. The remote host may not be running, blocked by a firewall, or disconnected.", e);
 		} catch( ConnectException e) {
 			throw new ConnectionException("The port is unreachable on the remote host. The server may not be running, or blocked by a firewall.", e);
-		} catch (SocketException e) {
-			e.printStackTrace();
 		}
+		
 		if (client == null) {
 			throw new ConnectionException("Socket unable to connect.");
 		}

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionSettingsPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionSettingsPanel.java
@@ -53,7 +53,8 @@ public class ConnectionSettingsPanel extends AbstractUGSSettings {
     private final JComboBox<Language> languageCombo = new JComboBox<>(AvailableLanguages.getAvailableLanguages().toArray(new Language[0]));
     private final JComboBox<String> connectionDriver = new JComboBox<>(new String[]{
             ConnectionDriver.JSSC.getPrettyName(),
-            ConnectionDriver.JSERIALCOMM.getPrettyName()});
+            ConnectionDriver.JSERIALCOMM.getPrettyName(),
+            ConnectionDriver.TCP.getPrettyName(),});
 
     public ConnectionSettingsPanel(Settings settings, IChanged changer) {
         super(settings, changer);

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionSettingsPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionSettingsPanel.java
@@ -87,6 +87,8 @@ public class ConnectionSettingsPanel extends AbstractUGSSettings {
         settings.setLanguage(((Language)languageCombo.getSelectedItem()).getLanguageCode());
         if (connectionDriver.getSelectedItem().equals(ConnectionDriver.JSERIALCOMM.getPrettyName())) {
             settings.setConnectionDriver(ConnectionDriver.JSERIALCOMM);
+        } else if (connectionDriver.getSelectedItem().equals(ConnectionDriver.TCP.getPrettyName())) {
+            settings.setConnectionDriver(ConnectionDriver.TCP);
         } else {
             settings.setConnectionDriver(ConnectionDriver.JSSC);
         }


### PR DESCRIPTION
Add a driver for connecting to a remote target on a TCP port.

Currently this has been tested with GRBL 1.1g connected to a Raspberry Pi 3 which has shared the serial port (`/dev/ttyAMA0`) using the `socat` utility, invoked as follows:
`/usr/bin/socat tcp-l:9001,reuseaddr,fork file:/dev/ttyAMA0,nonblock,b115200,waitlock=/tmp/ttyAMA0.lock`

This shares the serial port on TCP port `9001`, and can be connected with UGS by choosing Tools -> Options, clicking on UGS, and then the Sender Options tab and changing the driver to "TCP". Click OK back to the main screen. Finally, enter the hostname (or IP address) where one would normally enter the serial port, and replace the baudrate with the TCP port.