### PR TITLE
Bugfix/dynamic action registration

### DIFF
--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroAction.java
@@ -1,0 +1,60 @@
+package com.willwinder.ugs.nbp.core.control;
+
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.MacroHelper;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import com.willwinder.universalgcodesender.model.UGSEvent;
+import com.willwinder.universalgcodesender.types.Macro;
+import com.willwinder.universalgcodesender.utils.GUIHelpers;
+import org.openide.util.Exceptions;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.io.Serializable;
+
+public class MacroAction extends AbstractAction implements Serializable {
+    private transient BackendAPI backend;
+    private Macro macro;
+
+    public MacroAction() {
+
+    }
+
+    public MacroAction(BackendAPI b, Macro macro) {
+        this.macro = macro;
+        getBackend().addUGSEventListener(this::onEvent);
+    }
+
+    private BackendAPI getBackend() {
+        if (backend == null) {
+            backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+        }
+        return backend;
+    }
+
+    private void onEvent(UGSEvent event) {
+        if (event != null && event.isStateChangeEvent()) {
+            EventQueue.invokeLater(() -> setEnabled(isEnabled()));
+        }
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (macro != null && macro.getGcode() != null) {
+            EventQueue.invokeLater(() -> {
+                try {
+                    MacroHelper.executeCustomGcode(macro.getGcode(), getBackend());
+                } catch (Exception ex) {
+                    GUIHelpers.displayErrorDialog(ex.getMessage());
+                    Exceptions.printStackTrace(ex);
+                }
+            });
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return getBackend().isConnected() && getBackend().isIdle();
+    }
+}

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroAction.java
@@ -17,8 +17,10 @@ public class MacroAction extends AbstractAction implements Serializable {
     private transient BackendAPI backend;
     private Macro macro;
 
+    /**
+     * Empty constructor to be used for serialization
+     */
     public MacroAction() {
-
     }
 
     public MacroAction(BackendAPI b, Macro macro) {

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
@@ -97,39 +97,5 @@ public final class MacroService {
         }
     }
 
-    protected class MacroAction extends AbstractAction {
-        private BackendAPI backend;
-        private Macro macro;
 
-        public MacroAction(BackendAPI b, Macro macro) {
-            backend = b;
-            this.macro = macro;
-            backend.addUGSEventListener(this::onEvent);
-        }
-
-        private void onEvent(UGSEvent event) {
-            if (event != null && event.isStateChangeEvent()) {
-                EventQueue.invokeLater(() -> setEnabled(isEnabled()));
-            }
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent e) {
-            if (macro != null && macro.getGcode() != null) {
-                EventQueue.invokeLater(() -> {
-                    try {
-                        MacroHelper.executeCustomGcode(macro.getGcode(), backend);
-                    } catch (Exception ex) {
-                        GUIHelpers.displayErrorDialog(ex.getMessage());
-                        Exceptions.printStackTrace(ex);
-                    }
-                });
-            }
-        }
-
-        @Override
-        public boolean isEnabled() {
-            return backend.isConnected() && backend.isIdle();
-        }
-    }
 }

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogAction.java
@@ -1,3 +1,21 @@
+/*
+    Copyright 2016-2021 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.ugs.nbp.core.services;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogAction.java
@@ -1,0 +1,53 @@
+package com.willwinder.ugs.nbp.core.services;
+
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.services.JogService;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+
+public class JogAction extends AbstractAction {
+
+    private transient JogService js;
+    private int x, y, z, a, b, c;
+
+    /**
+     * Empty constructor to be used for serialization
+     */
+    public JogAction() {
+    }
+
+    public JogAction(Integer x, Integer y, Integer z, Integer a, Integer b, Integer c) {
+        js = CentralLookup.getDefault().lookup(JogService.class);
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.a = a;
+        this.b = b;
+        this.c = c;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (z != 0) {
+            getJogService().adjustManualLocationZ(z);
+        } else if (x != 0 || y != 0) {
+            getJogService().adjustManualLocationXY(x, y);
+        } else if (a != 0 || b != 0 || c != 0) {
+            getJogService().adjustManualLocationABC(a, b, c);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return getJogService().canJog();
+    }
+
+    private JogService getJogService() {
+        if (js == null) {
+            js = CentralLookup.getDefault().lookup(JogService.class);
+        }
+
+        return js;
+    }
+}

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogActionService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogActionService.java
@@ -18,18 +18,18 @@
  */
 package com.willwinder.ugs.nbp.core.services;
 
-import static com.willwinder.ugs.nbp.core.services.JogActionService.Operation.*;
-import com.willwinder.ugs.nbp.lib.services.ActionRegistrationService;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.lib.services.ActionRegistrationService;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.services.JogService;
-import java.awt.event.ActionEvent;
-import java.io.IOException;
-import javax.swing.AbstractAction;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;
+
+import java.io.IOException;
+
+import static com.willwinder.ugs.nbp.core.services.JogSizeAction.Operation.*;
 
 /**
  * A service for registering jog actions such as menu items and shortcuts
@@ -38,10 +38,8 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=JogActionService.class) 
 public class JogActionService {
-    private JogService jogService;
 
     public JogActionService() {
-        jogService = CentralLookup.getDefault().lookup(JogService.class);
         initActions();
     }
 
@@ -61,44 +59,44 @@ public class JogActionService {
 
             // Jog plus/minus X
             ars.registerAction(JogActionService.class.getCanonicalName() + ".xPlus", Localization.getString("jogging.xPlus") ,
-                    category, "M-RIGHT" , menuPath, 0, localized, new JogAction(jogService, 1, 0));
+                    category, "M-RIGHT" , menuPath, 0, localized, new JogAction(1, 0, 0, 0, 0, 0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".xMinus", Localization.getString("jogging.xMinus"),
-                    category, "M-LEFT"  , menuPath, 0, localized, new JogAction(jogService,-1, 0));
+                    category, "M-LEFT"  , menuPath, 0, localized, new JogAction(-1, 0, 0, 0, 0, 0));
             // Jog plus/minus Y
             ars.registerAction(JogActionService.class.getCanonicalName() + ".yPlus", Localization.getString("jogging.yPlus") ,
-                    category, "M-UP"    , menuPath, 0, localized, new JogAction(jogService, 0, 1));
+                    category, "M-UP"    , menuPath, 0, localized, new JogAction(0, 1, 0, 0, 0,0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".yMinus", Localization.getString("jogging.yMinus"),
-                    category, "M-DOWN"  , menuPath, 0, localized, new JogAction(jogService, 0,-1));
+                    category, "M-DOWN"  , menuPath, 0, localized, new JogAction( 0,-1, 0,0 ,0 ,0));
             // Jog plus/minus Z
             ars.registerAction(JogActionService.class.getCanonicalName() + ".zPlus", Localization.getString("jogging.zPlus") ,
-                    category, "SM-UP"   , menuPath, 0, localized, new JogAction(jogService, 1));
+                    category, "SM-UP"   , menuPath, 0, localized, new JogAction(0, 0, 1, 0,0, 0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".zMinus", Localization.getString("jogging.zMinus"),
-                    category, "SM-DOWN" , menuPath, 0, localized, new JogAction(jogService, -1));
+                    category, "SM-DOWN" , menuPath, 0, localized, new JogAction(0, 0,-1, 0,0,0));
             // Jog plus/minus A
             ars.registerAction(JogActionService.class.getCanonicalName() + ".aPlus", Localization.getString("jogging.aPlus") ,
-                    category, null   , menuPath, 0, localized, new JogAction(jogService, 0, 0, 0, 1, 0, 0));
+                    category, null   , menuPath, 0, localized, new JogAction(0, 0, 0, 1, 0, 0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".aMinus", Localization.getString("jogging.aMinus"),
-                    category, null , menuPath, 0, localized, new JogAction(jogService, 0, 0, 0, -1, 0, 0));
+                    category, null , menuPath, 0, localized, new JogAction(0, 0, 0, -1, 0, 0));
             // Jog plus/minus B
             ars.registerAction(JogActionService.class.getCanonicalName() + ".bPlus", Localization.getString("jogging.bPlus") ,
-                    category, null , menuPath, 0, localized, new JogAction(jogService, 0, 0, 0, 0, 1, 0));
+                    category, null , menuPath, 0, localized, new JogAction(0, 0, 0, 0, 1, 0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".bMinus", Localization.getString("jogging.bMinus"),
-                    category, null , menuPath, 0, localized, new JogAction(jogService, 0, 0, 0, 0, -1, 0));
+                    category, null , menuPath, 0, localized, new JogAction(0, 0, 0, 0, -1, 0));
             // Jog plus/minus C
             ars.registerAction(JogActionService.class.getCanonicalName() + ".cPlus", Localization.getString("jogging.cPlus") ,
-                    category, null , menuPath, 0, localized, new JogAction(jogService, 0, 0, 0, 0, 0, 1));
+                    category, null , menuPath, 0, localized, new JogAction(0, 0, 0, 0, 0, 1));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".cMinus", Localization.getString("jogging.cMinus"),
-                    category, null , menuPath, 0, localized, new JogAction(jogService, 0, 0, 0, 0, 0, -1));
+                    category, null , menuPath, 0, localized, new JogAction(0, 0, 0, 0, 0, -1));
 
             // Jog Diagonals
             ars.registerAction(JogActionService.class.getCanonicalName() + ".xPlus.yPlus", Localization.getString("jogging.xPlus.yPlus") ,
-                    category, null , menuPath, 0, localized, new JogAction(jogService, 1, 1));
+                    category, null , menuPath, 0, localized, new JogAction( 1, 1, 0,0,0,0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".xPlus.yMinus", Localization.getString("jogging.xPlus.yMinus") ,
-                    category, null , menuPath, 0, localized, new JogAction(jogService, 1, -1));
+                    category, null , menuPath, 0, localized, new JogAction( 1, -1,0,0,0,0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".xMinus.yMinus", Localization.getString("jogging.xMinus.yMinus") ,
-                    category, null , menuPath, 0, localized, new JogAction(jogService, -1, -1));
+                    category, null , menuPath, 0, localized, new JogAction(-1, -1,0 ,0,0,0));
             ars.registerAction(JogActionService.class.getCanonicalName() + ".xMinus.yPlus", Localization.getString("jogging.xMinus.yPlus") ,
-                    category, null , menuPath, 0, localized, new JogAction(jogService, -1, 1));
+                    category, null , menuPath, 0, localized, new JogAction( -1, 1, 0,0,0,0));
 
             localized = String.format("Menu/%s/%s/%s",
                     Localization.getString("platform.menu.machine"),
@@ -108,259 +106,90 @@ public class JogActionService {
 
             // Set Step Size XY
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "xy.10", "XY 10",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 10, StepType.XY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(10, JogSizeAction.StepType.XY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "xy.1", "XY 1",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 1, StepType.XY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(1, JogSizeAction.StepType.XY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "xy.01", "XY 0.1",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.1, StepType.XY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.1, JogSizeAction.StepType.XY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "xy.001", "XY 0.01",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.01, StepType.XY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.01, JogSizeAction.StepType.XY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "xy.0001", "XY 0.001",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.001, StepType.XY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.001, JogSizeAction.StepType.XY));
 
             // Set Step Size Z
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "z.10", "Z 10",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 10, StepType.Z));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(10, JogSizeAction.StepType.Z));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "z.1", "Z 1",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 1, StepType.Z));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(1, JogSizeAction.StepType.Z));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "z.01", "Z 0.1",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.1, StepType.Z));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.1, JogSizeAction.StepType.Z));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "z.001", "Z 0.01",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.01, StepType.Z));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.01, JogSizeAction.StepType.Z));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "z.0001", "Z 0.001",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.001, StepType.Z));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.001, JogSizeAction.StepType.Z));
 
             // Set Step Size ABC
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "abc.10", "ABC 10",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 10, StepType.ABC));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(10, JogSizeAction.StepType.ABC));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "abc.1", "ABC 1",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 1, StepType.ABC));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(1, JogSizeAction.StepType.ABC));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "abc.01", "ABC 0.1",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.1, StepType.ABC));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.1, JogSizeAction.StepType.ABC));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "abc.001", "ABC 0.01",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.01, StepType.ABC));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.01, JogSizeAction.StepType.ABC));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + "abc.0001", "ABC 0.001",
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, 0.001, StepType.ABC));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(0.001, JogSizeAction.StepType.ABC));
 
             // Modify Step Size XY
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".divide", Localization.getString("jogging.divide"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPXY_DIVIDE));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPXY_DIVIDE));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".multiply", Localization.getString("jogging.multiply"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPXY_MULTIPLY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPXY_MULTIPLY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".decrease", Localization.getString("jogging.decrease"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPXY_MINUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPXY_MINUS));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".increase", Localization.getString("jogging.increase"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPXY_PLUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPXY_PLUS));
 
             // Modify Step Size Z
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".divide.z", Localization.getString("jogging.divide.z"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPZ_DIVIDE));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPZ_DIVIDE));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".multiply.z", Localization.getString("jogging.multiply.z"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPZ_MULTIPLY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPZ_MULTIPLY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".decrease.z", Localization.getString("jogging.decrease.z"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPZ_MINUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPZ_MINUS));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".increase.z", Localization.getString("jogging.increase.z"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPZ_PLUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPZ_PLUS));
 
             // Modify Step Size ABC
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".divide.abc", Localization.getString("jogging.divide.abc"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPABC_DIVIDE));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPABC_DIVIDE));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".multiply.abc", Localization.getString("jogging.multiply.abc"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPABC_MULTIPLY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPABC_MULTIPLY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".decrease.abc", Localization.getString("jogging.decrease.abc"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPABC_MINUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPABC_MINUS));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".increase.abc", Localization.getString("jogging.increase.abc"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, STEPABC_PLUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(STEPABC_PLUS));
 
             // Feed Rate
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".decrease.feed", Localization.getString("jogging.decrease.feed"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, FEED_MINUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(FEED_MINUS));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".increase.feed", Localization.getString("jogging.increase.feed"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, FEED_PLUS));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(FEED_PLUS));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".multiply.feed", Localization.getString("jogging.multiply.feed"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, FEED_MULTIPLY));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(FEED_MULTIPLY));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".divide.feed", Localization.getString("jogging.divide.feed"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, FEED_DIVIDE));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(FEED_DIVIDE));
 
             // Units
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".inch", Localization.getString("jogging.units.inch"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, Units.INCH));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(Units.INCH));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".mm", Localization.getString("jogging.units.mm"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, Units.MM));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(Units.MM));
             ars.registerAction(JogSizeAction.class.getCanonicalName() + ".toggle", Localization.getString("jogging.units.toggle"),
-                    category, "" , menuPath, 0, localized, new JogSizeAction(jogService, UNITS_TOGGLE));
+                    category, "" , menuPath, 0, localized, new JogSizeAction(UNITS_TOGGLE));
 
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
-        }
-    }
-
-    protected enum Operation {
-      STEPXY_PLUS,
-      STEPXY_MINUS,
-      STEPXY_MULTIPLY,
-      STEPXY_DIVIDE,
-      STEPZ_PLUS,
-      STEPZ_MINUS,
-      STEPZ_MULTIPLY,
-      STEPZ_DIVIDE,
-      STEPABC_PLUS,
-      STEPABC_MINUS,
-      STEPABC_MULTIPLY,
-      STEPABC_DIVIDE,
-      FEED_PLUS,
-      FEED_MINUS,
-      FEED_MULTIPLY,
-      FEED_DIVIDE,
-      UNITS_TOGGLE
-    }
-
-    protected enum StepType {
-        XY,
-        Z,
-        ABC
-    }
-
-    protected class JogSizeAction extends AbstractAction {
-        private JogService js;
-        private Double size = null;
-        private Operation operation = null;
-        private Units unit = null;
-        private StepType type = null;
-
-        public JogSizeAction(JogService service, Units u) {
-            js = service;
-            unit = u;
-        }
-        public JogSizeAction(JogService service, Operation op) {
-            js = service;
-            operation = op;
-        }
-
-        public JogSizeAction(JogService service, double size, StepType type) {
-            js = service;
-            this.size = size;
-            this.type = type;
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent e) {
-            if (size != null) {
-                switch (type) {
-                    case XY:
-                        js.setStepSizeXY(size);
-                        break;
-                    case Z:
-                        js.setStepSizeZ(size);
-                        break;
-                    case ABC:
-                        js.setStepSizeABC(size);
-                        break;
-                }
-            }
-            else if (operation != null) {
-                switch (operation) {
-                    case STEPXY_MULTIPLY:
-                        js.multiplyXYStepSize();
-                        break;
-                    case STEPXY_DIVIDE:
-                        js.divideXYStepSize();
-                        break;
-                    case STEPXY_PLUS:
-                        js.increaseXYStepSize();
-                        break;
-                    case STEPXY_MINUS:
-                        js.decreaseXYStepSize();
-                        break;
-                    case STEPZ_MULTIPLY:
-                        js.multiplyZStepSize();
-                        break;
-                    case STEPZ_DIVIDE:
-                        js.divideZStepSize();
-                        break;
-                    case STEPZ_PLUS:
-                        js.increaseZStepSize();
-                        break;
-                    case STEPZ_MINUS:
-                        js.decreaseZStepSize();
-                        break;
-                    case STEPABC_MULTIPLY:
-                        js.multiplyABCStepSize();
-                        break;
-                    case STEPABC_DIVIDE:
-                        js.divideABCStepSize();
-                        break;
-                    case STEPABC_PLUS:
-                        js.increaseABCStepSize();
-                        break;
-                    case STEPABC_MINUS:
-                        js.decreaseABCStepSize();
-                        break;
-                    case FEED_PLUS:
-                        js.increaseFeedRate();
-                        break;
-                    case FEED_MINUS:
-                        js.decreaseFeedRate();
-                        break;
-                    case FEED_MULTIPLY:
-                        js.multiplyFeedRate();
-                        break;
-                    case FEED_DIVIDE:
-                        js.divideFeedRate();
-                        break;
-                    case UNITS_TOGGLE:
-                        js.setUnits(js.getUnits() == Units.MM ? Units.INCH : Units.MM);
-                        break;
-                    default:
-                        break;
-                }
-            } else if (unit != null) {
-                js.setUnits(unit);
-            }
-        }
-
-        @Override
-        public boolean isEnabled() {
-            return true;
-        }
-    }
-
-    protected class JogAction extends AbstractAction {
-        private JogService js;
-        private int x,y,z,a,b,c;
-
-        public JogAction(JogService service, int x, int y, int z, int a, int b, int c) {
-            js = service;
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.a = a;
-            this.b = b;
-            this.c = c;
-        }
-
-        public JogAction(JogService service, int x, int y) {
-            this(service, x, y, 0, 0, 0, 0);
-        }
-
-        public JogAction(JogService service, int z) {
-            this(service, 0, 0, z, 0, 0, 0);
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent e) {
-            if (z != 0) {
-                js.adjustManualLocationZ(z);
-            } else if (x != 0 || y != 0) {
-                js.adjustManualLocationXY(x, y);
-            } else if (a != 0 || b != 0 || c != 0) {
-                js.adjustManualLocationABC(a, b, c);
-            }
-        }
-
-        @Override
-        public boolean isEnabled() {
-            return js.canJog();
         }
     }
 }

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogActionService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogActionService.java
@@ -18,11 +18,9 @@
  */
 package com.willwinder.ugs.nbp.core.services;
 
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.nbp.lib.services.ActionRegistrationService;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
-import com.willwinder.universalgcodesender.services.JogService;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogSizeAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogSizeAction.java
@@ -1,3 +1,21 @@
+/*
+    Copyright 2016-2021 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.ugs.nbp.core.services;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogSizeAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/JogSizeAction.java
@@ -1,0 +1,150 @@
+package com.willwinder.ugs.nbp.core.services;
+
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.services.JogService;
+import com.willwinder.universalgcodesender.model.UnitUtils.Units;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.io.Serializable;
+
+public class JogSizeAction extends AbstractAction implements Serializable {
+    public enum Operation {
+        STEPXY_PLUS,
+        STEPXY_MINUS,
+        STEPXY_MULTIPLY,
+        STEPXY_DIVIDE,
+        STEPZ_PLUS,
+        STEPZ_MINUS,
+        STEPZ_MULTIPLY,
+        STEPZ_DIVIDE,
+        STEPABC_PLUS,
+        STEPABC_MINUS,
+        STEPABC_MULTIPLY,
+        STEPABC_DIVIDE,
+        FEED_PLUS,
+        FEED_MINUS,
+        FEED_MULTIPLY,
+        FEED_DIVIDE,
+        UNITS_TOGGLE
+    }
+
+    public enum StepType {
+        XY,
+        Z,
+        ABC
+    }
+
+    private transient JogService js;
+    private Double size = null;
+    private Operation operation = null;
+    private Units unit = null;
+    private StepType type = null;
+
+    /**
+     * Empty constructor to be used for serialization
+     */
+    public JogSizeAction() {
+    }
+
+    public JogSizeAction(Units u) {
+        unit = u;
+    }
+
+    public JogSizeAction(Operation op) {
+        operation = op;
+    }
+
+    public JogSizeAction(double size, StepType type) {
+        this.size = size;
+        this.type = type;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (size != null) {
+            switch (type) {
+                case XY:
+                    getJogService().setStepSizeXY(size);
+                    break;
+                case Z:
+                    getJogService().setStepSizeZ(size);
+                    break;
+                case ABC:
+                    getJogService().setStepSizeABC(size);
+                    break;
+            }
+        } else if (operation != null) {
+            switch (operation) {
+                case STEPXY_MULTIPLY:
+                    js.multiplyXYStepSize();
+                    break;
+                case STEPXY_DIVIDE:
+                    getJogService().divideXYStepSize();
+                    break;
+                case STEPXY_PLUS:
+                    getJogService().increaseXYStepSize();
+                    break;
+                case STEPXY_MINUS:
+                    getJogService().decreaseXYStepSize();
+                    break;
+                case STEPZ_MULTIPLY:
+                    getJogService().multiplyZStepSize();
+                    break;
+                case STEPZ_DIVIDE:
+                    getJogService().divideZStepSize();
+                    break;
+                case STEPZ_PLUS:
+                    getJogService().increaseZStepSize();
+                    break;
+                case STEPZ_MINUS:
+                    getJogService().decreaseZStepSize();
+                    break;
+                case STEPABC_MULTIPLY:
+                    getJogService().multiplyABCStepSize();
+                    break;
+                case STEPABC_DIVIDE:
+                    getJogService().divideABCStepSize();
+                    break;
+                case STEPABC_PLUS:
+                    getJogService().increaseABCStepSize();
+                    break;
+                case STEPABC_MINUS:
+                    getJogService().decreaseABCStepSize();
+                    break;
+                case FEED_PLUS:
+                    getJogService().increaseFeedRate();
+                    break;
+                case FEED_MINUS:
+                    getJogService().decreaseFeedRate();
+                    break;
+                case FEED_MULTIPLY:
+                    getJogService().multiplyFeedRate();
+                    break;
+                case FEED_DIVIDE:
+                    getJogService().divideFeedRate();
+                    break;
+                case UNITS_TOGGLE:
+                    getJogService().setUnits(js.getUnits() == Units.MM ? Units.INCH : Units.MM);
+                    break;
+                default:
+                    break;
+            }
+        } else if (unit != null) {
+            getJogService().setUnits(unit);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    private JogService getJogService() {
+        if (js == null) {
+            js = CentralLookup.getDefault().lookup(JogService.class);
+        }
+
+        return js;
+    }
+}

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/OverrideAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/OverrideAction.java
@@ -18,38 +18,50 @@
  */
 package com.willwinder.ugs.nbp.core.services;
 
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.Overrides;
+import org.openide.util.Lookup;
 
 import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
+import java.io.Serializable;
 
 /**
  * Defines an action for an override command
  *
  * @author wwinder
  */
-public class OverrideAction extends AbstractAction {
-    private final OverrideActionService overrideActionService;
-    private final Overrides action;
+public class OverrideAction extends AbstractAction implements Serializable {
+    private OverrideActionService overrideActionService;
+    private Overrides action;
+
+    public OverrideAction() {
+    }
 
     /**
      * Constructor
      *
-     * @param overrideActionService the service for running the action
      * @param action                the action to execute
      */
-    public OverrideAction(OverrideActionService overrideActionService, Overrides action) {
-        this.overrideActionService = overrideActionService;
+    public OverrideAction(Overrides action) {
         this.action = action;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        overrideActionService.runAction(action);
+        getOverrideActionService().runAction(action);
+    }
+
+    private OverrideActionService getOverrideActionService() {
+        if(overrideActionService == null) {
+            overrideActionService = Lookup.getDefault().lookup(OverrideActionService.class);
+        }
+        return overrideActionService;
     }
 
     @Override
     public boolean isEnabled() {
-        return overrideActionService.canRunAction();
+        return getOverrideActionService().canRunAction();
     }
 }

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/OverrideAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/OverrideAction.java
@@ -18,8 +18,6 @@
  */
 package com.willwinder.ugs.nbp.core.services;
 
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
-import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.Overrides;
 import org.openide.util.Lookup;
 
@@ -36,6 +34,9 @@ public class OverrideAction extends AbstractAction implements Serializable {
     private OverrideActionService overrideActionService;
     private Overrides action;
 
+    /**
+     * Empty constructor to be used for serialization
+     */
     public OverrideAction() {
     }
 

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/OverrideActionService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/services/OverrideActionService.java
@@ -75,23 +75,23 @@ public class OverrideActionService {
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".feedOvrCoarseMinus", String.format(pattern, OverridesPanel.MINUS_COARSE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_FEED_OVR_COARSE_MINUS));
+                    new OverrideAction(Overrides.CMD_FEED_OVR_COARSE_MINUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".feedOvrFineMinus", String.format(pattern, OverridesPanel.MINUS_FINE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_FEED_OVR_FINE_MINUS));
+                    new OverrideAction(Overrides.CMD_FEED_OVR_FINE_MINUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".feedOvrFinePlus", String.format(pattern, OverridesPanel.PLUS_FINE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_FEED_OVR_FINE_PLUS));
+                    new OverrideAction(Overrides.CMD_FEED_OVR_FINE_PLUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".feedOvrCoarsePlus", String.format(pattern, OverridesPanel.PLUS_COARSE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_FEED_OVR_COARSE_PLUS));
+                    new OverrideAction(Overrides.CMD_FEED_OVR_COARSE_PLUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".feedOvrReset", String.format(pattern, OverridesPanel.RESET_FEED),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_FEED_OVR_RESET));
+                    new OverrideAction(Overrides.CMD_FEED_OVR_RESET));
 
             // Spindle Overrides
             menuPath = "Menu/Machine/Overrides";
@@ -102,23 +102,23 @@ public class OverrideActionService {
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".spindleOvrCoarseMinus", String.format(pattern, OverridesPanel.MINUS_COARSE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_SPINDLE_OVR_COARSE_MINUS));
+                    new OverrideAction(Overrides.CMD_SPINDLE_OVR_COARSE_MINUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".spindleOvrFineMinus", String.format(pattern, OverridesPanel.MINUS_FINE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_SPINDLE_OVR_FINE_MINUS));
+                    new OverrideAction(Overrides.CMD_SPINDLE_OVR_FINE_MINUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".spindleOvrFinePlus", String.format(pattern, OverridesPanel.PLUS_FINE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_SPINDLE_OVR_FINE_PLUS));
+                    new OverrideAction(Overrides.CMD_SPINDLE_OVR_FINE_PLUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".spindleOvrCoarsePlus", String.format(pattern, OverridesPanel.PLUS_COARSE),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_SPINDLE_OVR_COARSE_PLUS));
+                    new OverrideAction(Overrides.CMD_SPINDLE_OVR_COARSE_PLUS));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".spindleOvrReset", String.format(pattern, Localization.getString("mainWindow.swing.reset")),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_SPINDLE_OVR_RESET));
+                    new OverrideAction(Overrides.CMD_SPINDLE_OVR_RESET));
 
             // Rapid Overrides
             menuPath = "Menu/Machine/Overrides";
