### PR TITLE
Resetting localization before tests

### DIFF
--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -126,7 +126,7 @@ public class GrblControllerTest {
 
     @Test
     public void testGetGrblVersion() throws Exception {
-        Localization.initialize(settings.getLanguage());
+        Localization.initialize("en_US");
 
         System.out.println("getGrblVersion");
         GrblController instance = new GrblController(mgc);
@@ -524,7 +524,7 @@ public class GrblControllerTest {
      */
     @Test
     public void testIsReadyToStreamFile() throws Exception {
-        Localization.initialize(settings.getLanguage());
+        Localization.initialize("en_US");
 
         System.out.println("isReadyToStreamFile");
         GrblController instance = new GrblController(mgc);
@@ -1272,7 +1272,7 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerWithKnownErrorShouldWriteMessageToConsole() throws Exception {
-        Localization.initialize(settings.getLanguage());
+        Localization.initialize("en_US");
 
         // Given
         GrblController instance = new GrblController(mgc);
@@ -1299,7 +1299,7 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerWithUnknownErrorShouldWriteGenericMessageToConsole() throws Exception {
-        Localization.initialize(settings.getLanguage());
+        Localization.initialize("en_US");
 
         // Given
         GrblController instance = new GrblController(mgc);
@@ -1324,7 +1324,7 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerOnErrorWithNoSentCommandsShouldSendMessageToConsole() throws Exception {
-        Localization.initialize(settings.getLanguage());
+        Localization.initialize("en_US");
 
         // Given
         GrblController instance = new GrblController(mgc);

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -100,6 +100,7 @@ public class GrblControllerTest {
         Field f = GUIHelpers.class.getDeclaredField("unitTestMode");
         f.setAccessible(true);
         f.set(null, true);
+        Localization.initialize("en_US");
     }
 
     @After
@@ -126,8 +127,6 @@ public class GrblControllerTest {
 
     @Test
     public void testGetGrblVersion() throws Exception {
-        Localization.initialize("en_US");
-
         System.out.println("getGrblVersion");
         GrblController instance = new GrblController(mgc);
         String result;
@@ -524,8 +523,6 @@ public class GrblControllerTest {
      */
     @Test
     public void testIsReadyToStreamFile() throws Exception {
-        Localization.initialize("en_US");
-
         System.out.println("isReadyToStreamFile");
         GrblController instance = new GrblController(mgc);
 
@@ -1272,8 +1269,6 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerWithKnownErrorShouldWriteMessageToConsole() throws Exception {
-        Localization.initialize("en_US");
-
         // Given
         GrblController instance = new GrblController(mgc);
         instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
@@ -1299,8 +1294,6 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerWithUnknownErrorShouldWriteGenericMessageToConsole() throws Exception {
-        Localization.initialize("en_US");
-
         // Given
         GrblController instance = new GrblController(mgc);
         instance.setDistanceModeCode("G90");
@@ -1324,8 +1317,6 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerOnErrorWithNoSentCommandsShouldSendMessageToConsole() throws Exception {
-        Localization.initialize("en_US");
-
         // Given
         GrblController instance = new GrblController(mgc);
         instance.setDistanceModeCode("G90");

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -20,6 +20,7 @@ package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.AbstractController.UnexpectedCommand;
 import com.willwinder.universalgcodesender.gcode.util.Code;
+import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.MessageType;
@@ -125,6 +126,8 @@ public class GrblControllerTest {
 
     @Test
     public void testGetGrblVersion() throws Exception {
+        Localization.initialize(settings.getLanguage());
+
         System.out.println("getGrblVersion");
         GrblController instance = new GrblController(mgc);
         String result;
@@ -521,6 +524,8 @@ public class GrblControllerTest {
      */
     @Test
     public void testIsReadyToStreamFile() throws Exception {
+        Localization.initialize(settings.getLanguage());
+
         System.out.println("isReadyToStreamFile");
         GrblController instance = new GrblController(mgc);
 
@@ -1267,6 +1272,8 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerWithKnownErrorShouldWriteMessageToConsole() throws Exception {
+        Localization.initialize(settings.getLanguage());
+
         // Given
         GrblController instance = new GrblController(mgc);
         instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
@@ -1292,6 +1299,8 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerWithUnknownErrorShouldWriteGenericMessageToConsole() throws Exception {
+        Localization.initialize(settings.getLanguage());
+
         // Given
         GrblController instance = new GrblController(mgc);
         instance.setDistanceModeCode("G90");
@@ -1315,6 +1324,8 @@ public class GrblControllerTest {
 
     @Test
     public void rawResponseHandlerOnErrorWithNoSentCommandsShouldSendMessageToConsole() throws Exception {
+        Localization.initialize(settings.getLanguage());
+
         // Given
         GrblController instance = new GrblController(mgc);
         instance.setDistanceModeCode("G90");


### PR DESCRIPTION
Tests in com.willwinder.universalgcodesender.GrblControllerTest have assertions that rely on the localization setting being US, and the localization is shared between tests. If a test like com.willwinder.universalgcodesender.i18n.LocalizationTest.loadLocalizationThatDoesExistShouldLoad changes the localization without setting it back, it will pollute that shared state and these tests that run afterwards would fail. This pull request proposes to explicitly set the localization before tests are run as to ensure they do not fail when run after LocalizationTest.loadLocalizationThatDoesExistShouldLoad.