### PR TITLE
fix for issue #1344

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -172,7 +172,7 @@ public abstract class AbstractController implements CommunicatorListener, IContr
      */
     @Override
     public void resetCoordinatesToZero() throws Exception {
-        setWorkPosition(new PartialPosition(0.0, 0.0, 0.0));
+        setWorkPosition(new PartialPosition(0.0, 0.0, 0.0, UnitUtils.Units.getUnits(getCurrentGcodeState().units)));
     }
     
     /**
@@ -180,7 +180,7 @@ public abstract class AbstractController implements CommunicatorListener, IContr
      */
     @Override
     public void resetCoordinateToZero(final Axis axis) throws Exception {
-        setWorkPosition(PartialPosition.from(axis, 0.0));
+        setWorkPosition(PartialPosition.from(axis, 0.0, UnitUtils.Units.getUnits(getCurrentGcodeState().units)));
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -465,8 +465,13 @@ public class GrblController extends AbstractController {
         if (!this.isCommOpen()) {
             throw new Exception("Must be connected to set work position");
         }
-
-        String gcode = GrblUtils.getSetCoordCommand(axisPosition, this.grblVersion, this.grblVersionLetter);
+        
+        if (axisPosition.getUnits() == UnitUtils.Units.UNKNOWN) {
+            throw new Exception("axisPosition must have units specified");
+        }
+    
+        String gcode = GrblUtils.getSetCoordCommand(axisPosition.getPositionIn(UnitUtils.Units.getUnits(getCurrentGcodeState().units)),
+                this.grblVersion, this.grblVersionLetter);
         if (StringUtils.isNotEmpty(gcode)) {
             GcodeCommand command = createCommand(gcode);
             this.sendCommandImmediately(command);

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -169,7 +169,7 @@ public class GrblUtils {
     /**
      * Generate a command to set the work coordinate position for multiple axis.
      *
-     * @param offsets the new work position to use (one ore more axis)
+     * @param offsets the new work position to use (one ore more axis) (Note: must already be converted to gcode state units)
      * @param grblVersion the GRBL version
      * @param grblVersionLetter the GRBL build version
      * @return a string with the gcode command

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -358,7 +358,11 @@ public class TinyGController extends AbstractController {
 
     @Override
     public void setWorkPosition(PartialPosition axisPosition) throws Exception {
-        String command = TinyGUtils.generateSetWorkPositionCommand(controllerStatus, getCurrentGcodeState(), axisPosition);
+        if (axisPosition.getUnits() == UnitUtils.Units.UNKNOWN) {
+            throw new Exception("axisPosition must have units specified");
+        }
+        String command = TinyGUtils.generateSetWorkPositionCommand(controllerStatus, getCurrentGcodeState(),
+                axisPosition.getPositionIn(UnitUtils.Units.getUnits(getCurrentGcodeState().units)));
         sendCommandImmediately(new GcodeCommand(command));
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
@@ -305,7 +305,7 @@ public class TinyGUtils {
      *
      * @param controllerStatus the current controller status
      * @param gcodeState       the current gcode state
-     * @param positions        the position to set
+     * @param positions        the position to set (Note: must already be converted to gcode state units)
      * @return a command for setting the position
      */
     public static String generateSetWorkPositionCommand(ControllerStatus controllerStatus, GcodeState gcodeState, PartialPosition positions) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/Utils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/Utils.java
@@ -38,7 +38,9 @@ import java.text.NumberFormat;
  */
 public class Utils {
 
-    public static NumberFormat formatter = new DecimalFormat("#.###", Localization.dfs);
+    public static NumberFormat mmFormatter = new DecimalFormat("#.###", Localization.dfs);
+    public static NumberFormat inchFormatter = new DecimalFormat("#.#####", Localization.dfs); // 5 decimals in inches gives similar precision to mm w/ 3
+    public static NumberFormat formatter = mmFormatter;
 
     public static String formattedMillis(long millis) {
         String format = String.format("%%0%dd", 2);  

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
@@ -59,6 +59,10 @@ public class PartialPosition {
         return new Builder().setValue(axis, value).build();
     }
 
+    public static PartialPosition from(Axis axis, Double value, UnitUtils.Units units) {
+        return new Builder().setValue(axis, value).setUnits(units).build();
+    }
+
     public static PartialPosition from(Position position) {
         return new PartialPosition(position.getX(), position.getY(), position.getZ(), position.getUnits());
     }
@@ -206,8 +210,7 @@ public class PartialPosition {
     }
 
     public String getFormattedGCode() {
-        return getFormattedGCode(Utils.formatter);
-
+        return getFormattedGCode(this.units == UnitUtils.Units.MM ? Utils.mmFormatter : Utils.inchFormatter);
     }
 
     public String getFormattedGCode(NumberFormat formatter) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/G2CoreControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/G2CoreControllerTest.java
@@ -300,7 +300,7 @@ public class G2CoreControllerTest {
         orderVerifier.verify(communicator).streamCommands();
 
         GcodeCommand command = queueCommandArgumentCaptor.getAllValues().get(0);
-        assertEquals("G20G90G1X0.039Y0.079Z0.118F39.37", command.getCommandString());
+        assertEquals("G20G90G1X0.03937Y0.07874Z0.11811F39.37", command.getCommandString());
         assertTrue(command.isGenerated());
         assertTrue(command.isTemporaryParserModalChange());
     }

--- a/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
@@ -263,7 +263,7 @@ public class TinyGControllerTest {
         orderVerifier.verify(communicator).streamCommands();
 
         GcodeCommand command = queueCommandArgumentCaptor.getAllValues().get(0);
-        assertEquals("G20G90G1X0.039Y0.079Z0.118F39.37", command.getCommandString());
+        assertEquals("G20G90G1X0.03937Y0.07874Z0.11811F39.37", command.getCommandString());
         assertTrue(command.isGenerated());
         assertTrue(command.isTemporaryParserModalChange());
     }

--- a/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
@@ -387,7 +387,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.X, "10.1");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.X, 10.1));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.X, 10.1, UnitUtils.Units.MM));
     }
 
     @Test
