### PR TITLE
Bugfix/connection driver

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -462,7 +462,7 @@ public class Settings {
     }
 
     public ConnectionDriver getConnectionDriver() {
-        ConnectionDriver connectionDriver = ConnectionDriver.JSSC;
+        ConnectionDriver connectionDriver = ConnectionDriver.JSERIALCOMM;
         if (StringUtils.isNotEmpty(this.connectionDriver)) {
             try {
                 connectionDriver = ConnectionDriver.valueOf(this.connectionDriver);

--- a/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
@@ -140,7 +140,7 @@ public class AbstractControllerTest {
         expect(expectLastCall()).anyTimes();
         mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall()).anyTimes();
-        expect(mockCommunicator.openCommPort(ConnectionDriver.JSSC, port, portRate)).andReturn(true).once();
+        expect(mockCommunicator.openCommPort(ConnectionDriver.JSERIALCOMM, port, portRate)).andReturn(true).once();
         expect(instance.isCommOpen()).andReturn(false).once();
         expect(instance.isCommOpen()).andReturn(true).anyTimes();
         expect(instance.handlesAllStateChangeEvents()).andReturn(handleStateChange).anyTimes();
@@ -235,7 +235,7 @@ public class AbstractControllerTest {
         // Message for open and close.
         mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall()).times(2);
-        expect(mockCommunicator.openCommPort(ConnectionDriver.JSSC, port, baud)).andReturn(true).once();
+        expect(mockCommunicator.openCommPort(ConnectionDriver.JSERIALCOMM, port, baud)).andReturn(true).once();
         mockCommunicator.closeCommPort();
         expect(expectLastCall()).once();
         replay(instance, mockCommunicator, mockListener);


### PR DESCRIPTION
Fixes #940 and makes JSerialComm as the default driver. This will only have effect if the user is missing the ugs-settings directory and the default settings are loaded.