@@ -130,15 +130,15 @@ public class OverrideActionService {
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".rapidOvrLow", String.format(pattern, OverridesPanel.RAPID_LOW),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_RAPID_OVR_LOW));
+                    new OverrideAction(Overrides.CMD_RAPID_OVR_LOW));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".rapidOvrMedium", String.format(pattern, OverridesPanel.RAPID_MEDIUM),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_RAPID_OVR_MEDIUM));
+                    new OverrideAction(Overrides.CMD_RAPID_OVR_MEDIUM));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".rapidOvrReset", String.format(pattern, OverridesPanel.RAPID_FULL),
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_RAPID_OVR_RESET));
+                    new OverrideAction(Overrides.CMD_RAPID_OVR_RESET));
 
             // Toggles
             menuPath = "Menu/Machine/Overrides/Toggles";
@@ -149,15 +149,15 @@ public class OverrideActionService {
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".toggleSpindle", OverridesPanel.SPINDLE_SHORT,
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_TOGGLE_SPINDLE));
+                    new OverrideAction(Overrides.CMD_TOGGLE_SPINDLE));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".toogleFloodCoolant", OverridesPanel.FLOOD,
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_TOGGLE_FLOOD_COOLANT));
+                    new OverrideAction(Overrides.CMD_TOGGLE_FLOOD_COOLANT));
 
             ars.registerAction(OverrideAction.class.getCanonicalName() + ".toggleMistCoolant", OverridesPanel.MIST,
                     category, null, menuPath, 0, localized,
-                    new OverrideAction(this, Overrides.CMD_TOGGLE_MIST_COOLANT));
+                    new OverrideAction(Overrides.CMD_TOGGLE_MIST_COOLANT));
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
         }