@@ -401,7 +401,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.Y, "10.1 * 10");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Y, 101.0));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Y, 101.0, UnitUtils.Units.MM));
     }
 
     @Test
@@ -415,7 +415,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.Y, "-10.1");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Y, -10.1));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Y, -10.1, UnitUtils.Units.MM));
     }
 
     @Test
@@ -429,7 +429,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.Y, "# + 10");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Y, 21.0));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Y, 21.0, UnitUtils.Units.MM));
     }
 
     @Test
@@ -443,7 +443,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.Z, "# * 10");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 110.0));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 110.0, UnitUtils.Units.MM));
     }
 
     @Test
@@ -457,7 +457,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.Z, "* 10");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 110.0));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 110.0, UnitUtils.Units.MM));
     }
 
     @Test
@@ -471,7 +471,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.Z, "# / 10");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 1.1));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 1.1, UnitUtils.Units.MM));
     }
 
     @Test
@@ -485,7 +485,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.Z, "/ 10");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 1.1));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.Z, 1.1, UnitUtils.Units.MM));
     }
 
     @Test
@@ -499,7 +499,7 @@ public class GUIBackendTest {
         instance.setWorkPositionUsingExpression(Axis.X, "# - 10");
 
         // Then
-        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.X, 1.0));
+        verify(controller, times(1)).setWorkPosition(PartialPosition.from(Axis.X, 1.0, UnitUtils.Units.MM));
     }
 
     @Test
@@ -510,10 +510,10 @@ public class GUIBackendTest {
         instance.statusStringListener(status);
 
         // When
-        instance.setWorkPosition(new PartialPosition(25.0,99.0));
+        instance.setWorkPosition(new PartialPosition(25.0,99.0,UnitUtils.Units.MM));
 
         // Then
-        verify(controller, times(1)).setWorkPosition(new PartialPosition(25.0,99.0));
+        verify(controller, times(1)).setWorkPosition(new PartialPosition(25.0,99.0, UnitUtils.Units.MM));
     }
 
 }


### PR DESCRIPTION
The fix for issue #1344 was to ensure that the AbstractController.setWorkPosition() function was always passed a PartialPosition that had the units specified, and to convert the units to match the gcode state before sending to the controller.  Once this started working, I noticed that when the DRO was in mm, but the Gcode state was Inches, that we ran into round-off errors because PartialPosition was always truncating off to 3 decimal places regardless of the units, so I put in a fix for that, and as a result had to modify some of the test code due to the additional precision.  Now, regardless of what the Jog/DRO unit state is and the Gcode unit state, when you enter a position into an axis in the DRO it will always convert to the proper units for the G10 L20 command sent to the controller.  Some modification was needed in the mathematical expression evaluation code also to ensure the proper units were being used.  I tested this in each possible permutation of jog units and gcode units and it all seems to work - a little more involved than I first thought.