### PR TITLE
Added error message for when connecting to g2core hardware using the tinyg controller driver

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -57,6 +57,8 @@ public class TinyGController extends AbstractController {
     private static final Logger LOGGER = Logger.getLogger(TinyGController.class.getSimpleName());
     private static final String NOT_SUPPORTED_YET = "Not supported yet.";
     private static final String STATUS_REPORT_CONFIG = "{sr:{posx:t, posy:t, posz:t, mpox:t, mpoy:t, mpoz:t, plan:t, vel:t, unit:t, stat:t, dist:t, frmo:t, coor:t}}";
+    private static final double LATEST_TINYG_FIRMWARE_VERSION = 0.97;
+
     protected final Capabilities capabilities;
     private final TinyGFirmwareSettings firmwareSettings;
     protected ControllerStatus controllerStatus;
@@ -228,6 +230,11 @@ public class TinyGController extends AbstractController {
             firmwareVersion = "TinyG " + firmwareVersionNumber;
         }
 
+        if (firmwareVersionNumber > LATEST_TINYG_FIRMWARE_VERSION) {
+            dispatchConsoleMessage(MessageType.ERROR, String.format(Localization.getString("tinyg.exception.unknownVersion"), firmwareVersionNumber)  + "\n");
+            return;
+        }
+
         capabilities.addCapability(CapabilitiesConstants.JOGGING);
         capabilities.removeCapability(CapabilitiesConstants.CONTINUOUS_JOGGING);
         capabilities.addCapability(CapabilitiesConstants.HOMING);
@@ -356,12 +363,12 @@ public class TinyGController extends AbstractController {
     }
 
     @Override
-    protected void isReadyToStreamCommandsEvent() throws Exception {
+    protected void isReadyToStreamCommandsEvent() {
         // Not needed yet
     }
 
     @Override
-    protected void isReadyToSendCommandsEvent() throws Exception {
+    protected void isReadyToSendCommandsEvent() {
         // Not needed yet
     }
 

--- a/ugs-core/src/resources/MessagesBundle_en_US.properties
+++ b/ugs-core/src/resources/MessagesBundle_en_US.properties
@@ -259,6 +259,7 @@ jogging.units.mm = Jog: MM
 jogging.units.toggle = Jog: Toggle Units
 grbl.exception.Alarm = File stream is disabled when GRBL is in the Alarm state.
 grbl.exception.cancelReset = Timeout waiting for GRBL to Idle during cancel, cancel incomplete.
+tinyg.exception.unknownVersion = This is an unknown TinyG version: %s. If you are running g2core please update your connection settings.
 platform.menu.window = Window
 platform.menu.classic = Classic
 platform.menu.plugins = Plugins


### PR DESCRIPTION
I added a new firmware profile for g2core. We need an message for when connecting with the wrong profile to the g2core hardware.