### PR TITLE
fix for #1341

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -629,29 +629,16 @@ public abstract class AbstractController implements CommunicatorListener, IContr
     @Override
     public void cancelSend() throws Exception {
         this.dispatchConsoleMessage(MessageType.INFO, "\n**** Canceling file transfer. ****\n\n");
-
         cancelSendBeforeEvent();
-        
-        // Don't clear the command queue, there might be a situation where a
-        // send is in progress while the next queue is being built. In which
-        // case a cancel would only be expected to cancel the current action
-        // to make way for the queued commands.
-        //this.prepQueue.clear();
-        
         cancelCommands();
-        
-        // If there are no active commands, done streaming. Otherwise wait for
-        // them to finish.
-        if (!comm.areActiveCommands()) {
-            this.isStreaming = false;
-        }
-
         cancelSendAfterEvent();
     }
 
     @Override
     public void cancelCommands() {
         this.comm.cancelSend();
+        this.isStreaming = false;
+        if (this.streamStopWatch.isStarted()) this.streamStopWatch.stop();
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -211,7 +211,7 @@ public class GrblController extends AbstractController {
 
                 // In case a reset occurred while streaming.
                 if (this.isStreaming()) {
-                    this.dispatchConsoleMessage(MessageType.INFO, "\n**** GRBL was reset. Cancelling file transfer. ****\n\n");
+                    this.dispatchConsoleMessage(MessageType.INFO, "\n**** GRBL was reset. Canceling file transfer. ****\n\n");
                     cancelCommands();
                 }
                 

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -211,7 +211,8 @@ public class GrblController extends AbstractController {
 
                 // In case a reset occurred while streaming.
                 if (this.isStreaming()) {
-                    checkStreamFinished();
+                    this.dispatchConsoleMessage(MessageType.INFO, "\n**** GRBL was reset. Cancelling file transfer. ****\n\n");
+                    cancelCommands();
                 }
                 
                 this.grblVersion = GrblUtils.getVersionDouble(response);


### PR DESCRIPTION
This fixes the bug where UGS doesn't stop streaming commands when grbl is reset.

There is still a race condition present that could lead to one command still being executed by grbl after reset - see https://github.com/gnea/grbl/issues/793.  This race is easy to hit if you reset/abort the grbl controller while it's in the middle of a G4 dwell, because during a dwell grbl will not alarm if reset, and a reset/abort also cancels the dwell and causes "ok" to be sent immediately before the controller is reset.  I'm working on a fix for grbl as well.