### PR TITLE
Feature/handle inverted homing

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/IFirmwareSettings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/IFirmwareSettings.java
@@ -170,7 +170,7 @@ public interface IFirmwareSettings {
      *
      * @param axis the axis to retrieve
      * @return the soft limits in millimeters
-     * @throws FirmwareSettingsException if the setting couldn't be retreived
+     * @throws FirmwareSettingsException if the setting couldn't be retrieved
      */
     double getSoftLimit(Axis axis) throws FirmwareSettingsException;
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
@@ -3,7 +3,6 @@ package com.willwinder.universalgcodesender.model;
 
 import com.google.common.collect.ImmutableMap;
 import com.willwinder.universalgcodesender.Utils;
-import com.willwinder.universalgcodesender.firmware.IFirmwareSettings;
 
 import java.text.NumberFormat;
 import java.util.Map;

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
@@ -3,6 +3,7 @@ package com.willwinder.universalgcodesender.model;
 
 import com.google.common.collect.ImmutableMap;
 import com.willwinder.universalgcodesender.Utils;
+import com.willwinder.universalgcodesender.firmware.IFirmwareSettings;
 
 import java.text.NumberFormat;
 import java.util.Map;
@@ -44,6 +45,13 @@ public class PartialPosition {
         this.y = y;
         this.z = z;
         this.units = units;
+    }
+
+    public PartialPosition() {
+        this.x = null;
+        this.y = null;
+        this.z = null;
+        this.units = UnitUtils.Units.UNKNOWN;
     }
 
 
@@ -189,7 +197,13 @@ public class PartialPosition {
             return this;
         }
 
-
+        public Builder copy(PartialPosition position) {
+            this.x = position.getX();
+            this.y = position.getY();
+            this.z = position.getZ();
+            this.units = position.getUnits();
+            return this;
+        }
     }
 
     public String getFormattedGCode() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/UGSEvent.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/UGSEvent.java
@@ -68,23 +68,27 @@ public class UGSEvent {
     }
 
     public boolean isStateChangeEvent() {
-        return evt == EventType.STATE_EVENT;
+        return EventType.STATE_EVENT.equals(evt);
     }
 
     public boolean isFileChangeEvent() {
-        return evt == EventType.FILE_EVENT;
+        return EventType.FILE_EVENT.equals(evt);
     }
 
     public boolean isSettingChangeEvent() {
-        return evt == EventType.SETTING_EVENT;
+        return EventType.SETTING_EVENT.equals(evt);
+    }
+
+    public boolean isFirmwareSettingEvent() {
+        return EventType.FIRMWARE_SETTING_EVENT.equals(evt);
     }
 
     public boolean isProbeEvent() {
-        return evt == EventType.PROBE_EVENT;
+        return EventType.PROBE_EVENT.equals(evt);
     }
 
     public boolean isControllerStatusEvent() {
-        return evt == EventType.CONTROLLER_STATUS_EVENT;
+        return EventType.CONTROLLER_STATUS_EVENT.equals(evt);
     }
 
     /**

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelHardLimits.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelHardLimits.java
@@ -158,7 +158,7 @@ public class WizardPanelHardLimits extends AbstractWizardPanel implements UGSEve
 
     @Override
     public void UGSEvent(UGSEvent evt) {
-        if (evt.getEventType() == UGSEvent.EventType.FIRMWARE_SETTING_EVENT) {
+        if (evt.isFirmwareSettingEvent()) {
             refreshComponents();
         } else if (evt.isControllerStatusEvent()) {
             ThreadHelper.invokeLater(() -> {

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelHoming.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelHoming.java
@@ -289,7 +289,7 @@ public class WizardPanelHoming extends AbstractWizardPanel implements UGSEventLi
 
     @Override
     public void UGSEvent(UGSEvent event) {
-        if (event.getEventType() == UGSEvent.EventType.FIRMWARE_SETTING_EVENT) {
+        if (event.isFirmwareSettingEvent()) {
             refreshControls();
         }
     }

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelMotorWiring.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelMotorWiring.java
@@ -158,7 +158,7 @@ public class WizardPanelMotorWiring extends AbstractWizardPanel implements UGSEv
 
     @Override
     public void UGSEvent(UGSEvent event) {
-        if (event.getEventType() == UGSEvent.EventType.FIRMWARE_SETTING_EVENT) {
+        if (event.isFirmwareSettingEvent()) {
             ThreadHelper.invokeLater(this::refreshReverseDirectionCheckboxes);
         } else if (event.isControllerStatusEvent() || event.isStateChangeEvent()) {
             WizardUtils.killAlarm(getBackend());

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelSoftLimits.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelSoftLimits.java
@@ -340,7 +340,7 @@ public class WizardPanelSoftLimits extends AbstractWizardPanel implements UGSEve
                 labelPositionY.setText(positionDecimalFormat.format(machineCoord.get(Axis.Y)) + " mm");
                 labelPositionZ.setText(positionDecimalFormat.format(machineCoord.get(Axis.Z)) + " mm");
             }
-        } else if (event.getEventType() == UGSEvent.EventType.FIRMWARE_SETTING_EVENT) {
+        } else if (event.isFirmwareSettingEvent()) {
             refeshControls();
         }
 

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/renderables/MachineBoundries.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/renderables/MachineBoundries.java
@@ -1,3 +1,21 @@
+/*
+    Copyright 2016-2019 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+*/
 package com.willwinder.ugs.nbm.visualizer.renderables;
 
 import com.jogamp.opengl.GL2;
@@ -18,6 +36,8 @@ import static com.willwinder.ugs.nbm.visualizer.options.VisualizerOptions.VISUAL
 
 /**
  * Displays the machine boundries based on the soft limits
+ *
+ * @author Joacim Breiler
  */
 public class MachineBoundries extends Renderable {
     private final BackendAPI backendAPI;
@@ -125,12 +145,13 @@ public class MachineBoundries extends Renderable {
     }
 
     private void drawBase(GL2 gl, Point3d bottomLeft, Point3d topRight) {
+        double bottomZ = Math.min(bottomLeft.getZ(), topRight.getZ());
         gl.glColor4fv(machineBoundryBottomColor, 0);
         gl.glBegin(GL2.GL_QUADS);
-            gl.glVertex3d(bottomLeft.x, bottomLeft.y, bottomLeft.getZ());
-            gl.glVertex3d(bottomLeft.x, topRight.y, bottomLeft.getZ());
-            gl.glVertex3d(topRight.x, topRight.y, bottomLeft.getZ());
-            gl.glVertex3d(topRight.x, bottomLeft.y, bottomLeft.getZ());
+            gl.glVertex3d(bottomLeft.x, bottomLeft.y, bottomZ);
+            gl.glVertex3d(bottomLeft.x, topRight.y, bottomZ);
+            gl.glVertex3d(topRight.x, topRight.y, bottomZ);
+            gl.glVertex3d(topRight.x, bottomLeft.y, bottomZ);
         gl.glEnd();
     }
 


### PR DESCRIPTION
Fixes #1287

As far as I've tested this should fix the visualization of the machine boundry if the homing direction is inverted. (It still requires that soft limits is enabled)

![Homing inverting 2019-10-17 20_24_02](https://user-images.githubusercontent.com/8962024/67036682-550ffc00-f11c-11e9-8454-1f642aa31be1.gif)
