### PR TITLE
Fixed problem with opening files on windows

### DIFF
--- a/ugs-platform/pom.xml
+++ b/ugs-platform/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
       <maven.build.timestamp.format>yyyy.MM.dd.HH.mm</maven.build.timestamp.format>
-      <netbeans.version>RELEASE120-1</netbeans.version>
+      <netbeans.version>RELEASE122</netbeans.version>
       <ugs.app.title>Universal Gcode Platform ${project.version}</ugs.app.title>
       <ugs.appbundle.name>Universal Gcode Platform</ugs.appbundle.name>
 

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/GcodeDataObject.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/GcodeDataObject.java
@@ -18,25 +18,18 @@
 */
 package com.willwinder.ugs.nbp.editor;
 
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
-import com.willwinder.universalgcodesender.model.BackendAPI;
-import org.openide.ErrorManager;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
-import org.openide.filesystems.FileAttributeEvent;
-import org.openide.filesystems.FileChangeListener;
-import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileRenameEvent;
 import org.openide.filesystems.MIMEResolver;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.MultiDataObject;
 import org.openide.loaders.MultiFileLoader;
 import org.openide.util.NbBundle.Messages;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 @Messages({
         "LBL_Gcode_LOADER=Files of Gcode"
@@ -106,53 +99,11 @@ import java.io.IOException;
         )
 })
 public class GcodeDataObject extends MultiDataObject {
+    private static final Logger LOGGER = Logger.getLogger(GcodeDataObject.class.getName());
 
     public GcodeDataObject(FileObject pf, MultiFileLoader loader) throws IOException {
         super(pf, loader);
         registerEditor(GcodeLanguageConfig.MIME_TYPE, true);
-        BackendAPI backend = CentralLookup.getDefault().lookup(BackendAPI.class);
-
-        try {
-            backend.setGcodeFile(new File(pf.getPath()));
-        } catch (Exception e) {
-            ErrorManager.getDefault().notify(ErrorManager.WARNING, e);
-        }
-
-        pf.addFileChangeListener(new FileChangeListener() {
-            @Override
-            public void fileFolderCreated(FileEvent fe) {
-
-            }
-
-            @Override
-            public void fileDataCreated(FileEvent fe) {
-
-            }
-
-            @Override
-            public void fileChanged(FileEvent fe) {
-                try {
-                    backend.reloadGcodeFile();
-                } catch (Exception e) {
-                    ErrorManager.getDefault().notify(ErrorManager.WARNING, e);
-                }
-            }
-
-            @Override
-            public void fileDeleted(FileEvent fe) {
-
-            }
-
-            @Override
-            public void fileRenamed(FileRenameEvent fe) {
-
-            }
-
-            @Override
-            public void fileAttributeChanged(FileAttributeEvent fe) {
-
-            }
-        });
     }
 
     @Override

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/GcodeFileListener.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/GcodeFileListener.java
@@ -1,0 +1,71 @@
+/*
+    Copyright 2016-2021 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package com.willwinder.ugs.nbp.editor;
+
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import org.openide.ErrorManager;
+import org.openide.filesystems.FileAttributeEvent;
+import org.openide.filesystems.FileChangeListener;
+import org.openide.filesystems.FileEvent;
+import org.openide.filesystems.FileRenameEvent;
+
+/**
+ * Listens to external file change events and updates it on the controller
+ */
+public class GcodeFileListener implements FileChangeListener {
+
+    @Override
+    public void fileFolderCreated(FileEvent fe) {
+
+    }
+
+    @Override
+    public void fileDataCreated(FileEvent fe) {
+
+    }
+
+    @Override
+    public void fileChanged(FileEvent fe) {
+        try {
+            BackendAPI backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+            // Do not reload the file if the machine is running.
+            if (backend.isIdle() || !backend.isConnected()) {
+                backend.reloadGcodeFile();
+            }
+        } catch (Exception e) {
+            ErrorManager.getDefault().notify(ErrorManager.WARNING, e);
+        }
+    }
+
+    @Override
+    public void fileDeleted(FileEvent fe) {
+
+    }
+
+    @Override
+    public void fileRenamed(FileRenameEvent fe) {
+
+    }
+
+    @Override
+    public void fileAttributeChanged(FileAttributeEvent fe) {
+
+    }
+}


### PR DESCRIPTION
The GcodeDataObject is not recreated on windows if opening the same file twice. Needed to move the opening code to the SourceMultiViewElement instead and listen to if the TopComponent is opened.

Should fix the issue: #1507