### PR TITLE
Removed the CommandLengthProcessor from the default rules.

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -318,7 +318,6 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
         parser.addCommandProcessor(new WhitespaceProcessor());
         parser.addCommandProcessor(new M30Processor());
         parser.addCommandProcessor(new DecimalProcessor(4));
-        parser.addCommandProcessor(new CommandLengthProcessor(50));
     }
 
     @Override


### PR DESCRIPTION
This caused problems when loading files while not connected to the machine.
Fixes #1496