### PR TITLE
Autoleveler fixes

### DIFF
--- a/ugs-core/src/resources/MessagesBundle_en_US.properties
+++ b/ugs-core/src/resources/MessagesBundle_en_US.properties
@@ -391,6 +391,7 @@ autoleveler.panel.use-file = Use Loaded File
 autoleveler.panel.scan-surface = Scan Surface
 autoleveler.panel.apply = Apply to Gcode
 autoleveler.panel.view-data = View Data
+autoleveler.panel.visible = Visible AutoLeveler
 autoleveler.option.z-zero = Z Height of probe surface in gcode
 autoleveler.option.arc-segment-length = Arc line segment length (mm)
 autoleveler.option.offset-x = Probe X offset

--- a/ugs-core/src/resources/MessagesBundle_es_ES.properties
+++ b/ugs-core/src/resources/MessagesBundle_es_ES.properties
@@ -349,6 +349,7 @@ autoleveler.panel.use-file = Fichero de carga usado
 autoleveler.panel.scan-surface = Escaner Superficial
 autoleveler.panel.apply = Aplicar GCode
 autoleveler.panel.view-data = Ver Datos
+autoleveler.panel.visible = ver nivelación
 autoleveler.option.z-zero = Altura Z de la sonda de superficie en gcode
 autoleveler.option.arc-segment-length = Longitud del segmento de línea de arco (mm)
 autoleveler.option.offset-x = Compensación de la sonda X

--- a/ugs-core/src/resources/MessagesBundle_pt_BR.properties
+++ b/ugs-core/src/resources/MessagesBundle_pt_BR.properties
@@ -347,6 +347,7 @@ autoleveler.panel.use-file = Use o arquivo carregado
 autoleveler.panel.scan-surface = Superfície de digitalização
 autoleveler.panel.apply = Aplique o código G
 autoleveler.panel.view-data = Exibir dados
