### PR TITLE
fix saving of last opened project state

### DIFF
--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/GcodeFileListener.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/GcodeFileListener.java
@@ -25,11 +25,13 @@ import org.openide.filesystems.FileAttributeEvent;
 import org.openide.filesystems.FileChangeListener;
 import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileRenameEvent;
+import java.io.Serializable;
 
 /**
  * Listens to external file change events and updates it on the controller
  */
-public class GcodeFileListener implements FileChangeListener {
+public class GcodeFileListener implements FileChangeListener, Serializable {
+    private static final long serialVersionUID = 7255903502190131123L;
 
     @Override
     public void fileFolderCreated(FileEvent fe) {

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
@@ -38,7 +38,7 @@ import java.io.File;
         position = 1000
 )
 public class SourceMultiviewElement extends MultiViewEditorElement {
-
+    private static final long serialVersionUID = 7255236202190135442L;
     private static EditorListener editorListener = new EditorListener();
     private final GcodeDataObject obj;
     private final GcodeFileListener fileListener;


### PR DESCRIPTION
Serialization errors prevented the saving of currently
opened project state and prevented the app to remember
if some gcode was open when app was closed.

NotSerializable error that occurs can be tested with following steps
1) start the ugs-platform with command: mvn nbm:run-platform -pl ugs-platform/application
2) open gcode file
3) closes the ugs-platform
4) Errors in console were shown from the serialization errors
5) restart ugs-platform and previously opened gcode should open automatically

Fixes: https://github.com/winder/Universal-G-Code-Sender/issues/1589

Signed-off-by: Mika Laitio <lamikr@gmail.com>