### PR TITLE
ignore RMB with regards to LongMouseListener, fixes #1132, fixes #1146

### DIFF
--- a/ugs-platform/ugs-platform-plugin-jog/src/main/java/com/willwinder/ugs/nbp/jog/JogPanel.java
+++ b/ugs-platform/ugs-platform-plugin-jog/src/main/java/com/willwinder/ugs/nbp/jog/JogPanel.java
@@ -32,6 +32,7 @@ import org.openide.util.ImageUtilities;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.SwingUtilities; // isLeftMouseButton() isRightMouseButton()
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.io.InputStream;
@@ -233,6 +234,9 @@ public class JogPanel extends JPanel implements SteppedSizeManager.SteppedSizeCh
         LongPressMouseListener longPressMouseListener = new LongPressMouseListener(LONG_PRESS_DELAY) {
             @Override
             protected void onMouseClicked(MouseEvent e) {
+                if(!SwingUtilities.isLeftMouseButton(e)) {
+                    return; // ignore RMB
+                }
                 JogPanelButtonEnum buttonEnum = getButtonEnumFromMouseEvent(e);
                 listeners.forEach(a -> a.onButtonClicked(buttonEnum));
             }
@@ -254,12 +258,18 @@ public class JogPanel extends JPanel implements SteppedSizeManager.SteppedSizeCh
 
             @Override
             protected void onMouseLongPressed(MouseEvent e) {
+                if(!SwingUtilities.isLeftMouseButton(e)) {
+                    return; // ignore RMB
+                }
                 JogPanelButtonEnum buttonEnum = getButtonEnumFromMouseEvent(e);
                 listeners.forEach(a -> a.onButtonLongPressed(buttonEnum));
             }
 
             @Override
             protected void onMouseLongRelease(MouseEvent e) {
+                if(!SwingUtilities.isLeftMouseButton(e)) {
+                    return; // ignore RMB
+                }
                 JogPanelButtonEnum buttonEnum = getButtonEnumFromMouseEvent(e);
                 listeners.forEach(a -> a.onButtonLongReleased(buttonEnum));
             }


### PR DESCRIPTION
This wants some testing on multiple platforms, and also left/right handed configuration. Tested so far:
[x] Linux right handed (@carneeki )
[x] Linux left handed (@carneeki )
[ ] MacOS right handed
[ ] MacOS left handed
[ ] Windows right handed
[ ] Windows left handed

Upon clicking with the secondary mouse button, a small popup to configure separate stepping for Z axis appears. While this was not intended in my fix, I suspect it is a useful thing to have, and it does not result in machine movement. Will remove if requested.