### PR TITLE
flakiness in bucket

### DIFF
--- a/ugs-platform/ugs-platform-plugin-cloud-storage/src/test/java/com/willwinder/ugs/nbp/S3FileSystemViewTest.java
+++ b/ugs-platform/ugs-platform-plugin-cloud-storage/src/test/java/com/willwinder/ugs/nbp/S3FileSystemViewTest.java
@@ -100,6 +100,8 @@ public class S3FileSystemViewTest {
         // Compare result to original file.
         byte[] results = Files.readAllBytes(localFile.toPath());
         Assert.assertArrayEquals(fileContents, results);
+    
+        instance.minioClient.removeBucket("test-files");
     }
     
     @Test


### PR DESCRIPTION
The test com.willwinder.ugs.nbp.S3FileSystemViewTest.testGetFiles asserts that under the directory "s3:/test-files/" there
are two files. However, the createBucket method has a caching method that saves the bucket with the same name across tests. So if another test like
com.willwinder.ugs.nbp.S3FileSystemViewTest.testUploadDownloadFile calls the method createBucket with the same name
and then puts files under this bucket, it will pollute the cached bucket and the assertion will fail.