### PR TITLE
Tweaked tests to prevent unnecessary error messages and updated lexer to allow space in parameter

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -886,7 +886,7 @@ public abstract class AbstractController implements SerialCommunicatorListener, 
         if (messageService != null) {
             messageService.dispatchMessage(type, message);
         } else {
-            logger.warning("No message service is assigned, so the message could not be delivered: " + type + ": " + message);
+            logger.fine("No message service is assigned, so the message could not be delivered: " + type + ": " + message);
         }
     }
     

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -1425,6 +1425,7 @@ public class GrblControllerTest {
     public void errorInCheckModeNotSending() throws Exception {
         // Given
         AbstractCommunicator communicator = mock(AbstractCommunicator.class);
+        when(communicator.isCommOpen()).thenReturn(true);
         GrblController gc = new GrblController(communicator);
         gc.rawResponseHandler("Grbl 1.1f"); // We will assume that we are using version Grbl 1.0 with streaming support
         gc.rawResponseHandler("<Check|MPos:0.000,0.000,0.000|FS:0,0|Pn:XYZ>");
@@ -1443,6 +1444,7 @@ public class GrblControllerTest {
     public void errorInCheckModeSending() throws Exception {
         // Given
         AbstractCommunicator communicator = mock(AbstractCommunicator.class);
+        when(communicator.isCommOpen()).thenReturn(true);
         ControllerListener controllerListener = mock(ControllerListener.class);
         GrblController gc = new GrblController(communicator);
         gc.addListener(controllerListener);

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexer.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexer.java
@@ -159,10 +159,13 @@ public class GcodeLexer implements Lexer<GcodeTokenId> {
         int length = 0;
         int minusCount = 0;
         int commaCount = 0;
+        int numberCount = 0;
 
         while (true) {
             char character = (char) input.read();
-            if (!isNumeric(character)) {
+            if (character == ' ' && length == 0) {
+                // It's allowed to have a leading space after parameter name
+            } else if (!isNumeric(character)) {
                 input.backup(1);
                 break;
             } else if (character == ',' || character == '.') {
@@ -171,10 +174,14 @@ public class GcodeLexer implements Lexer<GcodeTokenId> {
                 minusCount++;
             }
 
+            if (isNumeric(character)) {
+                numberCount++;
+            }
+
             length++;
         }
 
-        if (length == 0 || minusCount > 1 || commaCount > 1) {
+        if (length == 0 || minusCount > 1 || commaCount > 1 || numberCount == 0) {
             return createToken(GcodeTokenId.ERROR);
         }
 

--- a/ugs-platform/ugs-platform-gcode-editor/src/test/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexerTest.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/test/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexerTest.java
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with UGS.  If not, see <http://www.gnu.org/licenses/>.
 */
-package com.willwinder.ugs.nbp.editor.syntax;
+package com.willwinder.ugs.nbp.editor.lexer;
 
 import com.willwinder.ugs.nbp.editor.lexer.GcodeTokenId;
 import org.junit.Test;
@@ -250,5 +250,122 @@ public class GcodeLexerTest {
         t = ts.token();
         assertEquals(GcodeTokenId.ERROR, t.id());
         assertEquals("S.100.10", t.text());
+    }
+
+    @Test
+    public void parsingParametersWithLeadingSpaceShouldBeOk() {
+        String text = "G01 X -.100 Y 10 Z 0.3 S 1000 F 500";
+        TokenSequence<GcodeTokenId> ts = parseTokenSequence(text);
+
+        ts.moveNext();
+        Token<?> t = ts.token();
+        assertEquals(GcodeTokenId.MOVEMENT, t.id());
+        assertEquals("G01", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("X -.100", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("Y 10", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("Z 0.3", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.PARAMETER, t.id());
+        assertEquals("S 1000", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.PARAMETER, t.id());
+        assertEquals("F 500", t.text());
+    }
+
+    @Test
+    public void parsingParametersWithSpaceShouldGenerateErrors() {
+        String text = "G01 X- .100 Z0. 3";
+        TokenSequence<GcodeTokenId> ts = parseTokenSequence(text);
+
+        ts.moveNext();
+        Token<?> t = ts.token();
+        assertEquals(GcodeTokenId.MOVEMENT, t.id());
+        assertEquals("G01", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("X-", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.ERROR, t.id());
+        assertEquals(".1", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.ERROR, t.id());
+        assertEquals("00", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("Z0.", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.ERROR, t.id());
+        assertEquals("3", t.text());
     }
 }


### PR DESCRIPTION
Tweaked tests so that unnecessary error messages in tests no longer is printed.

Adjusted lexer for gcode editor to allow a parameter with a space `X 10.0` which seems to be added by some CAM:s.

Discussion in #1214