### PR TITLE
Now uses JSSC as a default connection driver on Linux

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -25,6 +25,7 @@ import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.types.Macro;
 import com.willwinder.universalgcodesender.types.WindowSettings;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -430,15 +431,23 @@ public class Settings {
     }
 
     public ConnectionDriver getConnectionDriver() {
-        ConnectionDriver connectionDriver = ConnectionDriver.JSERIALCOMM;
         if (StringUtils.isNotEmpty(this.connectionDriver)) {
             try {
-                connectionDriver = ConnectionDriver.valueOf(this.connectionDriver);
+                return ConnectionDriver.valueOf(this.connectionDriver);
             } catch (IllegalArgumentException | NullPointerException ignored) {
                 // Never mind, we'll use the default
             }
         }
-        return connectionDriver;
+
+        return getDefaultDriver();
+    }
+
+    private ConnectionDriver getDefaultDriver() {
+        ConnectionDriver result = ConnectionDriver.JSERIALCOMM;
+        if (SystemUtils.IS_OS_LINUX) {
+            result = ConnectionDriver.JSSC;
+        }
+        return result;
     }
 
     public void setConnectionDriver(ConnectionDriver connectionDriver) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
@@ -53,15 +53,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.newCapture;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reset;
-import static org.easymock.EasyMock.verify;
+import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -145,7 +137,7 @@ public class AbstractControllerTest {
         expect(expectLastCall()).anyTimes();
         mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall()).anyTimes();
-        mockCommunicator.connect(ConnectionDriver.JSERIALCOMM, port, portRate);
+        mockCommunicator.connect(or(eq(ConnectionDriver.JSERIALCOMM), eq(ConnectionDriver.JSSC)), eq(port), eq(portRate));
         expect(instance.isCommOpen()).andReturn(false).once();
         expect(instance.isCommOpen()).andReturn(true).anyTimes();
         expect(instance.handlesAllStateChangeEvents()).andReturn(handleStateChange).anyTimes();


### PR DESCRIPTION
Windows and MacOSX can successfully use JSerialComm but Linux have problems with it and still needs JSSC.
Made JSSC default driver on Linux.

Temporary fix for #1213