### PR TITLE
added GRBL v1.1  jog syntax support to jogMachineTo (G90) jog command

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -560,7 +560,18 @@ public class GrblController extends AbstractController {
             super.jogMachine(dirX, dirY, dirZ, stepSize, feedRate, units);
         }
     }
-
+    
+    @Override
+    public void jogMachineTo(PartialPosition position, double feedRate) throws Exception {
+        if (capabilities.hasCapability(GrblCapabilitiesConstants.HARDWARE_JOGGING)) {
+            String commandString = GcodeUtils.generateMoveToCommand(position, feedRate);
+            GcodeCommand command = createCommand("$J=" + commandString);
+            sendCommandImmediately(command);
+        } else {
+            super.jogMachineTo(position, feedRate);
+        }
+    }
+    
     /************
      * Helpers.
      ************/


### PR DESCRIPTION
I'm working on my own joystick / joypad jogging plugin for UGS with GRBL, based on the GRBL team's [suggested implementation](https://github.com/gnea/grbl/wiki/Grbl-v1.1-Jogging#joystick-implementation). Adding support for $J jog commands to the jogMachineTo method (analogous to how it was done for jogMachine) lets such a plugin overcome the limited choices of jogging directions available in jogMachine, allowing for a much more satisfying / responsive joypad interface.