### PR TITLE
Error popups replaced with error messages in console

### DIFF
--- a/ugs-classic/src/main/java/com/willwinder/universalgcodesender/MainWindow.java
+++ b/ugs-classic/src/main/java/com/willwinder/universalgcodesender/MainWindow.java
@@ -389,6 +389,9 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
         scrollWindowCheckBox.setText("Scroll output window");
         scrollWindowCheckBox.addActionListener(this::scrollWindowCheckBoxActionPerformed);
 
+        showVerboseOutputCheckBox.setText("Show verbose output");
+        showVerboseOutputCheckBox.addActionListener(this::showVerboseCheckBoxActionPerformed);
+
         bottomTabbedPane.setBorder(javax.swing.BorderFactory.createTitledBorder(""));
         bottomTabbedPane.setMinimumSize(new java.awt.Dimension(0, 0));
         bottomTabbedPane.setPreferredSize(new java.awt.Dimension(468, 100));
@@ -665,8 +668,6 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
                     .add(firmwareComboBox, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
                 .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
-
-        showVerboseOutputCheckBox.setText("Show verbose output");
 
         statusPanel.setBorder(javax.swing.BorderFactory.createTitledBorder("Machine status"));
         statusPanel.setMinimumSize(new java.awt.Dimension(247, 160));
@@ -1100,6 +1101,10 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
     private void scrollWindowCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_scrollWindowCheckBoxActionPerformed
         backend.getSettings().setScrollWindowEnabled(scrollWindowCheckBox.isSelected());
     }//GEN-LAST:event_scrollWindowCheckBoxActionPerformed
+
+    private void showVerboseCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_scrollWindowCheckBoxActionPerformed
+        backend.getSettings().setVerboseOutputEnabled(showVerboseOutputCheckBox.isSelected());
+    }
 
     private void opencloseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_opencloseButtonActionPerformed
         if( this.opencloseButton.getText().equalsIgnoreCase(Localization.getString("open")) ) {
@@ -1900,6 +1905,7 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
 
         if (evt.isSettingChangeEvent()) {
             scrollWindowCheckBox.setSelected(backend.getSettings().isScrollWindowEnabled());
+            showVerboseOutputCheckBox.setSelected(backend.getSettings().isVerboseOutputEnabled());
             commandTable.setAutoWindowScroll(backend.getSettings().isScrollWindowEnabled());
         }
 

--- a/ugs-classic/src/main/java/com/willwinder/universalgcodesender/MainWindow.java
+++ b/ugs-classic/src/main/java/com/willwinder/universalgcodesender/MainWindow.java
@@ -100,8 +100,6 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
     // Duration timer
     private Timer timer;
 
-    // Services
-    private JogService jogService;
     private JogPanel jogPanel;
     private final MacroPanel macroPanel;
 
@@ -120,7 +118,7 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
             throw new RuntimeException(e);
         }
 
-        this.jogService = new JogService(backend);
+        JogService jogService = new JogService(backend);
 
         this.jogPanel = new JogPanel(backend, jogService, true);
 
@@ -1325,10 +1323,6 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
         showCommandTable(showCommandTableCheckBox.isSelected());
     }//GEN-LAST:event_showCommandTableCheckBoxActionPerformed
 
-    private void commandTextFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_commandTextFieldActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_commandTextFieldActionPerformed
-
     private void controlContextTabbedPaneComponentShown(java.awt.event.ComponentEvent evt) {//GEN-FIRST:event_controlContextTabbedPaneComponentShown
         // TODO add your handling code here:
     }//GEN-LAST:event_controlContextTabbedPaneComponentShown
@@ -1444,7 +1438,7 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
                 this, true);
         
         gcsd.setVisible(true);
