### PR TITLE
Fixes problem where position is reported with an even number.

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -507,9 +507,9 @@ public class GrblUtils {
         return Units.UNKNOWN;
     }
 
-    static Pattern machinePattern = Pattern.compile("(?<=MPos:)(-?\\d*\\..\\d*),(-?\\d*\\..\\d*),(-?\\d*\\..\\d*)");
-    static Pattern workPattern = Pattern.compile("(?<=WPos:)(\\-?\\d*\\..\\d*),(\\-?\\d*\\..\\d*),(\\-?\\d*\\..\\d*)");
-    static Pattern wcoPattern = Pattern.compile("(?<=WCO:)(\\-?\\d*\\..\\d*),(\\-?\\d*\\..\\d*),(\\-?\\d*\\..\\d*)");
+    static Pattern machinePattern = Pattern.compile("(?<=MPos:)(-?\\d*\\.?\\d*),(-?\\d*\\.?\\d*),(-?\\d*\\.?\\d*)");
+    static Pattern workPattern = Pattern.compile("(?<=WPos:)(\\-?\\d*\\.?\\d*),(\\-?\\d*\\.?\\d*),(\\-?\\d*\\.?\\d*)");
+    static Pattern wcoPattern = Pattern.compile("(?<=WCO:)(\\-?\\d*\\.?\\d*),(\\-?\\d*\\.?\\d*),(\\-?\\d*\\.?\\d*)");
     static protected Position getMachinePositionFromStatusString(final String status, final Capabilities version, Units reportingUnits) {
         if (version.hasCapability(GrblCapabilitiesConstants.REAL_TIME)) {
             return GrblUtils.getPositionFromStatusString(status, machinePattern, reportingUnits);

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2018 Will Winder
+    Copyright 2013-2020 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -31,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
 /**
- *
  * @author wwinder
  */
 public class GrblUtilsTest {
@@ -44,7 +43,7 @@ public class GrblUtilsTest {
         String response;
         Boolean expResult;
         Boolean result;
-        
+
         response = "Grbl 0.8c";
         expResult = true;
         result = GrblUtils.isGrblVersionString(response);
@@ -70,14 +69,14 @@ public class GrblUtilsTest {
         expResult = 0.8;
         result = GrblUtils.getVersionDouble(response);
         assertEquals(expResult, result, 0.0);
-        
-        
+
+
         response = "CarbideMotion 0.9g";
         expResult = 0.9;
         result = GrblUtils.getVersionDouble(response);
         assertEquals(expResult, result, 0.0);
 
-        
+
     }
 
     /**
@@ -91,7 +90,7 @@ public class GrblUtilsTest {
         Character result = GrblUtils.getVersionLetter(response);
         assertEquals(expResult, result);
     }
-    
+
     @Test
     public void testGetHomingCommand() {
         System.out.println("getHomingCommand");
@@ -99,13 +98,13 @@ public class GrblUtilsTest {
         Character letter;
         String result;
         String expResult;
-        
+
         version = 0.7;
         letter = null;
         expResult = "";
         result = GrblUtils.getHomingCommand(version, letter);
         assertEquals(expResult, result);
-        
+
         version = 0.8;
         letter = null;
         expResult = GrblUtils.GCODE_PERFORM_HOMING_CYCLE_V8;
@@ -118,7 +117,7 @@ public class GrblUtilsTest {
         result = GrblUtils.getHomingCommand(version, letter);
         assertEquals(expResult, result);
     }
-    
+
     @Test
     public void testGetReturnToHomeCommand() {
         System.out.println("getReturnToHomeCommands");
@@ -126,7 +125,7 @@ public class GrblUtilsTest {
         Character letter;
         ArrayList<String> result;
         String expResult;
-        
+
         version = 0.8;
         letter = null;
         expResult = GrblUtils.GCODE_RETURN_TO_ZERO_LOCATION_V8;
@@ -147,7 +146,7 @@ public class GrblUtilsTest {
         assertEquals(expResult, result.get(1));
         assertEquals(expResult2, result.get(2));
     }
-        
+
     @Test
     public void testGetKillAlarmLockCommand() {
         System.out.println("getKillAlarmLockCommand");
@@ -155,13 +154,13 @@ public class GrblUtilsTest {
         Character letter;
         String result;
         String expResult;
-        
+
         version = 0.7;
         letter = null;
         expResult = "";
         result = GrblUtils.getKillAlarmLockCommand(version, letter);
         assertEquals(expResult, result);
-        
+
         version = 0.8;
         letter = null;
         expResult = "";
@@ -180,7 +179,7 @@ public class GrblUtilsTest {
         result = GrblUtils.getKillAlarmLockCommand(version, letter);
         assertEquals(expResult, result);
     }
-    
+
     @Test
     public void testToggleCheckModeCommand() {
         System.out.println("getToggleCheckModeCommand");
@@ -188,13 +187,13 @@ public class GrblUtilsTest {
         Character letter;
         String result;
         String expResult;
-        
+
         version = 0.7;
         letter = null;
         expResult = "";
         result = GrblUtils.getToggleCheckModeCommand(version, letter);
         assertEquals(expResult, result);
-        
+
         version = 0.8;
         letter = null;
         expResult = "";
@@ -213,7 +212,7 @@ public class GrblUtilsTest {
         result = GrblUtils.getToggleCheckModeCommand(version, letter);
         assertEquals(expResult, result);
     }
-    
+
     @Test
     public void testGetViewParserStateCommand() {
         System.out.println("getViewParserStateCommand");
@@ -221,13 +220,13 @@ public class GrblUtilsTest {
         Character letter;
         String result;
         String expResult;
-        
+
         version = 0.7;
         letter = null;
         expResult = "";
         result = GrblUtils.getViewParserStateCommand(version, letter);
         assertEquals(expResult, result);
-        
+
         version = 0.8;
         letter = null;
         expResult = "";
@@ -303,12 +302,12 @@ public class GrblUtilsTest {
         String response;
         Boolean expResult;
         Boolean result;
-        
+
         response = "<position string is in angle brackets...>";
         expResult = true;
         result = GrblUtils.isGrblStatusString(response);
         assertEquals(expResult, result);
-        
+
         response = "blah";
         expResult = false;
         result = GrblUtils.isGrblStatusString(response);
@@ -333,6 +332,17 @@ public class GrblUtilsTest {
         assertEquals(expResult, result);
     }
 
+    @Test
+    public void testGetWorkPositionFromStatusStringWithEvenNumbers() {
+        String status = "<Run,MPos:50.400,43.200,0.000,WPos:50000,42.600,0.000>";
+        Capabilities version = new Capabilities();
+        version.addCapability(GrblCapabilitiesConstants.REAL_TIME);
+        Position position = GrblUtils.getWorkPositionFromStatusString(status, version, UnitUtils.Units.MM);
+
+        Position expResult = new Position(50000, 42.6, 0, UnitUtils.Units.MM);
+        assertEquals(expResult, position);
+    }
+
     /**
      * Test of getMachinePositionFromStatusString method, of class GrblUtils.
      */
@@ -345,6 +355,17 @@ public class GrblUtilsTest {
         Position expResult = new Position(5.529, 0.560, 7.000, UnitUtils.Units.UNKNOWN);
         Position result = GrblUtils.getMachinePositionFromStatusString(status, version, UnitUtils.Units.UNKNOWN);
         assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testGetMachinePositionFromStatusStringWithEvenNumbers() {
+        String status = "<Run,MPos:5,43.200,1,WPos:50000,42.600,0.000>";
+        Capabilities version = new Capabilities();
+        version.addCapability(GrblCapabilitiesConstants.REAL_TIME);
+        Position position = GrblUtils.getMachinePositionFromStatusString(status, version, UnitUtils.Units.MM);
+
+        Position expResult = new Position(5, 43.2, 1, UnitUtils.Units.MM);
+        assertEquals(expResult, position);
     }
 
     /**
@@ -360,7 +381,7 @@ public class GrblUtilsTest {
         Position result = GrblUtils.getWorkPositionFromStatusString(status, version, UnitUtils.Units.UNKNOWN);
         assertEquals(expResult, result);
     }
-    
+
     @Test
     public void testGetResetCoordCommand() {
         System.out.println("getResetCoordCommand");
@@ -368,16 +389,16 @@ public class GrblUtilsTest {
         double version = 0.8;
         Character letter = 'c';
         String result;
-        
+
         result = GrblUtils.getResetCoordToZeroCommand(X, version, letter);
         assertEquals("G92 X0", result);
         result = GrblUtils.getResetCoordToZeroCommand(Y, version, letter);
         assertEquals("G92 Y0", result);
         result = GrblUtils.getResetCoordToZeroCommand(Z, version, letter);
         assertEquals("G92 Z0", result);
-        
+
         version = 0.9;
-        
+
         result = GrblUtils.getResetCoordToZeroCommand(X, version, letter);
         assertEquals("G10 P0 L20 X0", result);
         result = GrblUtils.getResetCoordToZeroCommand(Y, version, letter);
@@ -390,7 +411,7 @@ public class GrblUtilsTest {
     public void okErrorAlarmTests() {
         assertTrue(GrblUtils.isOkResponse("ok"));
         assertFalse(GrblUtils.isOkResponse("not ok"));
-        
+
         assertTrue(GrblUtils.isErrorResponse("error: some error"));
         assertFalse(GrblUtils.isErrorResponse("ok"));
 
@@ -438,9 +459,9 @@ public class GrblUtilsTest {
         assertEquals("Idle", controllerStatus.getStateString());
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
 
-        assertEquals(new Position(1.1,2.2,3.3, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
-        assertEquals(new Position(4.4,5.5,6.6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
-        assertEquals(new Position(7.7,8.8,9.9, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
+        assertEquals(new Position(1.1, 2.2, 3.3, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
+        assertEquals(new Position(4.4, 5.5, 6.6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
+        assertEquals(new Position(7.7, 8.8, 9.9, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
 
         assertEquals(1, controllerStatus.getOverrides().feed);
         assertEquals(2, controllerStatus.getOverrides().rapid);
@@ -473,9 +494,9 @@ public class GrblUtilsTest {
 
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
 
-        assertEquals(new Position(1.1,2.2,3.3, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
-        assertEquals(new Position(4.4,5.5,6.6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
-        assertEquals(new Position(0,0,0, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
+        assertEquals(new Position(1.1, 2.2, 3.3, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
+        assertEquals(new Position(4.4, 5.5, 6.6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
+        assertEquals(new Position(0, 0, 0, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
     }
 
     @Test
@@ -487,9 +508,9 @@ public class GrblUtilsTest {
 
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
 
-        assertEquals(new Position(1,2,3, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
-        assertEquals(new Position(-6,-6,-6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
-        assertEquals(new Position(7,8,9, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
+        assertEquals(new Position(1, 2, 3, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
+        assertEquals(new Position(-6, -6, -6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
+        assertEquals(new Position(7, 8, 9, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
     }
 
     @Test
@@ -501,9 +522,9 @@ public class GrblUtilsTest {
 
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
 
-        assertEquals(new Position(11,13,15, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
-        assertEquals(new Position(4,5,6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
-        assertEquals(new Position(7,8,9, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
+        assertEquals(new Position(11, 13, 15, UnitUtils.Units.MM), controllerStatus.getMachineCoord());
+        assertEquals(new Position(4, 5, 6, UnitUtils.Units.MM), controllerStatus.getWorkCoord());
+        assertEquals(new Position(7, 8, 9, UnitUtils.Units.MM), controllerStatus.getWorkCoordinateOffset());
     }
 
     @Test
@@ -515,8 +536,8 @@ public class GrblUtilsTest {
 
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
 
-        assertEquals( Double.valueOf(12345.6), controllerStatus.getFeedSpeed());
-        assertEquals( Double.valueOf(65432.1), controllerStatus.getSpindleSpeed());
+        assertEquals(Double.valueOf(12345.6), controllerStatus.getFeedSpeed());
+        assertEquals(Double.valueOf(65432.1), controllerStatus.getSpindleSpeed());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1269 

Made the decimal point optional which now makes it possible to parse positions reported like this:
<Run,MPos:50.400,43.200,0.000,WPos:50000,42.600,0.000>