### PR TITLE
Fixed scaling problems when using dark theme

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ButtonGridPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/ButtonGridPanel.java
@@ -1,3 +1,21 @@
+/*
+    Copyright 2020 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.universalgcodesender.uielements.panels;
 
 import com.willwinder.universalgcodesender.uielements.helpers.SteppedSizeManager;
@@ -7,6 +25,12 @@ import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.util.Arrays;
 
+/**
+ * The button grid panel tries to adjust the columns and rows of several buttons so that
+ * the have the best fit for the given size.
+ *
+ * @author Joacim Breiler
+ */
 public class ButtonGridPanel extends JPanel {
 
     public ButtonGridPanel() {

--- a/ugs-platform/ugs-platform-plugin-toolbox/src/main/java/com/willwinder/ugs/nbp/toolbox/ToolboxTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-toolbox/src/main/java/com/willwinder/ugs/nbp/toolbox/ToolboxTopComponent.java
@@ -67,9 +67,7 @@ public final class ToolboxTopComponent extends TopComponent implements ISettings
         actionRegistrationService = Lookup.getDefault().lookup(ActionRegistrationService.class);
         buttonGridPanel = new ButtonGridPanel();
 
-        JScrollPane scrollPane = new JScrollPane(buttonGridPanel, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollPane.setBorder(createEmptyBorder());
-        add(scrollPane, BorderLayout.CENTER);
+        add(buttonGridPanel, BorderLayout.CENTER);
         settingsChanged();
     }
 


### PR DESCRIPTION
When using the dark theme it won't adjust columns when shrinking the window. Needed to remove the scrollbar.