-        
+
         if (gcsd.saveChanges()) {
             // TODO: Reprocess gcode file?
             /*
@@ -1598,8 +1592,8 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
         
         boolean hasFile = backend.getGcodeFile() != null;
         if (hasFile) {
-                this.saveButton.setEnabled(true);
-                this.visualizeButton.setEnabled(true);
+            this.saveButton.setEnabled(true);
+            this.visualizeButton.setEnabled(true);
         }
         
         switch (backend.getControlState()) {
@@ -1688,7 +1682,6 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
         this.controlContextTabbedPane.setTitleAt(1, Localization.getString("mainWindow.swing.controlContextTabbedPane.macros"));
         this.durationLabel.setText(Localization.getString("mainWindow.swing.durationLabel"));
         this.fileModePanel.setBorder(javax.swing.BorderFactory.createTitledBorder(Localization.getString("mainWindow.swing.fileLabel")));
-        //this.jogPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(Localization.getString("mainWindow.swing.keyboardMovementPanel")));
         this.firmwareLabel.setText(Localization.getString("mainWindow.swing.firmwareLabel"));
         this.firmwareSettings.setText(Localization.getString("mainWindow.swing.firmwareSettingsMenu"));
         this.grblConnectionSettingsMenuItem.setText(Localization.getString("mainWindow.swing.grblConnectionSettingsMenuItem"));
@@ -1780,7 +1773,6 @@ public class MainWindow extends JFrame implements ControllerListener, UGSEventLi
         remainingTimeValueLabel.setText(Utils.formattedMillis(0));
         remainingRowsValueLabel.setText("" + backend.getNumRemainingRows());
 
-        final String durationLabelCopy = this.durationValueLabel.getText();
         if (success) {
             java.awt.EventQueue.invokeLater(new Runnable() { @Override public void run() {
                 JOptionPane.showMessageDialog(new JFrame(),

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -502,16 +502,11 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
             // This will throw an exception and prevent that other stuff from
             // happening (clearing the table before its ready for clearing.
             this.controller.isReadyToStreamFile();
-
-            //this.controller.queueCommands(processedCommandLines);
-            //this.controller.queueStream(new BufferedReader(new FileReader(this.processedGcodeFile)));
             this.controller.queueStream(new GcodeStreamReader(this.processedGcodeFile));
-
             this.controller.beginStreaming();
         } catch (Exception e) {
             this.sendUGSEvent(new UGSEvent(ControlState.COMM_IDLE), false);
-            e.printStackTrace();
-            throw new Exception(Localization.getString("mainWindow.error.startingStream") + ": "+e.getMessage());
+            throw new Exception(Localization.getString("mainWindow.error.startingStream"), e);
         }
     }
     

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
  *
  * @author wwinder
  */
-public class GUIBackend implements BackendAPI, ControllerListener, SettingChangeListener, IFirmwareSettingsListener, MessageListener {
+public class GUIBackend implements BackendAPI, ControllerListener, SettingChangeListener, IFirmwareSettingsListener {
     private static final Logger logger = Logger.getLogger(GUIBackend.class.getName());
     private static final String NEW_LINE = "\n    ";
 
@@ -84,10 +84,6 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     private boolean autoconnect = false;
     
     private GcodeParser gcp = new GcodeParser();
-
-    public GUIBackend() {
-        messageService.addListener(this);
-    }
 
     @Override
     public void addUGSEventListener(UGSEventListener listener) {
@@ -881,12 +877,5 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     @Override
     public void onUpdatedFirmwareSetting(FirmwareSetting setting) {
         this.sendUGSEvent(new UGSEvent(EventType.FIRMWARE_SETTING_EVENT), false);
-    }
-
-    @Override
-    public void onMessage(MessageType messageType, String message) {
-        if (messageType == MessageType.ERROR) {
-            GUIHelpers.displayErrorDialog(message);
-        }
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/CommandPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/CommandPanel.java
@@ -29,7 +29,12 @@ import com.willwinder.universalgcodesender.uielements.components.LengthLimitedDo
 import com.willwinder.universalgcodesender.utils.SwingHelpers;
 import net.miginfocom.swing.MigLayout;
 
-import javax.swing.*;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
 import javax.swing.text.DefaultCaret;
 
 /**
@@ -57,6 +62,7 @@ public class CommandPanel extends JPanel implements UGSEventListener, MessageLis
 
     /**
      * No-Arg constructor to make this control work in the UI builder tools
+     *
      * @deprecated Use constructor with BackendAPI.
      */
     @Deprecated
@@ -120,7 +126,9 @@ public class CommandPanel extends JPanel implements UGSEventListener, MessageLis
     public void onMessage(MessageType messageType, String message) {
         java.awt.EventQueue.invokeLater(() -> {
             boolean verbose = MessageType.VERBOSE.equals(messageType);
-            if (!verbose || showVerboseMenuItem.isSelected()) {
+            if (messageType.equals(MessageType.ERROR)) {
+                consoleTextArea.append("[" +  messageType.getLocalizedString() + "] " + message);
+            } else if (!verbose || showVerboseMenuItem.isSelected()) {
                 if (verbose) {
                     consoleTextArea.append("[" + messageType.getLocalizedString() + "] ");
                 }
@@ -135,7 +143,7 @@ public class CommandPanel extends JPanel implements UGSEventListener, MessageLis
 
     private void checkScrollWindow() {
         // Console output.
-        DefaultCaret caret = (DefaultCaret)consoleTextArea.getCaret();
+        DefaultCaret caret = (DefaultCaret) consoleTextArea.getCaret();
         if (scrollWindowMenuItem.isSelected()) {
             caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
             consoleTextArea.setCaretPosition(consoleTextArea.getDocument().getLength());

--- a/ugs-core/src/resources/MessagesBundle_en_US.properties
+++ b/ugs-core/src/resources/MessagesBundle_en_US.properties
@@ -207,6 +207,7 @@ controller.error.response = Error while processing response
 controller.log.version = Grbl version
 controller.log.realtime = Real time mode
 controller.log.notconnected = Not connected
+controller.log.error.reported = An error has occured
 connection.exception.inuse = This port is already owned by another process.
 settings.log.location = Settings file location
 settings.log.loading = Loading settings.

--- a/ugs-pendant/pom.xml
+++ b/ugs-pendant/pom.xml
@@ -90,48 +90,61 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.6</version>
-                <configuration>
-                    <workingDirectory>${project.basedir}/src/main/webapp</workingDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>install node and npm</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
+    <profiles>
+        <!--
+            A profile that downloads NPM and builds the web application.
+            If the profile is inactivated the pendant web ui will not be available.
+        -->
+        <profile>
+            <id>create-pendant-web-ui</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.6</version>
                         <configuration>
-                            <nodeVersion>v10.15.0</nodeVersion>
-                            <npmVersion>6.4.1</npmVersion>
+                            <workingDirectory>${project.basedir}/src/main/webapp</workingDirectory>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm install</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>build prod</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>
-                                run build
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v10.15.0</nodeVersion>
+                                    <npmVersion>6.4.1</npmVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm install</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>build prod</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>
+                                        run build
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/lifecycle/startup.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/lifecycle/startup.java
@@ -18,6 +18,7 @@
  */
 package com.willwinder.ugs.nbp.core.lifecycle;
 
+import com.willwinder.ugs.nbp.core.services.ConsoleNotificationService;
 import com.willwinder.ugs.nbp.core.services.JogActionService;
 import com.willwinder.ugs.nbp.core.control.MacroService;
 import com.willwinder.ugs.nbp.core.services.OverrideActionService;
@@ -76,6 +77,8 @@ public class startup extends OptionProcessor implements Runnable {
         Lookup.getDefault().lookup(WindowTitleUpdaterService.class);
         logger.info("Loading PendantService...");
         Lookup.getDefault().lookup(PendantService.class);
+        logger.info("Loading ConsoleNotificationService...");
+        Lookup.getDefault().lookup(ConsoleNotificationService.class);
         logger.info("Services loaded!");
 
         logger.info("Setting UGP version title.");

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/ConsoleNotificationService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/ConsoleNotificationService.java
@@ -1,0 +1,67 @@
+/*
+    Copyright 2019 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.core.services;
+
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.MessageListener;
+import com.willwinder.universalgcodesender.listeners.MessageType;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import com.willwinder.universalgcodesender.utils.ThreadHelper;
+import org.openide.awt.Notification;
+import org.openide.awt.NotificationDisplayer;
+import org.openide.util.ImageUtilities;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * A console notification service that will display notifications for all error messages.
+ *
+ * @author Joacim Breiler
+ */
+@ServiceProvider(service = ConsoleNotificationService.class)
+public class ConsoleNotificationService implements MessageListener {
+
+    public static final String ERROR_ICON_PATH = "/org/netbeans/core/windows/resources/error.png";
+
+    /**
+     * Number of milliseconds to show the notification
+     */
+    private static final int TIME_TO_LIVE = 10000;
+
+    public ConsoleNotificationService() {
+        BackendAPI backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+        backend.addMessageListener(this);
+    }
+
+    @Override
+    public void onMessage(MessageType messageType, String message) {
+        if (messageType.equals(MessageType.ERROR)) {
+            Notification notify = NotificationDisplayer.getDefault()
+                    .notify(Localization.getString("controller.log.error.reported"),
+                            ImageUtilities.loadImageIcon(ERROR_ICON_PATH, false),
+                            message,
+                            null,
+                            NotificationDisplayer.Priority.LOW,
+                            NotificationDisplayer.Category.ERROR);
+
+            // Clears the notification automatically
+            ThreadHelper.invokeLater(notify::clear, TIME_TO_LIVE);
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogActionService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogActionService.java
@@ -1,5 +1,5 @@
 /*
-    Copywrite 2016 Will Winder
+    Copyright 2016-2019 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 


### PR DESCRIPTION
When an error occurs in the controller an error popup is created. Multiple errors results in multiple popups which doesn't seem user friendly. Also when running a headless instance these popups are created.

![image](https://user-images.githubusercontent.com/8962024/60767824-7b55e280-a0bd-11e9-9af7-4f80aa14170f.png)


I think it's better to log the errors in the console. In NetBeans notifications can also be created which wouldn't interfere with user interactions:
![image](https://user-images.githubusercontent.com/8962024/60767848-cb34a980-a0bd-11e9-81f1-735d2f7d4065.png)

This pull request also replaces the code in MainWindow for the console with the same UI-component used in the platform edition.