### PR TITLE
This fixes a serial buffer overrun that can happen in some cases when…

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/BufferedCommunicator.java
@@ -213,7 +213,7 @@ public abstract class BufferedCommunicator extends AbstractCommunicator {
                 continue;
             }
 
-            String commandString = command.getCommandString().trim();
+            String commandString = command.getCommandString();
             
             this.activeCommandList.add(command);
             this.sentBufferSize += (commandString.length() + 1);

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -39,8 +39,8 @@ import java.util.regex.Pattern;
  */
 public class GrblUtils {
     
-    // Note: 5 characters of this buffer reserved for real time commands.
-    public static final int GRBL_RX_BUFFER_SIZE= 123;
+    // Note: The Grbl RX buffer is not consumed by real-time commands
+    public static final int GRBL_RX_BUFFER_SIZE= 128;
 
     /**
      * Grbl commands

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblCommunicatorTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblCommunicatorTest.java
@@ -212,7 +212,7 @@ public class GrblCommunicatorTest {
         MockConnection mc = new MockConnection(mg.in, mg.out);
         GrblCommunicator instance = new GrblCommunicator(cb, asl, mc);
         String term = "\n";
-        String thirtyNineCharString = "thirty-nine character command here.....";
+        String thirtyCharString = "thirty character command......";
 
         boolean result;
         boolean expResult;
@@ -223,13 +223,14 @@ public class GrblCommunicatorTest {
         assertEquals(13, CommUtils.getSizeOfBuffer(l));
 
         // Make sure GrblUtils hasn't updated RX buffer size.
-        assertEquals(123, GrblUtils.GRBL_RX_BUFFER_SIZE);
+        assertEquals(128, GrblUtils.GRBL_RX_BUFFER_SIZE);
 
         // Add a bunch of commands so that the buffer is full.
-        // 39*3 + 3 newlines + 3 CommUtils caution  = 123 == buffer size.
-        instance.queueCommand(new GcodeCommand(thirtyNineCharString));
-        instance.queueCommand(new GcodeCommand(thirtyNineCharString));
-        instance.queueCommand(new GcodeCommand(thirtyNineCharString));
+        // (30 characters + 1 newline + 1 commUtils safety character) * 4 = 128
+        instance.queueCommand(new GcodeCommand(thirtyCharString));
+        instance.queueCommand(new GcodeCommand(thirtyCharString));
+        instance.queueCommand(new GcodeCommand(thirtyCharString));
+        instance.queueCommand(new GcodeCommand(thirtyCharString));
 
         // Stream them so that there are active commands.
         instance.streamCommands();
@@ -238,7 +239,7 @@ public class GrblCommunicatorTest {
         assertEquals(expResult, result);
 
         // Add another command and stream it so that something is queued.
-        instance.queueCommand(new GcodeCommand(thirtyNineCharString));
+        instance.queueCommand(new GcodeCommand(thirtyCharString));
         instance.streamCommands();
         expResult = true;
         result = instance.areActiveCommands();
@@ -246,7 +247,7 @@ public class GrblCommunicatorTest {
 
         // Check with MockGrbl to verify the fourth command wasn't sent.
         String output = mg.readStringFromGrblBuffer();
-        String goal = thirtyNineCharString+term+thirtyNineCharString+term+thirtyNineCharString+term;
+        String goal = thirtyCharString+term+thirtyCharString+term+thirtyCharString+term+thirtyCharString+term;
         assertEquals(goal, output);
         
         // Make room for the next command.
@@ -257,9 +258,10 @@ public class GrblCommunicatorTest {
         
         // Make sure the queued command was sent.
         output = mg.readStringFromGrblBuffer();
-        assertEquals(thirtyNineCharString+term, output);
+        assertEquals(thirtyCharString+term, output);
   
         // Wrap up.
+        mc.sendResponse("ok");
         mc.sendResponse("ok");
         mc.sendResponse("ok");
         mc.sendResponse("ok");


### PR DESCRIPTION
… a command has whitespace on it (ie, from a multi-command macro).  This also fixes the Grbl buffer size to be 128 - it was conservatively set at 123 with the assumption that space needed to be allocated for real-time commands. This is not true. Real-time commands do not consume ring buffer space. Updated the GrblCommunicator test to reflect the buffer size change.

Without this fix, I can reliably produce a buffer overrun by running a simple macro (G20; G53 G0 Z0;G53 G0 X0 Y2.6) 16 times and then running a previously-loaded gcode program.  The reason the macro has to be run a number of times is that the sent byte count gets increasingly off each time the macro is run (because of the .trim()'d command being used for the byte count when sending, but not using .trim() on the command when adjusting the byte count when the response is received.

With the fix in place, I cannot reproduce the buffer overrun.

The overrun was difficult to debug because it manifests as dropped characters - when the Grbl firmware receives a serial byte and the buffer is full, it's silently ignored (!!), which can end up causing a whole bunch of unpredictable behavior - weird error messages about badly formatted gcode, and even machine movements that were not intended resulting in crashes.  In order to help debug this, I modified the Grbl firmware slightly so that if there was ever a byte received when the ring buffer was full, it would mc_reset() and go into the ALARM state - this protects against executing corrupt code, and it made it a lot easier to diagnose and fix this problem.