### PR TITLE
Add deployment of nightly build of ugsplatform to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 
-
 cache:
   directories:
   - $HOME/.m2
@@ -16,13 +15,12 @@ after_success:
 before_script:
   - pip install --user codecov
 
+# deploy via pages on github
+
 deploy:
-  provider: releases
-  api_key: GITHUBAPIKEY
-  file: "/home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target/ugs-platform-app-2.0-SNAPSHOT.zip"
-  skip_cleanup: true
-  overwrite: true
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUBAPIKEY  # Set in the settings page of your repository, as a secure variable
+  keep-history: true
   on:
-    tags: false
-    
-    
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUBAPIKEY  # Set in the settings page of your repository, as a secure variable
   keep-history: true
+  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUBAPIKEY  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target/ugsplatform
+  local-dir: target/ugsplatform
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUBAPIKEY  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: target/ugsplatform
+  local-dir: ugs-platform/application/target/ugsplatform
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_script:
 
 deploy:
   provider: releases
-  api_key: "GITHUB OAUTH TOKEN"
-  file: "FILE TO UPLOAD"
+  api_key: GITHUBAPIKEY
+  file: "/home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target/ugs-platform-app-2.0-SNAPSHOT.zip"
   skip_cleanup: true
   overwrite: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 
+
 cache:
   directories:
   - $HOME/.m2
@@ -23,3 +24,5 @@ deploy:
   overwrite: true
   on:
     tags: true
+    
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,10 @@ after_success:
 before_script:
   - pip install --user codecov
 
+deploy:
+  provider: releases
+  api_key: "GITHUB OAUTH TOKEN"
+  file: "FILE TO UPLOAD"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUBAPIKEY  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target
+  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target/ugsplatform
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ deploy:
   skip_cleanup: true
   overwrite: true
   on:
-    tags: true
+    tags: false
     
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUBAPIKEY  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform
+  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target/ugs-platform
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUBAPIKEY  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target/ugs-platform
+  local-dir: /home/travis/build/mike-pittelko/Universal-G-Code-Sender-Build/ugs-platform/application/target
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ deploy:
   api_key: "GITHUB OAUTH TOKEN"
   file: "FILE TO UPLOAD"
   skip_cleanup: true
+  overwrite: true
   on:
     tags: true


### PR DESCRIPTION
This PR will add the necessary bits and bobs to .travis.yml to get the build artifacts deployed to winder/Universal-G-Code-Server branch gh-pages.  As it stands, no builds have posted since mid December 2018.

It won't work on it's own, you also need to make a change to the travis-ci settings for the respository.  In the "settings" page, add an environment variable with a github API key in it.  You can do this by generating one on github, and pasting it in to the box on travis.  It will not be displayed in any logs, and will not appear in the .yml file.

Here are the instructions on how to set up the environment variable: https://docs.travis-ci.com/user/environment-variables#defining-variables-in-repository-settings
Their example is "h" - you would use GITHUBAPIKEY
To generate the api key on github, go here: https://github.com/settings/tokens

if you want more than just ugsplatform, adjust the local-dir in the .travis.yml file.

Now, every time a build happens, the artifacts will end up in the gh-pages branch of the main repo.  This might not be the ideal way to make this all happen, but it works. Getting this hooked up to the web pages is some other exercise, sorry.