### PR TITLE
Fixed issue where application can't be compiled jdk11.

### DIFF
--- a/new-module-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/new-module-archetype/src/main/resources/archetype-resources/pom.xml
@@ -88,7 +88,7 @@
     <dependency> 
       <groupId>org.mockito</groupId>  
       <artifactId>mockito-core</artifactId>  
-      <version>2.7.22</version>  
+      <version>${mockito.version}</version>
       <scope>test</scope>  
       <type>jar</type> 
     </dependency>  

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,11 @@
     <vecmath.version>1.5.2</vecmath.version>
     <zxing.version>3.2.0</zxing.version>
     <qrgen.version>1.3</qrgen.version>
+    <jacoco.version>0.8.5</jacoco.version>
     <swing-layout.version>1.0.3</swing-layout.version>
     <surefire.reportplugin.version>2.19.1</surefire.reportplugin.version>
     <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
+    <mockito.version>3.1.0</mockito.version>
 
     <ugs.maven-compiler-plugin.version>3.6.1</ugs.maven-compiler-plugin.version>
     <ugs.jvm.version>1.8</ugs.jvm.version>
@@ -181,7 +183,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.7.22</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
       <type>jar</type>
     </dependency>

--- a/ugs-core/pom.xml
+++ b/ugs-core/pom.xml
@@ -159,7 +159,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.5.201505241946</version>
+        <version>${jacoco.version}</version>
         <executions>
           <execution>
             <goals>

--- a/ugs-platform/DowelModule/pom.xml
+++ b/ugs-platform/DowelModule/pom.xml
@@ -92,7 +92,7 @@
     <dependency> 
       <groupId>org.mockito</groupId>  
       <artifactId>mockito-core</artifactId>  
-      <version>2.7.22</version>  
+      <version>${mockito.version}</version>
       <scope>test</scope>  
       <type>jar</type> 
     </dependency>  

--- a/ugs-platform/GcodeTools/pom.xml
+++ b/ugs-platform/GcodeTools/pom.xml
@@ -88,7 +88,7 @@
     <dependency> 
       <groupId>org.mockito</groupId>  
       <artifactId>mockito-core</artifactId>  
-      <version>2.7.22</version>  
+      <version>${mockito.version}</version>
       <scope>test</scope>  
       <type>jar</type> 
     </dependency>  

--- a/ugs-platform/ProbeModule/pom.xml
+++ b/ugs-platform/ProbeModule/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.7.22</version>
+        <version>${mockito.version}</version>
         <scope>test</scope>
         <type>jar</type>
       </dependency>

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/pom.xml
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.7.22</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
             <type>jar</type>
         </dependency>

--- a/ugs-platform/ugs-platform-welcome-page/pom.xml
+++ b/ugs-platform/ugs-platform-welcome-page/pom.xml
@@ -114,7 +114,7 @@
     <dependency> 
       <groupId>org.mockito</groupId>  
       <artifactId>mockito-core</artifactId>  
-      <version>2.7.22</version>  
+      <version>${mockito.version}</version>
       <scope>test</scope>  
       <type>jar</type> 
     </dependency>  


### PR DESCRIPTION
Upgraded libraries that isn't compatible with jdk11.
Fixes #1263 have tested on a clean rpi-installation using the instructions under https://github.com/winder/Universal-G-Code-Sender/wiki/Raspberry-Pi