### PR DESCRIPTION
The config files for the dynamically created actions did not contain the serialized parameters for the actions. And some actions did not have an empty default constructor and prevents the action to be deserialized. It seems that the action class may not be nested either for deserialization to work. Before these changes a config file looked like this:

/Actions/Macro/.nbattr:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
<attributes version="1.0">
    <fileobject name="com.willwinder.ugs.nbp.core.control.MacroAction.Go to Zero.instance">
        <attr name="instanceClass" stringvalue="com.willwinder.ugs.nbp.core.control.MacroAction"/>
        <attr name="instanceCreate" serialvalue=""/>
    </fileobject>
    <fileobject name="com.willwinder.ugs.nbp.core.control.MacroAction.Macro #1.instance">
        <attr name="instanceClass" stringvalue="com.willwinder.ugs.nbp.core.control.MacroAction"/>
        <attr name="instanceCreate" serialvalue=""/>
    </fileobject>
</attributes>
```

After these changes it looked like this:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
<attributes version="1.0">
    <fileobject name="com.willwinder.ugs.nbp.core.control.MacroAction.Go to Zero.instance">
        <attr name="instanceClass" stringvalue="com.willwinder.ugs.nbp.core.control.MacroAction"/>
        <attr name="instanceCreate" serialvalue="aced00057372002f636f6d2e77696c6c77696e6465722e7567732e6e62702e636f72652e636f6e74726f6c2e4d6163726f416374696f6e830411a4a62185d30200014c00056d6163726f7400314c636f6d2f77696c6c77696e6465722f756e6976657273616c67636f646573656e6465722f74797065732f4d6163726f3b7872001a6a617661782e7377696e672e4162737472616374416374696f6ed5402533d63258e50300025a0007656e61626c65644c000d6368616e6765537570706f727474002e4c6a617661782f7377696e672f6576656e742f5377696e6750726f70657274794368616e6765537570706f72743b787001707704000000017400044e616d6574000a476f20746f205a65726f787372002f636f6d2e77696c6c77696e6465722e756e6976657273616c67636f646573656e6465722e74797065732e4d6163726f7a1f4c6ebb9fea430200034c000b6465736372697074696f6e7400124c6a6176612f6c616e672f537472696e673b4c000567636f646571007e00084c00046e616d6571007e000878707074000a4739312058302059303b71007e0006"/>
    </fileobject>
    <fileobject name="com.willwinder.ugs.nbp.core.control.MacroAction.Macro #1.instance">
        <attr name="instanceClass" stringvalue="com.willwinder.ugs.nbp.core.control.MacroAction"/>
        <attr name="instanceCreate" serialvalue="aced00057372002f636f6d2e77696c6c77696e6465722e7567732e6e62702e636f72652e636f6e74726f6c2e4d6163726f416374696f6e830411a4a62185d30200014c00056d6163726f7400314c636f6d2f77696c6c77696e6465722f756e6976657273616c67636f646573656e6465722f74797065732f4d6163726f3b7872001a6a617661782e7377696e672e4162737472616374416374696f6ed5402533d63258e50300025a0007656e61626c65644c000d6368616e6765537570706f727474002e4c6a617661782f7377696e672f6576656e742f5377696e6750726f70657274794368616e6765537570706f72743b787001707704000000017400044e616d657400084d6163726f202331787372002f636f6d2e77696c6c77696e6465722e756e6976657273616c67636f646573656e6465722e74797065732e4d6163726f7a1f4c6ebb9fea430200034c000b6465736372697074696f6e7400124c6a6176612f6c616e672f537472696e673b4c000567636f646571007e00084c00046e616d6571007e00087870707400042431207371007e0006"/>
    </fileobject>
</attributes>
```

So the actions should now always be loaded properly on startup from netbeans. On most computers this doesn't matter, because the ActionRegistrationService is executed before/after netbeans tries to load the actions from the config files. But for some these actions can't be loaded and prevents the actions to be available.

See error report here:
https://groups.google.com/g/universal-gcode-sender/c/q5wdEQSZZTU