+autoleveler.panel.visible = Visualizar Nivelador
 autoleveler.option.z-zero = Altura "Z" da superfície da sonda no código G
 autoleveler.option.arc-segment-length = Comprimento do segmento da linha do arco (mm)
 autoleveler.option.offset-x = Deslocamento da sonda no "X"

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelPreview.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelPreview.java
@@ -45,7 +45,7 @@ public class AutoLevelPreview extends Renderable {
 
     private float high[] = {0, 255, 0}; // green
     private float low[] = {255, 0, 0}; // red
-
+    
     public AutoLevelPreview(String title) {
         super(10, title);
 

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.form
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.form
@@ -154,9 +154,6 @@
             <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
               <SpinnerModel initial="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
             </Property>
-            <Property name="size" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[33, 26]"/>
-            </Property>
           </Properties>
         </Component>
         <Component class="javax.swing.JSpinner" name="yMin">
@@ -164,18 +161,12 @@
             <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
               <SpinnerModel initial="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
             </Property>
-            <Property name="size" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[33, 26]"/>
-            </Property>
           </Properties>
         </Component>
         <Component class="javax.swing.JSpinner" name="xMin">
           <Properties>
             <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
               <SpinnerModel initial="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
-            </Property>
-            <Property name="size" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[33, 26]"/>
             </Property>
           </Properties>
         </Component>
@@ -189,9 +180,6 @@
             <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
               <SpinnerModel initial="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
             </Property>
-            <Property name="size" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[33, 26]"/>
-            </Property>
           </Properties>
         </Component>
         <Component class="javax.swing.JSpinner" name="yMax">
@@ -199,18 +187,12 @@
             <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
               <SpinnerModel initial="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
             </Property>
-            <Property name="size" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[33, 26]"/>
-            </Property>
           </Properties>
         </Component>
         <Component class="javax.swing.JSpinner" name="zMax">
           <Properties>
             <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
               <SpinnerModel initial="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
-            </Property>
-            <Property name="size" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[33, 26]"/>
             </Property>
           </Properties>
         </Component>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.form
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.form
@@ -51,17 +51,9 @@
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Group type="102" alignment="1" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="xLabel" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="minLabel" min="-2" max="-2" attributes="0"/>
-                              <Component id="xMin" pref="106" max="32767" attributes="0"/>
-                          </Group>
-                      </Group>
                       <Group type="102" alignment="0" attributes="0">
                           <Component id="zLabel" min="-2" max="-2" attributes="0"/>
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
@@ -72,37 +64,55 @@
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
                           <Component id="yMin" max="32767" attributes="0"/>
                       </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <Component id="xLabel" min="-2" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Group type="102" attributes="0">
+                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <Component id="minLabel" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace pref="93" max="32767" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <EmptySpace min="-2" pref="13" max="-2" attributes="0"/>
+                                  <Component id="xMin" max="32767" attributes="0"/>
+                              </Group>
+                          </Group>
+                      </Group>
                   </Group>
                   <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="maxLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                       <Component id="yMax" alignment="0" pref="107" max="32767" attributes="0"/>
-                      <Component id="xMax" alignment="0" max="32767" attributes="0"/>
                       <Component id="zMax" alignment="0" max="32767" attributes="0"/>
+                      <Group type="102" alignment="1" attributes="0">
+                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                          <Component id="xMax" min="-2" pref="105" max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace min="-2" pref="2" max="-2" attributes="0"/>
+                          <Component id="maxLabel" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                      </Group>
                   </Group>
-                  <EmptySpace min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+              </Group>
+              <Group type="102" alignment="1" attributes="0">
+                  <EmptySpace max="32767" attributes="0"/>
+                  <Component id="visibleAutoLeveler" min="-2" pref="197" max="-2" attributes="0"/>
+                  <EmptySpace min="-2" pref="31" max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
+                  <EmptySpace min="-2" pref="13" max="-2" attributes="0"/>
+                  <Component id="visibleAutoLeveler" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="1" attributes="0">
                       <Group type="102" attributes="0">
                           <Component id="maxLabel" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace min="-2" pref="9" max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="0" attributes="0">
-                              <Group type="102" alignment="0" attributes="0">
-                                  <EmptySpace min="67" pref="67" max="-2" attributes="0"/>
-                                  <Component id="zMax" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                              <Group type="102" alignment="0" attributes="0">
-                                  <Component id="xMax" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace min="-2" pref="9" max="-2" attributes="0"/>
-                                  <Component id="yMax" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                          </Group>
+                          <EmptySpace min="-2" pref="79" max="-2" attributes="0"/>
+                          <Component id="zMax" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <Group type="102" attributes="0">
                           <Component id="minLabel" min="-2" max="-2" attributes="0"/>
@@ -110,11 +120,13 @@
                           <Group type="103" groupAlignment="3" attributes="0">
                               <Component id="xLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                               <Component id="xMin" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="xMax" alignment="3" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="-2" pref="9" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="3" attributes="0">
                               <Component id="yLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                               <Component id="yMin" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="yMax" alignment="3" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="3" attributes="0">
@@ -196,6 +208,15 @@
             </Property>
           </Properties>
         </Component>
+        <Component class="javax.swing.JCheckBox" name="visibleAutoLeveler">
+          <Properties>
+            <Property name="selected" type="boolean" value="true"/>
+            <Property name="text" type="java.lang.String" value="Visible AutoLeveler"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="visibleAutoLevelerActionPerformed"/>
+          </Events>
+        </Component>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="jPanel2">
@@ -210,16 +231,13 @@
                       <Component id="settingsButton" alignment="0" max="32767" attributes="0"/>
                       <Group type="102" attributes="0">
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Group type="102" alignment="0" attributes="0">
-                                  <Component id="resolutionLabel" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace min="-2" pref="40" max="-2" attributes="0"/>
-                                  <Component id="stepResolution" min="-2" pref="109" max="-2" attributes="0"/>
-                              </Group>
-                              <Group type="102" alignment="0" attributes="0">
-                                  <Component id="zSurfaceLabel" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="zSurface" min="-2" pref="109" max="-2" attributes="0"/>
-                              </Group>
+                              <Component id="resolutionLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="zSurfaceLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                          <EmptySpace min="-2" pref="30" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Component id="stepResolution" min="-2" pref="119" max="-2" attributes="0"/>
+                              <Component id="zSurface" min="-2" pref="119" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                       </Group>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.form
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.form
@@ -55,16 +55,6 @@
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Group type="102" alignment="0" attributes="0">
-                          <Component id="zLabel" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                          <Component id="zMin" max="32767" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="yLabel" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                          <Component id="yMin" max="32767" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
                           <Component id="xLabel" min="-2" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Group type="102" attributes="0">
@@ -72,33 +62,45 @@
                                   <Component id="minLabel" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace pref="93" max="32767" attributes="0"/>
                               </Group>
-                              <Group type="102" attributes="0">
-                                  <EmptySpace min="-2" pref="13" max="-2" attributes="0"/>
-                                  <Component id="xMin" max="32767" attributes="0"/>
+                              <Group type="102" alignment="1" attributes="0">
+                                  <EmptySpace max="32767" attributes="0"/>
+                                  <Component id="xMin" min="-2" pref="113" max="-2" attributes="0"/>
+                                  <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
                               </Group>
                           </Group>
                       </Group>
+                      <Group type="102" alignment="1" attributes="0">
+                          <Group type="103" groupAlignment="1" attributes="0">
+                              <Group type="102" alignment="1" attributes="0">
+                                  <Component id="zLabel" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <Component id="zMin" max="32767" attributes="0"/>
+                              </Group>
+                              <Group type="102" alignment="0" attributes="0">
+                                  <Component id="yLabel" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <Component id="yMin" max="32767" attributes="0"/>
+                              </Group>
+                          </Group>
+                          <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
+                      </Group>
                   </Group>
-                  <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="yMax" alignment="0" pref="107" max="32767" attributes="0"/>
                       <Component id="zMax" alignment="0" max="32767" attributes="0"/>
-                      <Group type="102" alignment="1" attributes="0">
-                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                          <Component id="xMax" min="-2" pref="105" max="-2" attributes="0"/>
-                      </Group>
                       <Group type="102" alignment="0" attributes="0">
                           <EmptySpace min="-2" pref="2" max="-2" attributes="0"/>
                           <Component id="maxLabel" min="-2" max="-2" attributes="0"/>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                       </Group>
+                      <Component id="xMax" alignment="1" max="32767" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
               </Group>
               <Group type="102" alignment="1" attributes="0">
                   <EmptySpace max="32767" attributes="0"/>
-                  <Component id="visibleAutoLeveler" min="-2" pref="197" max="-2" attributes="0"/>
-                  <EmptySpace min="-2" pref="31" max="-2" attributes="0"/>
+                  <Component id="visibleAutoLeveler" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -292,7 +294,7 @@
         <Component class="javax.swing.JSpinner" name="zSurface">
           <Properties>
             <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-              <SpinnerModel initial="0.0" minimum="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
+              <SpinnerModel initial="0.0" numberType="java.lang.Double" stepSize="1.0" type="number"/>
             </Property>
           </Properties>
         </Component>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
@@ -136,6 +136,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         this.dataViewer.setText(Localization.getString("autoleveler.panel.view-data"));
         this.settingsButton.setText(Localization.getString("mainWindow.swing.settingsMenu"));
         this.generateTestDataButton.setText("Generate Test Data");
+        this.visibleAutoLeveler.setText(Localization.getString("autoleveler.panel.visible"));
     }
 
     private void updateSettings() {

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
@@ -161,8 +161,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         if (evt.isProbeEvent()) {
             if (!scanner.isCollectedAllProbe()) return;
             
-            // position work
-            Position probe = backend.getWorkPosition();
+            Position probe = evt.getProbePosition();
             Position offset = this.settings.getAutoLevelSettings().autoLevelProbeOffset;
 
             if (probe.getUnits() == Units.UNKNOWN || offset.getUnits() == Units.UNKNOWN) {
@@ -330,39 +329,40 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
                 .addContainerGap()
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(jPanel1Layout.createSequentialGroup()
-                        .addComponent(zLabel)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                        .addComponent(zMin))
-                    .addGroup(jPanel1Layout.createSequentialGroup()
-                        .addComponent(yLabel)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                        .addComponent(yMin))
-                    .addGroup(jPanel1Layout.createSequentialGroup()
                         .addComponent(xLabel)
                         .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addGroup(jPanel1Layout.createSequentialGroup()
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                                 .addComponent(minLabel)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 93, Short.MAX_VALUE))
+                            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .addComponent(xMin, javax.swing.GroupLayout.PREFERRED_SIZE, 113, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGap(4, 4, 4))))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
+                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                             .addGroup(jPanel1Layout.createSequentialGroup()
-                                .addGap(13, 13, 13)
-                                .addComponent(xMin)))))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addComponent(zLabel)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addComponent(zMin))
+                            .addGroup(javax.swing.GroupLayout.Alignment.LEADING, jPanel1Layout.createSequentialGroup()
+                                .addComponent(yLabel)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addComponent(yMin)))
+                        .addGap(4, 4, 4)))
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(yMax, javax.swing.GroupLayout.DEFAULT_SIZE, 107, Short.MAX_VALUE)
                     .addComponent(zMax)
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
-                        .addGap(0, 0, Short.MAX_VALUE)
-                        .addComponent(xMax, javax.swing.GroupLayout.PREFERRED_SIZE, 105, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(jPanel1Layout.createSequentialGroup()
                         .addGap(2, 2, 2)
                         .addComponent(maxLabel)
-                        .addGap(0, 0, Short.MAX_VALUE)))
+                        .addGap(0, 0, Short.MAX_VALUE))
+                    .addComponent(xMax, javax.swing.GroupLayout.Alignment.TRAILING))
                 .addContainerGap())
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(visibleAutoLeveler, javax.swing.GroupLayout.PREFERRED_SIZE, 197, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(31, 31, 31))
+                .addComponent(visibleAutoLeveler)
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -400,7 +400,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
 
         org.openide.awt.Mnemonics.setLocalizedText(zSurfaceLabel, "Z Surface:");
 
