### PR TITLE
fix nodejs segfault build problem

### DIFF
--- a/ugs-pendant/pom.xml
+++ b/ugs-pendant/pom.xml
@@ -118,8 +118,8 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v10.15.0</nodeVersion>
-                                    <npmVersion>6.4.1</npmVersion>
+                                    <nodeVersion>v16.0.0</nodeVersion>
+                                    <npmVersion>7.10.0</npmVersion>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
Currently used nodejs v10.15.0 segfaults during the
build on systemcs which have also a newer systemwide
nodejs installed and prevents the build to complete.

Tested that upgrading nodejs to some newer versions like
10.16.3, 10.17.0, 14.16.0 or latest 16.0.0 fixes the
build problem.

Similar error and fix has been reported here:
https://github.com/eirslett/frontend-maven-plugin/issues/826

Fixes https://github.com/winder/Universal-G-Code-Sender/issues/1587

Signed-off-by: Mika Laitio <lamikr@gmail.com>