### PR TITLE
Remove option for display state color

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MainWindow.java
@@ -1644,24 +1644,19 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
     }
 
     private void setStatusColorForState(ControllerState state) {
-        if (settings.isDisplayStateColor()) {
-            java.awt.Color color = null; // default to a transparent background.
-            if (state == ControllerState.ALARM) {
-                color = Color.RED;
-            } else if (state == ControllerState.HOLD || state == ControllerState.DOOR || state == ControllerState.SLEEP) {
-                color = Color.YELLOW;
-            } else if (state == ControllerState.RUN || state == ControllerState.JOG || state == ControllerState.HOME) {
-                color = Color.GREEN;
-            } else {
-                color = Color.WHITE;
-            }
-
-            this.activeStateLabel.setBackground(color);
-            this.activeStateValueLabel.setBackground(color);
+        Color color = null; // default to a transparent background.
+        if (state == ControllerState.ALARM) {
+            color = Color.RED;
+        } else if (state == ControllerState.HOLD || state == ControllerState.DOOR || state == ControllerState.SLEEP) {
+            color = Color.YELLOW;
+        } else if (state == ControllerState.RUN || state == ControllerState.JOG || state == ControllerState.HOME) {
+            color = Color.GREEN;
         } else {
-            this.activeStateLabel.setBackground(null);
-            this.activeStateValueLabel.setBackground(null);
+            color = Color.WHITE;
         }
+
+        this.activeStateLabel.setBackground(color);
+        this.activeStateValueLabel.setBackground(color);
     }
     
     private void updateControls() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionSettingsPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ConnectionSettingsPanel.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2019 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -46,8 +46,6 @@ public class ConnectionSettingsPanel extends AbstractUGSSettings {
     private final Spinner statusPollRate = new Spinner(
                 Localization.getString("sender.status.rate"),
                 new SpinnerNumberModel(1, 1, null, 100));
-    private final Checkbox stateColorDisplayEnabled = new Checkbox(
-                Localization.getString("sender.state"));
     private final Checkbox showNightlyWarning = new Checkbox(
                 Localization.getString("sender.nightly-warning"));
     private final JComboBox<Language> languageCombo = new JComboBox<>(AvailableLanguages.getAvailableLanguages().toArray(new Language[0]));
@@ -81,7 +79,6 @@ public class ConnectionSettingsPanel extends AbstractUGSSettings {
         settings.setSingleStepMode(singleStepMode.getValue());
         settings.setStatusUpdatesEnabled(statusPollingEnabled.getValue());
         settings.setStatusUpdateRate((int)statusPollRate.getValue());
-        settings.setDisplayStateColor(stateColorDisplayEnabled.getValue());
         //settings.setAutoConnectEnabled(autoConnect.getValue());
         settings.setShowNightlyWarning(showNightlyWarning.getValue());
         settings.setLanguage(((Language)languageCombo.getSelectedItem()).getLanguageCode());
@@ -121,9 +118,6 @@ public class ConnectionSettingsPanel extends AbstractUGSSettings {
 
         statusPollRate.setValue(s.getStatusUpdateRate());
         add(statusPollRate, "spanx, wrap");
-
-        stateColorDisplayEnabled.setSelected(s.isDisplayStateColor());
-        add(stateColorDisplayEnabled, "spanx, wrap");
 
         showNightlyWarning.setSelected(s.isShowNightlyWarning());
         add(showNightlyWarning, "spanx, wrap");

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/MachineStatusPanel.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2019 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -154,11 +154,7 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Cont
         activeStateValueLabel.setText(OFFLINE);
 
         activeStatePanel.setLayout(new MigLayout(debug + "fill, inset 0 5 0 5"));
-        if (backend.getSettings().isDisplayStateColor()) {
-            activeStatePanel.setBackground(Color.BLACK);
-        } else {
-            activeStatePanel.setBackground(Color.WHITE);
-        }
+        activeStatePanel.setBackground(Color.BLACK);
         activeStatePanel.setForeground(ThemeColors.VERY_DARK_GREY);
         activeStatePanel.add(activeStateValueLabel, "al center");
         activeStateValueLabel.setBorder(BorderFactory.createEmptyBorder());
@@ -259,9 +255,7 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Cont
         return new Timer((int) REFRESH_RATE.toMillis(), (ae) -> EventQueue.invokeLater(() -> {
             if (! backend.isConnected()) {
                 activeStateValueLabel.setText(OFFLINE);
-                if (backend.getSettings().isDisplayStateColor()) {
-                    activeStatePanel.setBackground(Color.BLACK);
-                }
+                activeStatePanel.setBackground(Color.BLACK);
             }
             GcodeState state = backend.getGcodeState();
             if (state == null) {
@@ -404,28 +398,26 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Cont
 
     private void updateStatePanel(ControllerState state) {
 
-        if (backend.getSettings().isDisplayStateColor()) {
-            Color background = ThemeColors.GREY;
-            String text = Utils.getControllerStateText(state);
-            if (state == ControllerState.ALARM) {
-                background = ThemeColors.RED;
-            } else if (state == ControllerState.HOLD) {
-                background = ThemeColors.ORANGE;
-            } else if (state == ControllerState.DOOR) {
-                background = ThemeColors.ORANGE;
-            } else if (state == ControllerState.RUN) {
-                background = ThemeColors.GREEN;
-            } else if (state == ControllerState.JOG) {
-                background = ThemeColors.GREEN;
-            } else if (state == ControllerState.CHECK) {
-                background = ThemeColors.LIGHT_BLUE;
-            } else if (state == ControllerState.IDLE) {
-                background = ThemeColors.GREY;
-            }
-
-            this.activeStatePanel.setBackground(background);
-            this.activeStateValueLabel.setText(text.toUpperCase());
+        Color background = ThemeColors.GREY;
+        String text = Utils.getControllerStateText(state);
+        if (state == ControllerState.ALARM) {
+            background = ThemeColors.RED;
+        } else if (state == ControllerState.HOLD) {
+            background = ThemeColors.ORANGE;
+        } else if (state == ControllerState.DOOR) {
+            background = ThemeColors.ORANGE;
+        } else if (state == ControllerState.RUN) {
+            background = ThemeColors.GREEN;
+        } else if (state == ControllerState.JOG) {
+            background = ThemeColors.GREEN;
+        } else if (state == ControllerState.CHECK) {
+            background = ThemeColors.LIGHT_BLUE;
+        } else if (state == ControllerState.IDLE) {
+            background = ThemeColors.GREY;
         }
+
+        this.activeStatePanel.setBackground(background);
+        this.activeStateValueLabel.setText(text.toUpperCase());
     }
 
     private void resetCoordinateButton(Axis coord) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2014-2018 Will Winder
+    Copyright 2014-2019 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -19,7 +19,6 @@
 package com.willwinder.universalgcodesender.utils;
 
 import com.willwinder.universalgcodesender.connection.ConnectionDriver;
-import com.willwinder.universalgcodesender.model.GUIBackend;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
@@ -61,7 +60,6 @@ public class Settings {
     private boolean singleStepMode = false;
     private boolean statusUpdatesEnabled = true;
     private int statusUpdateRate = 200;
-    private boolean displayStateColor = true;
     private Units preferredUnits = Units.MM;
 
     private boolean showNightlyWarning = true;
@@ -320,15 +318,6 @@ public class Settings {
 
     public void setStatusUpdateRate(int statusUpdateRate) {
         this.statusUpdateRate = statusUpdateRate;
-        changed();
-    }
-
-    public boolean isDisplayStateColor() {
-        return displayStateColor;
-    }
-
-    public void setDisplayStateColor(boolean displayStateColor) {
-        this.displayStateColor = displayStateColor;
         changed();
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
@@ -138,7 +138,6 @@ public class SettingsFactory {
                 out.setSingleStepMode(Boolean.valueOf(properties.getProperty("singleStepMode", FALSE)));
                 out.setStatusUpdatesEnabled(Boolean.valueOf(properties.getProperty("statusUpdatesEnabled", "true")));
                 out.setStatusUpdateRate(Integer.valueOf(properties.getProperty("statusUpdateRate", "200")));
-                out.setDisplayStateColor(Boolean.valueOf(properties.getProperty("displayStateColor", "true")));
                 out.updateMacro(1, null, null, properties.getProperty("customGcode1", "G0 X0 Y0;"));
                 out.updateMacro(2, null, null, properties.getProperty("customGcode2", "G0 G91 X10;G0 G91 Y10;"));
                 out.updateMacro(3, null, null, properties.getProperty("customGcode3", ""));

--- a/ugs-core/src/resources/MessagesBundle_en_US.properties
+++ b/ugs-core/src/resources/MessagesBundle_en_US.properties
@@ -166,7 +166,6 @@ sender.singlestep = Enable single step mode
 sender.whitespace = Remove all whitespace in commands
 sender.status = Enable status polling
 sender.status.rate = Status poll rate (ms)
-sender.state = Enable state color display
 sender.arcs = Convert arcs to lines
 sender.arcs.threshold = Small arc threshold (mm)
 sender.arcs.length = Small arc segment length (mm)

--- a/ugs-core/test/com/willwinder/universalgcodesender/utils/SettingsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/utils/SettingsTest.java
@@ -48,7 +48,6 @@ public class SettingsTest {
         assertFalse(target.isAutoReconnect());
         assertFalse(target.isCommandTableEnabled());
         assertEquals("mm", target.getPreferredUnits().abbreviation);
-        assertTrue(target.isDisplayStateColor());
         assertNotNull(target.getFileStats());
         assertEquals("GRBL", target.getFirmwareVersion());
         assertEquals(Double.valueOf(10.0), Double.valueOf(target.getJogFeedRate()));


### PR DESCRIPTION
The option for enabling the state color is broken in platform edition. I propose that we remove that option as I have a hard time seeing the use for it?

The setting "Enable get state color display" gets removed:
![Screenshot 2019-03-14 12 55 24](https://user-images.githubusercontent.com/8962024/54355870-842c2f80-465a-11e9-86c1-7aea6262270a.png)

The panel gets white but never changes the state text:
![Screenshot 2019-03-14 12 55 34](https://user-images.githubusercontent.com/8962024/54355872-842c2f80-465a-11e9-9fff-dc333f5163c2.png)


Reject this pull request otherwise, and I'll try to fix the settings for the platform edition instead!