### PR TITLE
Do not remove comments by default

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -944,7 +944,6 @@ public abstract class AbstractController implements CommunicatorListener, IContr
 
         try {
           parser.addCommand(command.getCommandString());
-          //System.out.println(parser.getCurrentState());
         } catch (Exception e) {
           logger.log(Level.SEVERE, "Problem parsing command.", e);
         }

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
@@ -55,7 +55,7 @@ public class GcodeParser implements IGcodeParser {
     // Current state
     private GcodeState state;
 
-    private final ArrayList<CommandProcessor> processors = new ArrayList<>();
+    private final List<CommandProcessor> processors = new ArrayList<>();
 
     private Stats statsProcessor;
 
@@ -230,7 +230,7 @@ public class GcodeParser implements IGcodeParser {
 
         // Error to mix group 1 (Motion) and certain group 0 (NonModal) codes (G10, G28, G30, G92)
         Collection<Code> motionCodes = gCodes.stream()
-                .filter(c -> c.consumesMotion())
+                .filter(Code::consumesMotion)
                 .collect(Collectors.toList());
 
         // 1 motion code per line.
@@ -250,7 +250,7 @@ public class GcodeParser implements IGcodeParser {
             if (i == UNKNOWN) {
                 logger.warning("An unknown gcode command was detected in: " + command);
             } else {
-                GcodeMeta meta = handleGCode(i, args, line, state, hasAxisWords);
+                GcodeMeta meta = handleGCode(i, args, line, state);
                 meta.command = command;
                 // Commands like 'G21' don't return a point segment.
                 if (meta.point != null) {
@@ -348,7 +348,7 @@ public class GcodeParser implements IGcodeParser {
      * 
      * A copy of the state object should go in the resulting GcodeMeta object.
      */
-    private static GcodeMeta handleGCode(final Code code, List<String> args, int line, GcodeState state, boolean hasAxisWords)
+    private static GcodeMeta handleGCode(final Code code, List<String> args, int line, GcodeState state)
             throws GcodeParserException {
         GcodeMeta meta = new GcodeMeta();
 
@@ -482,7 +482,7 @@ public class GcodeParser implements IGcodeParser {
     public List<String> preprocessCommand(String command, final GcodeState initialState) throws GcodeParserException {
         List<String> ret = new ArrayList<>();
         ret.add(command);
-        GcodeState tempState = null;
+        GcodeState tempState;
         for (CommandProcessor p : processors) {
             // Reset point segments after each pass. The final pass is what we will return.
             tempState = initialState.copy();

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodeParser.java
@@ -1,15 +1,5 @@
-/**
- * Object to parse gcode one command at a time in a way that can be used by any
- * other class which needs to know about the current state at a given command.
- * 
- * This object can be extended by adding in any number of ICommandProcessor
- * objects which are applied to each command in the order they were inserted
- * into the parser. These processors can be as simple as removing whitespace to
- * as complex as expanding a canned cycle or applying an leveling plane.
- */
-
 /*
-    Copyright 2013-2017 Will Winder
+    Copyright 2013-2020 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -49,6 +39,13 @@ import static com.willwinder.universalgcodesender.gcode.util.Code.*;
 import static com.willwinder.universalgcodesender.gcode.util.Code.ModalGroup.Motion;
 
 /**
+ * Object to parse gcode one command at a time in a way that can be used by any
+ * other class which needs to know about the current state at a given command.
+ *
+ * This object can be extended by adding in any number of ICommandProcessor
+ * objects which are applied to each command in the order they were inserted
+ * into the parser. These processors can be as simple as removing whitespace to
+ * as complex as expanding a canned cycle or applying an leveling plane.
  *
  * @author wwinder
  */
@@ -187,7 +184,7 @@ public class GcodeParser implements IGcodeParser {
     }
     
     /**
-     * Process commend given an initial state. This method will not modify its
+     * Process command given an initial state. This method will not modify its
      * input parameters.
      * 
      * @param includeNonMotionStates Create gcode meta responses even if there is no motion, for example "F100" will not

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -60,12 +60,12 @@ public class GcodePreprocessorUtils {
         // Check if command sets feed speed.
         Pattern pattern = Pattern.compile("F([0-9.]+)", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(command);
-        if (matcher.find()){
-            Double originalFeedRate = Double.parseDouble(matcher.group(1));
+        if (matcher.find()) {
+            double originalFeedRate = Double.parseDouble(matcher.group(1));
             //System.out.println( "Found feed     " + originalFeedRate.toString() );
-            Double newFeedRate      = originalFeedRate * speed / 100.0;
+            double newFeedRate = originalFeedRate * speed / 100.0;
             //System.out.println( "Change to feed " + newFeedRate.toString() );
-            returnString = matcher.replaceAll( "F" + newFeedRate.toString() );
+            returnString = matcher.replaceAll("F" + newFeedRate);
         }
 
         return returnString;
@@ -104,7 +104,7 @@ public class GcodePreprocessorUtils {
         Matcher matcher = decimalPattern.matcher(command);
 
         // Build up the truncated command.
-        Double d;
+        double d;
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             d = Double.parseDouble(matcher.group());
@@ -151,32 +151,8 @@ public class GcodePreprocessorUtils {
                 l.add(s.substring(1));
             }
         }
-        
+
         return l;
-    }
-    
-
-    static public List<Integer> parseGCodes(String command) {
-        Matcher matcher = GCODE_PATTERN.matcher(command);
-        List<Integer> codes = new ArrayList<>();
-        
-        while (matcher.find()) {
-            codes.add(Integer.parseInt(matcher.group(1)));
-        }
-        
-        return codes;
-    }
-
-    static private Pattern mPattern = Pattern.compile("[Mm]0*(\\d+)");
-    static public List<Integer> parseMCodes(String command) {
-        Matcher matcher = GCODE_PATTERN.matcher(command);
-        List<Integer> codes = new ArrayList<>();
-        
-        while (matcher.find()) {
-            codes.add(Integer.parseInt(matcher.group(1)));
-        }
-        
-        return codes;
     }
 
     /**
@@ -184,11 +160,11 @@ public class GcodePreprocessorUtils {
      */
     static public Position updatePointWithCommand(List<String> commandArgs, Position initial, boolean absoluteMode) {
 
-        Double x = parseCoord(commandArgs, 'X');
-        Double y = parseCoord(commandArgs, 'Y');
-        Double z = parseCoord(commandArgs, 'Z');
+        double x = parseCoord(commandArgs, 'X');
+        double y = parseCoord(commandArgs, 'Y');
+        double z = parseCoord(commandArgs, 'Z');
 
-        if (x.isNaN() && y.isNaN() && z.isNaN()) {
+        if (Double.isNaN(x) && Double.isNaN(y) && Double.isNaN(z)) {
             return null;
         }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -470,14 +470,13 @@ public class GcodePreprocessorUtils {
             boolean absoluteIJK,
             boolean clockwise,
             PlaneFormatter plane) {
-        double R = radius;
         Position center = new Position();
         
         // This math is copied from GRBL in gcode.c
         double x = plane.axis0(end) - plane.axis0(start);
         double y = plane.axis1(end) - plane.axis1(start);
 
-        double h_x2_div_d = 4 * R*R - x*x - y*y;
+        double h_x2_div_d = 4 * radius * radius - x * x - y * y;
         //if (h_x2_div_d < 0) { System.out.println("Error computing arc radius."); }
         h_x2_div_d = (-Math.sqrt(h_x2_div_d)) / Math.hypot(x, y);
 
@@ -487,10 +486,8 @@ public class GcodePreprocessorUtils {
 
         // Special message from gcoder to software for which radius
         // should be used.
-        if (R < 0) {
+        if (radius < 0) {
             h_x2_div_d = -h_x2_div_d;
-            // TODO: Places that use this need to run ABS on radius.
-            radius = -radius;
         }
 
         double offsetX = 0.5*(x-(y*h_x2_div_d));

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -484,6 +484,7 @@ public class GcodePreprocessorUtils {
 
     /**
      * Helper method for to convert IJK syntax to center point.
+     *
      * @return the center of rotation between two points with IJK codes.
      */
     static private Position convertRToCenter(
@@ -530,8 +531,9 @@ public class GcodePreprocessorUtils {
         return center;
     }
 
-    /** 
+    /**
      * Helper method for arc calculation
+     *
      * @return angle in radians of a line going from start to end.
      */
     static private double getAngle(final Position start, final Position end, PlaneFormatter plane) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtils.java
@@ -60,20 +60,20 @@ public class GcodeParserUtils {
     /**
      * Common logic in processAndExport* methods.
      */
-    private static void write(GcodeParser gcp, GcodeStreamWriter gsw, String original, String command, String comment, int idx) throws GcodeParserException {
+    private static void write(GcodeParser gcp, GcodeStreamWriter gsw, String command, String comment, int idx) throws GcodeParserException {
         if (idx % 100000 == 0) {
             logger.log(Level.FINE, "gcode processing line: " + idx);
         }
 
         if (StringUtils.isEmpty(command)) {
-            gsw.addLine(original, command, comment, idx);
+            gsw.addLine(command, command, comment, idx);
         }
         else {
             // Parse the gcode for the buffer.
             Collection<String> lines = gcp.preprocessCommand(command, gcp.getCurrentState());
 
             for(String processedLine : lines) {
-                gsw.addLine(original, processedLine, comment, idx);
+                gsw.addLine(command, processedLine, comment, idx);
             }
 
             gcp.addCommand(command);
@@ -95,7 +95,7 @@ public class GcodeParserUtils {
                 while (gsr.getNumRowsRemaining() > 0) {
                     i++;
                     GcodeCommand gc = gsr.getNextCommand();
-                    write(gcp, gsw, gc.getOriginalCommandString(), gc.getCommandString(), gc.getComment(), i);
+                    write(gcp, gsw, gc.getCommandString(), gc.getComment(), i);
                 }
 
                 // Done processing GcodeStream file.
@@ -121,9 +121,7 @@ public class GcodeParserUtils {
                     i++;
 
                     String comment = GcodePreprocessorUtils.parseComment(line);
-                    String commentRemoved = GcodePreprocessorUtils.removeComment(line);
-
-                    write(gcp, gsw, line, commentRemoved, comment, i);
+                    write(gcp, gsw, line, comment, i);
                 }
             }
         }

--- a/ugs-core/src/com/willwinder/universalgcodesender/types/GcodeCommand.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/types/GcodeCommand.java
@@ -43,7 +43,6 @@ public class GcodeCommand {
     private Boolean isError = false;
     private Integer commandNum = -1;
     private Boolean isSkipped = false;
-    private boolean isComment = false;
 
     /**
      * If this is a generated command not apart of any program such as jog or settings commands
@@ -61,11 +60,6 @@ public class GcodeCommand {
         this.command = command;
         this.commandNum = num;
         this.comment = GcodePreprocessorUtils.parseComment(command);
-        if (this.hasComment()) {
-            this.command = GcodePreprocessorUtils.removeComment(command);
-            if (this.command.trim().length() == 0)
-                this.isComment = true;
-        }
     }
 
     /**
@@ -141,10 +135,6 @@ public class GcodeCommand {
     
     public Boolean isSkipped() {
         return this.isSkipped;
-    }
-
-    public boolean isComment() {
-        return this.isComment;
     }
 
     public boolean hasComment() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamReader.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamReader.java
@@ -1,13 +1,5 @@
 /*
- * GcodeStreamReader.java
- *
- * Reads a 'GcodeStream' file containing command processing information, actual
- * command to send and other metadata like total number of commands.
- *
- * Created on Jan 7, 2016
- */
-/*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2020 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamReader.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamReader.java
@@ -20,20 +20,21 @@ package com.willwinder.universalgcodesender.utils;
 
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import java.io.BufferedReader;
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 
 /**
+ * Reads a 'GcodeStream' file containing command processing information, actual
+ * command to send and other metadata like total number of commands.
  *
  * @author wwinder
  */
 public class GcodeStreamReader extends GcodeStream implements IGcodeStreamReader {
-    BufferedReader reader;
-    int numRows;
-    int numRowsRemaining;
+    private BufferedReader reader;
+    private int numRows;
+    private int numRowsRemaining;
 
     public static class NotGcodeStreamFile extends Exception {}
 
@@ -47,7 +48,7 @@ public class GcodeStreamReader extends GcodeStream implements IGcodeStreamReader
                 throw new NotGcodeStreamFile();
             }
 
-            metadata = metadata.substring(super.metaPrefix.length(), metadata.length());
+            metadata = metadata.substring(super.metaPrefix.length());
             numRows = Integer.parseInt(metadata);
             numRowsRemaining = numRows;
         } catch (IOException | NumberFormatException e) {
@@ -77,12 +78,13 @@ public class GcodeStreamReader extends GcodeStream implements IGcodeStreamReader
     private String[] parseLine(String line) {
         return splitPattern.split(line, -1);
     }
+
     @Override
     public GcodeCommand getNextCommand() throws IOException {
         if (numRowsRemaining == 0) return null;
 
         String line = reader.readLine();
-        String nextLine[] = parseLine(line);
+        String[] nextLine = parseLine(line);
         if (nextLine.length != NUM_COLUMNS) {
             throw new IOException("Corrupt data found while processing gcode stream: " + line);
         }

--- a/ugs-core/src/resources/firmware_config/g2core.json
+++ b/ugs-core/src/resources/firmware_config/g2core.json
@@ -1,6 +1,6 @@
 {
     "Name": "g2core",
-    "Version": 6,
+    "Version": 7,
     "Controller": {
         "name": "g2core",
         "args": null
@@ -10,7 +10,7 @@
             {
                 "name": "CommentProcessor",
                 "enabled": true,
-                "optional": false
+                "optional": true
             },{
                 "name": "FeedOverrideProcessor",
                 "enabled": false,

--- a/ugs-core/test/com/willwinder/universalgcodesender/GcodePreprocessorUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GcodePreprocessorUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-    Copywrite 2018 Will Winder
+    Copyright 2018-2020 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -19,7 +19,9 @@
 package com.willwinder.universalgcodesender;
 
 import com.google.common.collect.ImmutableList;
+import com.willwinder.universalgcodesender.gcode.GcodeParser;
 import com.willwinder.universalgcodesender.gcode.GcodePreprocessorUtils;
+import com.willwinder.universalgcodesender.gcode.GcodeState;
 import com.willwinder.universalgcodesender.gcode.util.Code;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -268,5 +270,26 @@ public class GcodePreprocessorUtilsTest {
         assertEquals(4, splitted.size());
         assertEquals("G90", splitted.get(1));
         assertEquals("1", splitted.get(2));
+    }
+
+    @Test
+    public void splitCommandWithComments() {
+        List<String> splitted = GcodePreprocessorUtils.splitCommand("(comment)G1X10");
+        assertEquals(3, splitted.size());
+
+        splitted = GcodePreprocessorUtils.splitCommand("(comment)G1X10(comment)");
+        assertEquals(4, splitted.size());
+
+        splitted = GcodePreprocessorUtils.splitCommand(";commentG1X10(comment)");
+        assertEquals(1, splitted.size());
+    }
+
+    @Test
+    public void processCommandWithBlockComments() throws Exception {
+        List<String> splitted = GcodePreprocessorUtils.splitCommand("(hello world)G3");
+        assertThat(splitted.size()).isEqualTo(2);
+
+        splitted = GcodePreprocessorUtils.splitCommand("(1)(2)G3(3)");
+        assertThat(splitted.size()).isEqualTo(4);
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeParserTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodeParserTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2020 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -328,18 +328,14 @@ public class GcodeParserTest {
     }
 
     @Test
-    public void doubleParenCommentTest() throws Exception {
-        GcodeParser gcp = new GcodeParser();
-        gcp.addCommandProcessor(new CommentProcessor());
-
-
-
+    public void doubleParenCommentWithCommentProcessorTest() throws Exception {
         String command = "(comment (with subcomment) still in the comment) G01 X10";
         GcodeParser instance = new GcodeParser();
         instance.addCommandProcessor(new CommentProcessor());
         List<String> result = instance.preprocessCommand(command, instance.getCurrentState());
         assertEquals(1, result.size());
         assertEquals(" G01 X10", result.get(0));
+
     }
 
     @Test
@@ -398,6 +394,15 @@ public class GcodeParserTest {
         GcodeMeta meta = Iterables.getOnlyElement(metaList);
         assertThat(meta.code).isEqualTo(G3);
         assertThat(meta.state.currentPoint).isEqualTo(new Position(0, 0, 0, MM));
+    }
+
+    @Test
+    public void processCommandWithBlockComment() throws Exception {
+        List<GcodeMeta> metaList = GcodeParser.processCommand("(hello world)G3", 0, new GcodeState());
+        assertThat(metaList.size()).isEqualTo(1);
+
+        metaList = GcodeParser.processCommand("(1)(2)G3(3)", 0, new GcodeState());
+        assertThat(metaList.size()).isEqualTo(1);
     }
 
     @Test

--- a/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendPreprocessorTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendPreprocessorTest.java
@@ -91,7 +91,7 @@ public class GUIBackendPreprocessorTest {
          
         backend.preprocessAndExportToFile(gcp, inputFile.toFile(), outputFile.toFile());
 
-        List<String> expectedResults = Arrays.asList("line one", "line one", "", "line two", "line two");
+        List<String> expectedResults = Arrays.asList("line one", "line one", "", "", "line two", "line two");
 
         try (IGcodeStreamReader reader = new GcodeStreamReader(outputFile.toFile())) {
             Assert.assertEquals(expectedResults.size(), reader.getNumRows());


### PR DESCRIPTION
Fixes #1318

Removed the function in the gcode parsing that removes comments. This should be done by the preprocessor.