### PR TITLE
Fix ClassNotFoundException classpath error

### DIFF
--- a/ugs-platform/ugs-platform-plugin-dro/pom.xml
+++ b/ugs-platform/ugs-platform-plugin-dro/pom.xml
@@ -37,6 +37,7 @@
             <artifactId>ugs-core</artifactId>
             <version>${project.version}</version>
             <type>jar</type>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/ugs-platform/ugs-platform-plugin-jog/pom.xml
+++ b/ugs-platform/ugs-platform-plugin-jog/pom.xml
@@ -41,6 +41,7 @@
             <artifactId>ugs-core</artifactId>
             <version>${project.version}</version>
             <type>jar</type>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/ugs-platform/ugs-platform-plugin-joystick/pom.xml
+++ b/ugs-platform/ugs-platform-plugin-joystick/pom.xml
@@ -33,10 +33,16 @@
             <type>jar</type>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.willwinder.universalgcodesender</groupId>
             <artifactId>ugs-core</artifactId>
             <version>${project.version}</version>
             <type>jar</type>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Joystick -->


### PR DESCRIPTION
Fix the problem for running tests during the build of ugs-platform-app.

[INFO] ugs-platform-plugin-dro ............................ SUCCESS [  4.410 s]
[INFO] ugs-platform-app ................................... FAILURE [ 17.721 s]

Failure is caused by the error that occurs because two different modules
that depends from each other have same ugs-core jar in the classpath
and this causes error because the class is loaded from the wrong
classpath. Exact error printed out by the netbeans classloader:

Caused by: java.lang.ClassNotFoundException: Will not load class
com.willwinder.universalgcodesender.model.UnitUtils$Units arbitrarily
from one of
ModuleCL@0[com.willwinder.ugs.platform.ugslib] and
ModuleCL@1[com.willwinder.ugs.platform.plugin.joystick]
starting from SystemClassLoader[133 modules];
see http://wiki.netbeans.org/DevFaqModuleCCE
  org.netbeans.ProxyClassLoader.doFindClass(ProxyClassLoader.java:191)
  org.netbeans.ProxyClassLoader.loadClass(ProxyClassLoader.java:125)

Fixes https://github.com/winder/Universal-G-Code-Sender/issues/1584

Signed-off-by: Mika Laitio <lamikr@gmail.com>