### PR TITLE
Designer geometry split

### DIFF
--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gcode/toolpaths/AbstractToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gcode/toolpaths/AbstractToolPath.java
@@ -1,14 +1,14 @@
 package com.willwinder.ugs.nbp.designer.gcode.toolpaths;
 
 import com.willwinder.ugs.nbp.designer.gcode.path.*;
-import org.locationtech.jts.geom.CoordinateSequence;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LinearRing;
+import com.willwinder.ugs.nbp.designer.gcode.path.Coordinate;
+import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -79,37 +79,8 @@ public abstract class AbstractToolPath implements PathGenerator {
         gcodePath.addSegment(SegmentType.MOVE, new NumericCoordinate(0d));
     }
 
-    protected LinearRing pathToLinearRing(GcodePath gcodePath) {
-        List<org.locationtech.jts.geom.Coordinate> coordinateList = gcodePath.getSegments().stream()
-                .map(segment -> pointToCoordinate(segment.getPoint()))
-                .collect(Collectors.toList());
-
-        coordinateList.add(pointToCoordinate(gcodePath.getSegments().get(0).getPoint()));
-
-        CoordinateSequence points = new CoordinateArraySequence(coordinateList.toArray(new org.locationtech.jts.geom.Coordinate[]{}));
-        GeometryFactory factory = new GeometryFactory();
-        return new LinearRing(points, factory);
-    }
-
-    private org.locationtech.jts.geom.Coordinate pointToCoordinate(com.willwinder.ugs.nbp.designer.gcode.path.Coordinate point) {
-        return new org.locationtech.jts.geom.Coordinate(point.get(Axis.X), point.get(Axis.Y), point.get(Axis.Z));
-    }
-
     public GeometryFactory getGeometryFactory() {
         return geometryFactory;
-    }
-
-    protected List<NumericCoordinate> geometryToCoordinates(Geometry geometry) {
-        org.locationtech.jts.geom.Coordinate[] coordinates = geometry.getCoordinates();
-        return Arrays.stream(coordinates)
-                .map(c -> new NumericCoordinate(c.getX(), c.getY(), c.getZ()))
-                .collect(Collectors.toList());
-    }
-
-    protected Geometry simplifyGeometry(Geometry bufferedGeometry) {
-        DouglasPeuckerSimplifier simplifier = new DouglasPeuckerSimplifier(bufferedGeometry);
-        simplifier.setDistanceTolerance(0.01);
-        return simplifier.getResultGeometry();
     }
 
     protected GcodePath toGcodePath(List<List<NumericCoordinate>> coordinateList) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gcode/toolpaths/SimplePocket.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gcode/toolpaths/SimplePocket.java
@@ -30,6 +30,8 @@ import org.locationtech.jts.geom.Polygon;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.willwinder.ugs.nbp.designer.gcode.toolpaths.ToolPathUtils.*;
+
 /**
  * @author Joacim Breiler
  */
@@ -96,17 +98,7 @@ public class SimplePocket extends AbstractToolPath {
         return toGcodePath(coordinateList);
     }
 
