### PR TITLE
fix for issue #1341

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -651,29 +651,16 @@ public abstract class AbstractController implements CommunicatorListener, IContr
     @Override
     public void cancelSend() throws Exception {
         this.dispatchConsoleMessage(MessageType.INFO, "\n**** Canceling file transfer. ****\n\n");
-
         cancelSendBeforeEvent();
-
-        // Don't clear the command queue, there might be a situation where a
-        // send is in progress while the next queue is being built. In which
-        // case a cancel would only be expected to cancel the current action
-        // to make way for the queued commands.
-        //this.prepQueue.clear();
-
         cancelCommands();
-
-        // If there are no active commands, done streaming. Otherwise wait for
-        // them to finish.
-        if (!comm.areActiveCommands()) {
-            this.isStreaming = false;
-        }
-
         cancelSendAfterEvent();
     }
 
     @Override
     public void cancelCommands() {
         this.comm.cancelSend();
+        this.isStreaming = false;
+        if (this.streamStopWatch.isStarted()) this.streamStopWatch.stop();
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -202,7 +202,8 @@ public class GrblController extends AbstractController {
 
                 // In case a reset occurred while streaming.
                 if (this.isStreaming()) {
-                    checkStreamFinished();
+                    this.dispatchConsoleMessage(MessageType.INFO, "\n**** GRBL was reset. Canceling file transfer. ****\n\n");
+                    cancelCommands();
                 }
                 
                 this.grblVersion = GrblUtils.getVersionDouble(response);


### PR DESCRIPTION
This fixes issue #1341 - If the Grbl controller has a physical button connected to the reset/abort input, and it's pressed while UGS is streaming commands, UGS doesn't properly detect that Grbl has been reset and does not stop streaming, which could lead to a machine crash.