### PR TITLE
Added warning for movement in machine coordinates without using homing.

### DIFF
--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
@@ -40,14 +40,13 @@ import java.io.File;
 import java.util.Collection;
 
 @MultiViewElement.Registration(
-        displayName = "#LBL_Gcode_EDITOR",
+        displayName = "#platform.window.editor.source",
         iconBase = "com/willwinder/ugs/nbp/editor/edit.png",
         mimeType = "text/xgcode",
         persistenceType = TopComponent.PERSISTENCE_ONLY_OPENED,
         preferredID = "Gcode",
         position = 1000
 )
-@NbBundle.Messages("LBL_Gcode_EDITOR=Source")
 public class SourceMultiviewElement extends MultiViewEditorElement {
 
     private static EditorListener editorListener;

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/GcodeParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/GcodeParser.java
@@ -22,6 +22,7 @@ import com.willwinder.ugs.nbp.editor.lexer.GcodeTokenId;
 import com.willwinder.ugs.nbp.editor.parser.errors.ErrorParser;
 import com.willwinder.ugs.nbp.editor.parser.errors.FeedRateMissingErrorParser;
 import com.willwinder.ugs.nbp.editor.parser.errors.InvalidGrblCommandErrorParser;
+import com.willwinder.ugs.nbp.editor.parser.errors.MovementInMachineCoordinatesErrorParser;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.modules.parsing.api.Snapshot;
@@ -75,6 +76,7 @@ public class GcodeParser extends Parser {
         errorParserList = new ArrayList<>();
         errorParserList.add(new FeedRateMissingErrorParser(fileObject));
         errorParserList.add(new InvalidGrblCommandErrorParser(fileObject));
+        errorParserList.add(new MovementInMachineCoordinatesErrorParser(fileObject));
 
         tokenSequence = (TokenSequence<GcodeTokenId>) snapshot.getTokenHierarchy().tokenSequence();
         tokenSequence.moveStart();

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidGrblCommandErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidGrblCommandErrorParser.java
@@ -42,22 +42,18 @@ public class InvalidGrblCommandErrorParser implements ErrorParser {
     );
 
     private final FileObject fileObject;
-    private boolean isGrbl = false;
+    private final BackendAPI backend;
 
     private List<GcodeError> errorList = new ArrayList<>();
 
     public InvalidGrblCommandErrorParser(FileObject fileObject) {
         this.fileObject = fileObject;
-
-        BackendAPI backend = CentralLookup.getDefault().lookup(BackendAPI.class);
-        if (backend.getController() instanceof GrblController) {
-            isGrbl = true;
-        }
+        this.backend = CentralLookup.getDefault().lookup(BackendAPI.class);
     }
 
     @Override
     public void handleToken(Token<GcodeTokenId> token, int line) {
-        if (!isGrbl) {
+        if (!(backend.getController() instanceof GrblController)) {
             return;
         }
 

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/MovementInMachineCoordinatesErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/MovementInMachineCoordinatesErrorParser.java
@@ -28,7 +28,7 @@ public class MovementInMachineCoordinatesErrorParser implements ErrorParser {
 
     @Override
     public void handleToken(Token<GcodeTokenId> token, int line) {
-        if (StringUtils.equalsIgnoreCase("G53", token.text()) && isHomingEnabled()) {
+        if (StringUtils.equalsIgnoreCase("G53", token.text()) && !isHomingEnabled()) {
             int offset = token.offset(null);
             GcodeError error = new GcodeError("movement-in-machine-coordinates-without-homing",
                     "Using movement in machine coordinates without homing enabled",

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/MovementInMachineCoordinatesErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/MovementInMachineCoordinatesErrorParser.java
@@ -1,0 +1,60 @@
+package com.willwinder.ugs.nbp.editor.parser.errors;
+
+import com.willwinder.ugs.nbp.editor.lexer.GcodeTokenId;
+import com.willwinder.ugs.nbp.editor.parser.GcodeError;
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.firmware.FirmwareSettingsException;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import org.apache.commons.lang3.StringUtils;
+import org.netbeans.api.lexer.Token;
+import org.netbeans.modules.csl.api.Severity;
+import org.openide.filesystems.FileObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MovementInMachineCoordinatesErrorParser implements ErrorParser {
+
+    private final FileObject fileObject;
+    private final BackendAPI backend;
+
+    private List<GcodeError> errorList = new ArrayList<>();
+
+    public MovementInMachineCoordinatesErrorParser(FileObject fileObject) {
+        this.fileObject = fileObject;
+
+        this.backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+    }
+
+    @Override
+    public void handleToken(Token<GcodeTokenId> token, int line) {
+        if (StringUtils.equalsIgnoreCase("G53", token.text()) && isHomingEnabled()) {
+            int offset = token.offset(null);
+            GcodeError error = new GcodeError("movement-in-machine-coordinates-without-homing",
+                    "Using movement in machine coordinates without homing enabled",
+                    "Using movement in machine coordinates without homing enabled could be hazardous as there is no known machine reference point.",
+                    fileObject,
+                    offset,
+                    offset + token.length(),
+                    true,
+                    Severity.WARNING);
+
+            errorList.add(error);
+        }
+    }
+
+    private boolean isHomingEnabled() {
+        try {
+            return backend.getController() == null ||
+                    backend.getController().getFirmwareSettings() == null ||
+                    backend.getController().getFirmwareSettings().isHomingEnabled();
+        } catch (FirmwareSettingsException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<GcodeError> getErrors() {
+        return errorList;
+    }
+}

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/nbm/manifest.mf
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/nbm/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-OpenIDE-Module-Localizing-Bundle: resources/MessagesBundle.properties
+OpenIDE-Module-Localizing-Bundle: com/willwinder/ugs/nbp/editor/Bundle.properties
 OpenIDE-Module-Layer: com/willwinder/ugs/nbp/editor/layer.xml
 OpenIDE-Module-Specification-Version: ${ugs.modules.specification.version}
 AutoUpdate-Essential-Module: true

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/Bundle.properties
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/Bundle.properties
@@ -4,11 +4,13 @@ OpenIDE-Module-Long-Description=An editor for G-Code files
 OpenIDE-Module-Display-Category=UGS Plugin
 
 platform.menu.edit=Edit Gcode File...
-
+platform.window.editor.source=Source
 text/xgcode=Gcode
+
 MOVEMENT=Movement
 MACHINE=Machine
 PARAMETER=Parameter
 AXIS=Axis
 WHITESPACE=Whitespace
 COMMENT=Comment
+TOOL=Tool

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/GcodeTemplate.gcode
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/GcodeTemplate.gcode
@@ -1,9 +1,8 @@
-(first comment)
-;second comment
-G21 ;inline comment 1
-G21 (inline comment 2)
-G0 X10 Y10 Z10
-; another comment
-G0 X20 Y20 Z20
-(another comment)
-G0 X30 Y30 Z30
+; Gcode for a circle
+G17 G20 G90 G94 G54 M0 M5 M9 ; Setup
+G0 Z0.25 F5
+X-0.5 Y0.
+G1 Z0.
+(arcs...)
+G2 X0. Y-0.5 I0.5 J0.
+G2 X-0.5 Y0. I0. J0.5

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/layer.xml
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/layer.xml
@@ -7,12 +7,12 @@
     <folder name="Editors">
         <folder name="text">
             <folder name="xgcode">
-                <attr name="SystemFileSystem.localizingBundle" stringvalue="resources.MessagesBundle"/>
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="com.willwinder.ugs.nbp.editor.Bundle"/>
                 <folder name="FontsColors">
                     <folder name="NetBeans">
                         <folder name="Defaults">
                             <file name="FontAndColors.xml" url="FontAndColors.xml">
-                                <attr name="SystemFileSystem.localizingBundle" stringvalue="resources.MessagesBundle"/>
+                                <attr name="SystemFileSystem.localizingBundle" stringvalue="com.willwinder.ugs.nbp.editor.Bundle"/>
                             </file>
                         </folder>
                     </folder>


### PR DESCRIPTION
In issue #1108 theres a command G53 which isn't displayed correctly in the visualiser. I realised that this could also lead to other problems if the machine isn't using homing (which happened to me) there would be no known machine coordinate reference point. I wouldn't want to move in machine coordinates, we could at least show a warning in the editor.