-    private List<Geometry> toGeometryList(Geometry geometry) {
-        if (geometry instanceof MultiPolygon) {
-            List<Geometry> geometryList = new ArrayList<>();
-            for (int i = 0; i < geometry.getNumGeometries(); i++) {
-                geometryList.add(geometry.getGeometryN(i));
-            }
-            return geometryList;
-        }
 
-        return Collections.singletonList(geometry);
-    }
 
     public void setStepOver(double stepOver) {
         this.stepOver = Math.min(Math.max(0.01, Math.abs(stepOver)), 1.0);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gcode/toolpaths/ToolPathUtils.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gcode/toolpaths/ToolPathUtils.java
@@ -1,0 +1,57 @@
+package com.willwinder.ugs.nbp.designer.gcode.toolpaths;
+
+import com.willwinder.ugs.nbp.designer.gcode.path.Axis;
+import com.willwinder.ugs.nbp.designer.gcode.path.GcodePath;
+import com.willwinder.ugs.nbp.designer.gcode.path.NumericCoordinate;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ToolPathUtils {
+    public static List<Geometry> toGeometryList(Geometry geometry) {
+        if (geometry instanceof MultiPolygon) {
+            List<Geometry> geometryList = new ArrayList<>();
+            for (int i = 0; i < geometry.getNumGeometries(); i++) {
+                geometryList.add(geometry.getGeometryN(i));
+            }
+            return geometryList;
+        }
+
+        return Collections.singletonList(geometry);
+    }
+
+    public static List<NumericCoordinate> geometryToCoordinates(Geometry geometry) {
+        org.locationtech.jts.geom.Coordinate[] coordinates = geometry.getCoordinates();
+        return Arrays.stream(coordinates)
+                .map(c -> new NumericCoordinate(c.getX(), c.getY(), c.getZ()))
+                .collect(Collectors.toList());
+    }
+
+    public static Geometry simplifyGeometry(Geometry bufferedGeometry) {
+        DouglasPeuckerSimplifier simplifier = new DouglasPeuckerSimplifier(bufferedGeometry);
+        simplifier.setDistanceTolerance(0.01);
+        return simplifier.getResultGeometry();
+    }
+
+    public static LinearRing pathToLinearRing(GcodePath gcodePath) {
+        List<org.locationtech.jts.geom.Coordinate> coordinateList = gcodePath.getSegments().stream()
+                .map(segment -> pointToCoordinate(segment.getPoint()))
+                .collect(Collectors.toList());
+
+        coordinateList.add(pointToCoordinate(gcodePath.getSegments().get(0).getPoint()));
+
+        CoordinateSequence points = new CoordinateArraySequence(coordinateList.toArray(new org.locationtech.jts.geom.Coordinate[]{}));
+        GeometryFactory factory = new GeometryFactory();
+        return new LinearRing(points, factory);
+    }
+
+    private static org.locationtech.jts.geom.Coordinate pointToCoordinate(com.willwinder.ugs.nbp.designer.gcode.path.Coordinate point) {
+        return new org.locationtech.jts.geom.Coordinate(point.get(Axis.X), point.get(Axis.Y), point.get(Axis.Z));
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/ugsd/v1/EntityPathV1.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/ugsd/v1/EntityPathV1.java
@@ -20,7 +20,9 @@ package com.willwinder.ugs.nbp.designer.io.ugsd.v1;
 
 import com.willwinder.ugs.nbp.designer.entities.Entity;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.Path;
+import com.willwinder.ugs.nbp.designer.gcode.path.Coordinate;
 
+import java.awt.geom.Point2D;
 import java.util.List;
 
 /**
@@ -36,10 +38,13 @@ public class EntityPathV1 extends CuttableEntityV1 {
     @Override
     public Entity toInternal() {
         Path path = new Path();
+        final Point2D latestMoveTo = new Point2D.Double();
         getSegments().forEach(segment -> {
             switch(segment.getType()) {
                 case MOVE_TO:
                     path.moveTo(segment.getCoordinates().get(0)[0], segment.getCoordinates().get(0)[1]);
+                    latestMoveTo.setLocation(new Point2D.Double(segment.getCoordinates().get(0)[0], segment.getCoordinates().get(0)[1]));
+                    break;
                 case LINE_TO:
                     path.lineTo(segment.getCoordinates().get(0)[0], segment.getCoordinates().get(0)[1]);
                     break;
@@ -48,6 +53,9 @@ public class EntityPathV1 extends CuttableEntityV1 {
                     break;
                 case CUBIC_TO:
                     path.curveTo(segment.getCoordinates().get(0)[0], segment.getCoordinates().get(0)[1], segment.getCoordinates().get(1)[0], segment.getCoordinates().get(1)[1], segment.getCoordinates().get(2)[0], segment.getCoordinates().get(2)[1]);
+                    break;
+                case CLOSE:
+                    path.lineTo(latestMoveTo.getX(), latestMoveTo.getY());
             }
         });
         applyCommonAttributes(path);


### PR DESCRIPTION
When creating a toolpath with multipolygons it would treat it as one geometry and creating a cut path between the geometries. It will now treat each polygon in the multipolygon as separate features.

Also fixed a bug when reading a .ugsd file it would not close the polygon.