-        zSurface.setModel(new javax.swing.SpinnerNumberModel(0.0d, 0.0d, null, 1.0d));
+        zSurface.setModel(new javax.swing.SpinnerNumberModel(0.0d, null, null, 1.0d));
 
         org.openide.awt.Mnemonics.setLocalizedText(dataViewer, "View Data");
         dataViewer.addActionListener(new java.awt.event.ActionListener() {
@@ -559,7 +559,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         updateScanner(u);
 
         try {
-            scanner.enableCollectProbe();
+            scanner.enableCollectProbe(backend.getWorkPosition(), backend.getMachinePosition());
             
             AutoLevelSettings als = settings.getAutoLevelSettings();
             for (Position p : scanner.getProbeStartPositions()) {

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
@@ -276,6 +276,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         xMax = new javax.swing.JSpinner();
         yMax = new javax.swing.JSpinner();
         zMax = new javax.swing.JSpinner();
+        visibleAutoLeveler = new javax.swing.JCheckBox();
         jPanel2 = new javax.swing.JPanel();
         resolutionLabel = new javax.swing.JLabel();
         stepResolution = new javax.swing.JSpinner();
@@ -300,38 +301,34 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         org.openide.awt.Mnemonics.setLocalizedText(zLabel, "Z");
 
         zMin.setModel(new javax.swing.SpinnerNumberModel(0.0d, null, null, 1.0d));
-        zMin.setSize(new java.awt.Dimension(33, 26));
 
         yMin.setModel(new javax.swing.SpinnerNumberModel(0.0d, null, null, 1.0d));
-        yMin.setSize(new java.awt.Dimension(33, 26));
 
         xMin.setModel(new javax.swing.SpinnerNumberModel(0.0d, null, null, 1.0d));
-        xMin.setSize(new java.awt.Dimension(33, 26));
 
         org.openide.awt.Mnemonics.setLocalizedText(maxLabel, "Max");
 
         xMax.setModel(new javax.swing.SpinnerNumberModel(0.0d, null, null, 1.0d));
-        xMax.setSize(new java.awt.Dimension(33, 26));
 
         yMax.setModel(new javax.swing.SpinnerNumberModel(0.0d, null, null, 1.0d));
-        yMax.setSize(new java.awt.Dimension(33, 26));
 
         zMax.setModel(new javax.swing.SpinnerNumberModel(0.0d, null, null, 1.0d));
-        zMax.setSize(new java.awt.Dimension(33, 26));
+
+        visibleAutoLeveler.setSelected(true);
+        org.openide.awt.Mnemonics.setLocalizedText(visibleAutoLeveler, "Visible AutoLeveler");
+        visibleAutoLeveler.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                visibleAutoLevelerActionPerformed(evt);
+            }
+        });
 
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel1Layout.createSequentialGroup()
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(jPanel1Layout.createSequentialGroup()
-                        .addComponent(xLabel)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(minLabel)
-                            .addComponent(xMin, javax.swing.GroupLayout.DEFAULT_SIZE, 106, Short.MAX_VALUE)))
                     .addGroup(jPanel1Layout.createSequentialGroup()
                         .addComponent(zLabel)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
@@ -339,41 +336,57 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
                     .addGroup(jPanel1Layout.createSequentialGroup()
                         .addComponent(yLabel)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                        .addComponent(yMin)))
