### PR TITLE
Now invalidates the action cache if something is created or updated.

### DIFF
--- a/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/service/JoystickServiceImpl.java
+++ b/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/service/JoystickServiceImpl.java
@@ -149,8 +149,12 @@ public class JoystickServiceImpl implements JoystickService {
     @Override
     public void destroy() {
         isRunning = false;
-        if (controllerManager != null && controllerManager.getNumControllers() > 0) {
-            controllerManager.quitSDLGamepad();
+        try {
+            if (controllerManager != null && controllerManager.getNumControllers() > 0) {
+                controllerManager.quitSDLGamepad();
+            }
+        } catch (IllegalStateException e) {
+            LOGGER.fine("Couldn't release the joystick manager: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
Fixes #1410 

Turns out I have the same problem once I fetched the latest code. I was working on another feature and thought I had the latest.

So I first tried using an annotation which will will run a method when starting (@OnStart) which didn't work. Then I tried one that will run once the GUI is showing (@OnShowing) which did work. But I realised that this would require a restart as soon as you add a macro or install plugins. 

So it will now invalidate the action cache if something is created or updated.