+                        .addComponent(yMin))
+                    .addGroup(jPanel1Layout.createSequentialGroup()
+                        .addComponent(xLabel)
+                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(jPanel1Layout.createSequentialGroup()
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addComponent(minLabel)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 93, Short.MAX_VALUE))
+                            .addGroup(jPanel1Layout.createSequentialGroup()
+                                .addGap(13, 13, 13)
+                                .addComponent(xMin)))))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(maxLabel)
                     .addComponent(yMax, javax.swing.GroupLayout.DEFAULT_SIZE, 107, Short.MAX_VALUE)
-                    .addComponent(xMax)
-                    .addComponent(zMax))
+                    .addComponent(zMax)
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
+                        .addGap(0, 0, Short.MAX_VALUE)
+                        .addComponent(xMax, javax.swing.GroupLayout.PREFERRED_SIZE, 105, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(jPanel1Layout.createSequentialGroup()
+                        .addGap(2, 2, 2)
+                        .addComponent(maxLabel)
+                        .addGap(0, 0, Short.MAX_VALUE)))
                 .addContainerGap())
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(visibleAutoLeveler, javax.swing.GroupLayout.PREFERRED_SIZE, 197, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(31, 31, 31))
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jPanel1Layout.createSequentialGroup()
-                .addContainerGap()
+                .addGap(13, 13, 13)
+                .addComponent(visibleAutoLeveler)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                     .addGroup(jPanel1Layout.createSequentialGroup()
                         .addComponent(maxLabel)
-                        .addGap(9, 9, 9)
-                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(jPanel1Layout.createSequentialGroup()
-                                .addGap(67, 67, 67)
-                                .addComponent(zMax, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                            .addGroup(jPanel1Layout.createSequentialGroup()
-                                .addComponent(xMax, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addGap(9, 9, 9)
-                                .addComponent(yMax, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                        .addGap(79, 79, 79)
+                        .addComponent(zMax, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(jPanel1Layout.createSequentialGroup()
                         .addComponent(minLabel)
                         .addGap(9, 9, 9)
                         .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                             .addComponent(xLabel)
-                            .addComponent(xMin, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(xMin, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(xMax, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addGap(9, 9, 9)
                         .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                             .addComponent(yLabel)
-                            .addComponent(yMin, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(yMin, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(yMax, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                             .addComponent(zLabel)
@@ -421,14 +434,12 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
                     .addComponent(settingsButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addGroup(jPanel2Layout.createSequentialGroup()
                         .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(jPanel2Layout.createSequentialGroup()
-                                .addComponent(resolutionLabel)
-                                .addGap(40, 40, 40)
-                                .addComponent(stepResolution, javax.swing.GroupLayout.PREFERRED_SIZE, 109, javax.swing.GroupLayout.PREFERRED_SIZE))
-                            .addGroup(jPanel2Layout.createSequentialGroup()
-                                .addComponent(zSurfaceLabel)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(zSurface, javax.swing.GroupLayout.PREFERRED_SIZE, 109, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                            .addComponent(resolutionLabel)
+                            .addComponent(zSurfaceLabel))
+                        .addGap(30, 30, 30)
+                        .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(stepResolution, javax.swing.GroupLayout.PREFERRED_SIZE, 119, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(zSurface, javax.swing.GroupLayout.PREFERRED_SIZE, 119, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addGap(0, 0, Short.MAX_VALUE))
                     .addComponent(generateTestDataButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
@@ -652,6 +663,10 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         }
     }//GEN-LAST:event_generateTestDataButtonActionPerformed
 
+    private void visibleAutoLevelerActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_visibleAutoLevelerActionPerformed
+        r.setEnabled(visibleAutoLeveler.isSelected());
+    }//GEN-LAST:event_visibleAutoLevelerActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton applyToGcode;
     private javax.swing.JButton dataViewer;
@@ -669,6 +684,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
     private javax.swing.JRadioButton unitInch;
     private javax.swing.JRadioButton unitMM;
     private javax.swing.JButton useLoadedFile;
+    private javax.swing.JCheckBox visibleAutoLeveler;
     private javax.swing.JLabel xLabel;
     private javax.swing.JSpinner xMax;
     private javax.swing.JSpinner xMin;

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
@@ -85,7 +85,6 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
 
     // Used to disable the change listener temporarily.
     private boolean bulkChanges = false;
-    boolean scanningSurface = false;
 
     public final static String AutoLevelerTitle = Localization.getString("platform.window.autoleveler", lang);
     public final static String AutoLevelerTooltip = Localization.getString("platform.window.autoleveler.tooltip", lang);
@@ -160,9 +159,10 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
     @Override
     public void UGSEvent(UGSEvent evt) {
         if (evt.isProbeEvent()) {
-            if (!scanningSurface) return;
-
-            Position probe = evt.getProbePosition();
+            if (!scanner.isCollectedAllProbe()) return;
+            
+            // position work
+            Position probe = backend.getWorkPosition();
             Position offset = this.settings.getAutoLevelSettings().autoLevelProbeOffset;
 
             if (probe.getUnits() == Units.UNKNOWN || offset.getUnits() == Units.UNKNOWN) {
@@ -544,11 +544,11 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
             return;
         }
 
-        scanningSurface = true;
         Units u = this.unitMM.isSelected() ? Units.MM : Units.INCH;
         updateScanner(u);
-        
+
         try {
+            scanner.enableCollectProbe();
             
             AutoLevelSettings als = settings.getAutoLevelSettings();
             for (Position p : scanner.getProbeStartPositions()) {
@@ -558,8 +558,6 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
             }
         } catch (Exception ex) {
             Exceptions.printStackTrace(ex);
-        } finally {
-            scanningSurface = false;
         }
     }//GEN-LAST:event_scanSurfaceButtonActionPerformed
 
@@ -641,6 +639,8 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         if(scanner.getProbeStartPositions() == null)
             return;
 
+        scanner.enableTestProbe();
+        
         // Generate some random test data.
         Random random = new Random();
 

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
@@ -181,6 +181,10 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         else if(evt.isSettingChangeEvent()) {
             updateSettings();
         }
+        
+        else if(evt.isFileChangeEvent()){
+            applyToGcode.setEnabled(true);
+        }
     }
 
     private double getValue(JSpinner spinner) {
@@ -601,6 +605,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
 
         try {
             backend.applyGcodeParser(gcp);
+            applyToGcode.setEnabled(false);
         } catch (Exception ex) {
             GUIHelpers.displayErrorDialog(ex.getMessage());
             Exceptions.printStackTrace(ex);

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
@@ -242,7 +242,8 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
     @Override
     public void stateChanged(ChangeEvent e) {
         // This state change handler is only for the visualizer.
-        if (bulkChanges || scanner == null) {
+        // prevent infinite loop, only call when the stateChange event was triggered by a swing component.
+        if (bulkChanges || scanner == null || e == null) {
             return;
         }
 
@@ -252,10 +253,7 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         autoLevelSettings.zSurface = getValue(this.zSurface);
         autoLevelSettings.stepResolution = getValue(this.stepResolution);
 
-        // prevent infinite loop, only call when the stateChange event was triggered by a swing component.
-        if (e != null) {
-            settings.setAutoLevelSettings(autoLevelSettings);
-        }
+        settings.setAutoLevelSettings(autoLevelSettings);
     }
 
     /**
@@ -547,8 +545,11 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
         }
 
         scanningSurface = true;
+        Units u = this.unitMM.isSelected() ? Units.MM : Units.INCH;
+        updateScanner(u);
+        
         try {
-            Units u = this.unitMM.isSelected() ? Units.MM : Units.INCH;
+            
             AutoLevelSettings als = settings.getAutoLevelSettings();
             for (Position p : scanner.getProbeStartPositions()) {
                 backend.sendGcodeCommand(true, String.format("G90 G21 G0 X%f Y%f Z%f", p.x, p.y, p.z));
@@ -637,6 +638,9 @@ public final class AutoLevelerTopComponent extends TopComponent implements ItemL
     }//GEN-LAST:event_useLoadedFileActionPerformed
 
     private void generateTestDataButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_generateTestDataButtonActionPerformed
+        if(scanner.getProbeStartPositions() == null)
+            return;
+
         // Generate some random test data.
         Random random = new Random();
 

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
@@ -37,6 +37,7 @@ public class SurfaceScanner {
     private Units u = null;
     private Position minXYZ = null;
     private Position maxXYZ = null;
+    private Position probeOffset = null;
     private double resolution = 1;
     private double probeDistance = 0;
     private int yAxisPoints = -1;
@@ -46,9 +47,15 @@ public class SurfaceScanner {
     
     public SurfaceScanner(Units u) {
         this.u = u;
+        probeOffset = new Position();
     }
 
     public void probeEvent(final Position p) {      
+        Position pOffset = new Position(
+                p.x + probeOffset.x, 
+                p.y + probeOffset.y, 
+                p.z + probeOffset.z, u);
+        
         Position pCount = probePositions.asList().get(countProbe);
         
         double pCountMinX = pCount.x - STEP_OFFSET;
@@ -56,11 +63,11 @@ public class SurfaceScanner {
         double pCountMinY = pCount.y - STEP_OFFSET;
         double pCountMaxY = pCount.y + STEP_OFFSET;
               
-        if(p.x >= pCountMinX && p.x <= pCountMaxX &&
-           p.y >= pCountMinY && p.y <= pCountMaxY)
+        if(pOffset.x >= pCountMinX && pOffset.x <= pCountMaxX &&
+           pOffset.y >= pCountMinY && pOffset.y <= pCountMaxY)
         {
-            probePositionGrid[countProbe / yAxisPoints][countProbe % yAxisPoints] = p.getPositionIn(u);
-            pCount.z = p.z;
+            probePositionGrid[countProbe / yAxisPoints][countProbe % yAxisPoints] = pOffset.getPositionIn(u);
+            pCount.z = pOffset.z;
             
             countProbe++;
             if(countProbe >= probePositions.size())
@@ -125,12 +132,18 @@ public class SurfaceScanner {
     }
     
 
-    public void enableCollectProbe(){
+    public void enableCollectProbe(Position work, Position machine){
+        probeOffset.x = (-1 * machine.x) + work.x;
+        probeOffset.y = (-1 * machine.y) + work.y;
+        probeOffset.z = (-1 * machine.z) + work.z;
         countProbe = 0;
         scanningSurface = true;
     }
 
     public void enableTestProbe(){
+        probeOffset.x = 0;
+        probeOffset.y = 0;
+        probeOffset.z = 0;
         countProbe = 0;
     }
     

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
@@ -77,10 +77,6 @@ public class SurfaceScanner {
         Position newMin = new Position(minx, miny, minz, units);
         Position newMax = new Position(maxx, maxy, maxz, units);
 
-        // Make sure the position changed before resetting things.
-        if (newMin.equals(this.minXYZ) && newMax.equals(this.maxXYZ) && this.resolution == resolution) {
-            return;
-        }
 
         this.minXYZ = newMin;
         this.maxXYZ = newMax;

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
@@ -34,7 +34,7 @@ public class SurfaceScanner {
     // step error 
     final private static double STEP_OFFSET = 1;
     
-    private Units u = null;
+    private Units units = null;
     private Position minXYZ = null;
     private Position maxXYZ = null;
     private Position probeOffset = null;
@@ -45,8 +45,7 @@ public class SurfaceScanner {
     private int countProbe = 0;
     private boolean scanningSurface = false;
     
-    public SurfaceScanner(Units u) {
-        this.u = u;
+    public SurfaceScanner() {
         probeOffset = new Position();
     }
 
@@ -54,7 +53,7 @@ public class SurfaceScanner {
         Position pOffset = new Position(
                 p.x + probeOffset.x, 
                 p.y + probeOffset.y, 
-                p.z + probeOffset.z, u);
+                p.z + probeOffset.z, Units.MM).getPositionIn(units);
         
         Position pCount = probePositions.asList().get(countProbe);
         
@@ -66,7 +65,7 @@ public class SurfaceScanner {
         if(pOffset.x >= pCountMinX && pOffset.x <= pCountMaxX &&
            pOffset.y >= pCountMinY && pOffset.y <= pCountMaxY)
         {
-            probePositionGrid[countProbe / yAxisPoints][countProbe % yAxisPoints] = pOffset.getPositionIn(u);
+            probePositionGrid[countProbe / yAxisPoints][countProbe % yAxisPoints] = pOffset.getPositionIn(units);
             pCount.z = pOffset.z;
             
             countProbe++;
@@ -75,20 +74,21 @@ public class SurfaceScanner {
             
         } else{
             scanningSurface = false;
+            throw new IllegalArgumentException("Error in probe reference.");
         }
     }
 
     /**
      * Provides two points of the scanners bounding box and the number of points to sample in the X/Y directions.
      */
-    public void update(final Position corner1, final Position corner2, double resolution) {
+    public void update(final Position corner1, final Position corner2, double resolution, Units units) {
         if (corner1.getUnits() != corner2.getUnits()) {
             throw new IllegalArgumentException("Provide same unit for both measures.");
         }
-
+        this.units = units;
+        
         if (resolution == 0) return;
 
-        Units units = corner1.getUnits();
         double minx = Math.min(corner1.x, corner2.x);
         double maxx = Math.max(corner1.x, corner2.x);
         double miny = Math.min(corner1.y, corner2.y);
@@ -176,6 +176,6 @@ public class SurfaceScanner {
     }
 
     public final Units getUnits() {
-        return u;
+        return units;
     }
 }


### PR DESCRIPTION
Hello, all right? 

I made some autoleveler corrections that appeared for Min, if you can look at this, maybe I can help you.

Fixes:

-Clean autolever before applying surface leveling.

-Disable function to apply to Gcode when already applied.

-Correction of Probe collection:
	-Collect all measurement points.
	-Returns values from the job and not from the machine.

-Add checkbox to Autoleveler visible.

-inch scale.