### PR TITLE
Adjustments to visualizer and editor

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -591,7 +591,7 @@ public class GcodePreprocessorUtils {
      *
      * @return angle in radians of a line going from start to end.
      */
-    static private double getAngle(final Position start, final Position end, PlaneFormatter plane) {
+    static public double getAngle(final Position start, final Position end, PlaneFormatter plane) {
         double deltaX = plane.axis0(end) - plane.axis0(start);
         double deltaY = plane.axis1(end) - plane.axis1(start);
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/CNCPoint.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/CNCPoint.java
@@ -181,7 +181,7 @@ public class CNCPoint {
    * @param t1 the first tuple
    * @param t2 the second tuple
    */
-  public final void add(CNCPoint t1, CNCPoint t2)
+  public final CNCPoint add(CNCPoint t1, CNCPoint t2)
   {
     this.x = t1.x + t2.x;
     this.y = t1.y + t2.y;
@@ -189,6 +189,7 @@ public class CNCPoint {
     this.a = t1.a + t2.a;
     this.b = t1.b + t2.b;
     this.c = t1.c + t2.c;
+    return this;
   }
 
 
@@ -196,9 +197,9 @@ public class CNCPoint {
    * Sets the value of this tuple to the sum of itself and t1.
    * @param t1 the other tuple
    */  
-  public final void add(CNCPoint t1)
+  public final CNCPoint add(CNCPoint t1)
   { 
-    add(this, t1);
+    return add(this, t1);
   }
 
   /**
@@ -207,7 +208,7 @@ public class CNCPoint {
    * @param t1 the first tuple
    * @param t2 the second tuple
    */
-  public final void sub(CNCPoint t1, CNCPoint t2)
+  public final CNCPoint sub(CNCPoint t1, CNCPoint t2)
   {
     this.x = t1.x - t2.x;
     this.y = t1.y - t2.y;
@@ -215,6 +216,7 @@ public class CNCPoint {
     this.a = t1.a - t2.a;
     this.b = t1.b - t2.b;
     this.c = t1.c - t2.c;
+    return this;
   }
 
   /**  
@@ -222,9 +224,9 @@ public class CNCPoint {
    * of itself and t1 (this = this - t1).
    * @param t1 the other tuple
    */  
-  public final void sub(CNCPoint t1)
+  public final CNCPoint sub(CNCPoint t1)
   { 
-    sub(this, t1);
+    return sub(this, t1);
   }
 
 
@@ -232,23 +234,24 @@ public class CNCPoint {
    * Sets the value of this tuple to the negation of tuple t1.
    * @param t1 the source tuple
    */
-  public final void negate(CNCPoint t1)
+  public final CNCPoint negate(CNCPoint t1)
   {
     this.x = -t1.x;
     this.y = -t1.y;
     this.z = -t1.z;
-    this.x = -t1.a;
-    this.y = -t1.b;
-    this.z = -t1.c;
+    this.a = -t1.a;
+    this.b = -t1.b;
+    this.c = -t1.c;
+    return this;
   }
 
 
   /**
    * Negates the value of this tuple in place.
    */
-  public final void negate()
+  public final CNCPoint negate()
   {
-    negate(this);
+    return negate(this);
   }
 
 
@@ -258,7 +261,7 @@ public class CNCPoint {
    * @param s the scalar value
    * @param t1 the source tuple
    */
-  public final void scale(double s, CNCPoint t1)
+  public final CNCPoint scale(double s, CNCPoint t1)
   {
     this.x = s*t1.x;
     this.y = s*t1.y;
@@ -266,6 +269,7 @@ public class CNCPoint {
     this.a = s*t1.a;
     this.b = s*t1.b;
     this.c = s*t1.c;
+    return this;
   }
 
 
@@ -274,9 +278,9 @@ public class CNCPoint {
    * of itself.
    * @param s the scalar value
    */
-  public final void scale(double s)
+  public final CNCPoint scale(double s)
   {
-    scale(s, this);
+    return scale(s, this);
   }
 
 
@@ -287,7 +291,7 @@ public class CNCPoint {
    * @param t1 the tuple to be multipled
    * @param t2 the tuple to be added
    */
-  public final void scaleAdd(double s, CNCPoint t1, CNCPoint t2)
+  public final CNCPoint scaleAdd(double s, CNCPoint t1, CNCPoint t2)
   {
     this.x = s*t1.x + t2.x;
     this.y = s*t1.y + t2.y;
@@ -295,6 +299,7 @@ public class CNCPoint {
     this.a = s*t1.a + t2.a;
     this.b = s*t1.b + t2.b;
     this.c = s*t1.c + t2.c;
+    return this;
   }
 
   /**
@@ -303,8 +308,8 @@ public class CNCPoint {
    * @param s the scalar value
    * @param t1 the tuple to be added
    */  
-  public final void scaleAdd(double s, CNCPoint t1) {
-    scaleAdd(s, this, t1);
+  public final CNCPoint scaleAdd(double s, CNCPoint t1) {
+    return scaleAdd(s, this, t1);
   }
 
   /**

--- a/ugs-platform/ugs-platform-gcode-editor/pom.xml
+++ b/ugs-platform/ugs-platform-gcode-editor/pom.xml
@@ -126,6 +126,16 @@
             <artifactId>org-netbeans-modules-editor-mimelookup</artifactId>
             <version>${netbeans.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-editor</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-editor-lib</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
 
         <!-- For hints -->
         <dependency>

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
@@ -26,8 +26,14 @@ import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.UGSEvent;
 import org.netbeans.core.spi.multiview.MultiViewElement;
 import org.netbeans.core.spi.multiview.text.MultiViewEditorElement;
+import org.netbeans.editor.EditorUI;
+import org.netbeans.editor.Utilities;
 import org.openide.util.Lookup;
 import org.openide.windows.TopComponent;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Arrays;
 
 @MultiViewElement.Registration(
         displayName = "#platform.window.editor.source",
@@ -39,10 +45,11 @@ import org.openide.windows.TopComponent;
 )
 public class SourceMultiviewElement extends MultiViewEditorElement implements UGSEventListener {
     private static final long serialVersionUID = 7255236202190135442L;
-    private static EditorListener editorListener = new EditorListener();
+    private static final EditorListener editorListener = new EditorListener();
     private final GcodeDataObject obj;
     private final GcodeFileListener fileListener;
-    private final BackendAPI backend;
+    private final transient BackendAPI backend;
+    private static final Component TOOLBAR_PADDING = Box.createRigidArea(new Dimension(1, 30));
 
     public SourceMultiviewElement(Lookup lookup) {
         super(lookup);
@@ -65,6 +72,17 @@ public class SourceMultiviewElement extends MultiViewEditorElement implements UG
         editorListener.reset();
         if (getEditorPane() != null) {
             getEditorPane().addCaretListener(editorListener);
+            setToolBarHeight();
+        }
+    }
+
+    private void setToolBarHeight() {
+        EditorUI editorUI = Utilities.getEditorUI(getEditorPane());
+        JToolBar toolBarComponent = editorUI.getToolBarComponent();
+
+        // Adds an element with vertical height
+        if (Arrays.stream(toolBarComponent.getComponents()).noneMatch(c -> c.equals(TOOLBAR_PADDING))) {
+            toolBarComponent.add(TOOLBAR_PADDING);
         }
     }
 
@@ -87,7 +105,7 @@ public class SourceMultiviewElement extends MultiViewEditorElement implements UG
     @Override
     public void UGSEvent(UGSEvent ugsEvent) {
         // Disable the editor if not idle or disconnected
-        if (ugsEvent.isStateChangeEvent() && backend.getController() != null && backend.getController().getControllerStatus() != null ) {
+        if (ugsEvent.isStateChangeEvent() && backend.getController() != null && backend.getController().getControllerStatus() != null) {
             ControllerState state = backend.getController().getControllerStatus().getState();
             getEditorPane().setEditable(state == ControllerState.IDLE || state == ControllerState.DISCONNECTED);
         }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/AbstractRotateAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/AbstractRotateAction.java
@@ -35,7 +35,6 @@ import com.willwinder.universalgcodesender.visualizer.LineSegment;
 import com.willwinder.universalgcodesender.visualizer.VisualizerUtils;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
-import org.openide.util.ImageUtilities;
 import org.openide.util.actions.CookieAction;
 
 import java.io.File;
@@ -48,18 +47,15 @@ import java.util.stream.Stream;
  * An abstract action for applying rotation to a loaded model
  */
 public abstract class AbstractRotateAction extends CookieAction implements UGSEventListener {
-
-    public static final String ICON_BASE = "icons/rotation0.svg";
     public static final double ARC_SEGMENT_LENGTH = 0.5;
     private final double rotation;
-    private transient BackendAPI backend;
+    private final transient BackendAPI backend;
 
-    public AbstractRotateAction(double rotation) {
+    protected AbstractRotateAction(double rotation) {
         this.backend = CentralLookup.getDefault().lookup(BackendAPI.class);
         this.backend.addUGSEventListener(this);
         this.rotation = rotation;
         setEnabled(isEnabled());
-        setIcon(ImageUtilities.loadImageIcon(ICON_BASE, false));
     }
 
     @Override

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/MirrorAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/MirrorAction.java
@@ -1,6 +1,7 @@
 package com.willwinder.ugs.nbp.editor.actions;
 
 import com.willwinder.ugs.nbp.editor.GcodeDataObject;
+import com.willwinder.ugs.nbp.editor.GcodeLanguageConfig;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import com.willwinder.universalgcodesender.gcode.processors.MirrorProcessor;
@@ -15,13 +16,13 @@ import com.willwinder.universalgcodesender.utils.*;
 import com.willwinder.universalgcodesender.visualizer.GcodeViewParse;
 import com.willwinder.universalgcodesender.visualizer.LineSegment;
 import com.willwinder.universalgcodesender.visualizer.VisualizerUtils;
+import org.netbeans.api.editor.EditorActionRegistration;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
-import org.openide.util.ImageUtilities;
 import org.openide.util.actions.CookieAction;
 
 import java.awt.*;
@@ -35,7 +36,7 @@ import java.util.stream.Stream;
         category = LocalizingService.CATEGORY_PROGRAM,
         id = "MirrorAction")
 @ActionRegistration(
-        iconBase = AbstractRotateAction.ICON_BASE,
+        iconBase = MirrorAction.ICON_BASE,
         displayName = MirrorAction.NAME,
         lazy = false)
 @ActionReferences({
@@ -43,17 +44,23 @@ import java.util.stream.Stream;
                 path = LocalizingService.MENU_PROGRAM,
                 position = 1220)
 })
+@EditorActionRegistration(
+        name = "mirror-gcode",
+        toolBarPosition = 12,
+        mimeType = GcodeLanguageConfig.MIME_TYPE,
+        iconResource = MirrorAction.ICON_BASE
+)
 public class MirrorAction extends CookieAction implements UGSEventListener {
 
     public static final String ICON_BASE = "icons/mirror.svg";
+
     public static final String NAME = "Mirror";
     public static final double ARC_SEGMENT_LENGTH = 0.5;
-    private transient BackendAPI backend;
+    private final transient BackendAPI backend;
 
     public MirrorAction() {
         this.backend = CentralLookup.getDefault().lookup(BackendAPI.class);
         this.backend.addUGSEventListener(this);
-        setIcon(ImageUtilities.loadImageIcon(ICON_BASE, false));
         setEnabled(isEnabled());
     }
 
@@ -77,6 +84,11 @@ public class MirrorAction extends CookieAction implements UGSEventListener {
     @Override
     public HelpCtx getHelpCtx() {
         return null;
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_BASE;
     }
 
     @Override

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RotateLeftAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RotateLeftAction.java
@@ -1,17 +1,18 @@
 package com.willwinder.ugs.nbp.editor.actions;
 
+import com.willwinder.ugs.nbp.editor.GcodeLanguageConfig;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.netbeans.api.editor.EditorActionRegistration;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
-import org.openide.util.ImageUtilities;
 
 @ActionID(
         category = LocalizingService.CATEGORY_PROGRAM,
         id = "RotateThreeQuarterAction")
 @ActionRegistration(
-        iconBase = AbstractRotateAction.ICON_BASE,
+        iconBase = MirrorAction.ICON_BASE,
         displayName = "Rotate 270°",
         lazy = false)
 @ActionReferences({
@@ -19,13 +20,23 @@ import org.openide.util.ImageUtilities;
                 path = LocalizingService.MENU_PROGRAM,
                 position = 1203)
 })
+@EditorActionRegistration(
+        name = "rotate-quarter-left",
+        toolBarPosition = 11,
+        mimeType = GcodeLanguageConfig.MIME_TYPE,
+        iconResource = RotateLeftAction.ICON_BASE
+)
 public class RotateLeftAction extends AbstractRotateAction {
 
     public static final String ICON_BASE = "icons/rotate_left.svg";
 
     public RotateLeftAction() {
         super((Math.PI / 2) * 3);
-        setIcon(ImageUtilities.loadImageIcon(ICON_BASE, false));
         putValue(NAME, "Rotate left");
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_BASE;
     }
 }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RotateRightAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RotateRightAction.java
@@ -1,17 +1,18 @@
 package com.willwinder.ugs.nbp.editor.actions;
 
+import com.willwinder.ugs.nbp.editor.GcodeLanguageConfig;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.netbeans.api.editor.EditorActionRegistration;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
-import org.openide.util.ImageUtilities;
 
 @ActionID(
         category = LocalizingService.CATEGORY_PROGRAM,
         id = "RotateQuarterAction")
 @ActionRegistration(
-        iconBase = AbstractRotateAction.ICON_BASE,
+        iconBase = MirrorAction.ICON_BASE,
         displayName = "Rotate 90°",
         lazy = false)
 @ActionReferences({
@@ -19,13 +20,23 @@ import org.openide.util.ImageUtilities;
                 path = LocalizingService.MENU_PROGRAM,
                 position = 1201)
 })
+@EditorActionRegistration(
+        name = "rotate-quarter-right",
+        toolBarPosition = 10,
+        mimeType = GcodeLanguageConfig.MIME_TYPE,
+        iconResource = RotateRightAction.ICON_BASE
+)
 public class RotateRightAction extends AbstractRotateAction {
 
     public static final String ICON_BASE = "icons/rotate_right.svg";
 
     public RotateRightAction() {
         super(Math.PI / 2);
-        setIcon(ImageUtilities.loadImageIcon(ICON_BASE, false));
         putValue(NAME, "Rotate right");
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_BASE;
     }
 }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RunFromAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RunFromAction.java
@@ -33,13 +33,10 @@ import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
-import org.openide.util.ImageUtilities;
 import org.openide.util.actions.CookieAction;
 
-import javax.swing.AbstractAction;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import java.awt.event.ActionEvent;
+import javax.swing.*;
+import java.awt.*;
 
 @ActionID(
         category = LocalizingService.RunFromCategory,
@@ -57,22 +54,20 @@ public final class RunFromAction extends CookieAction implements UGSEventListene
 
     public static final String NAME = LocalizingService.RunFromTitle;
     public static final String ICON_BASE = "icons/fast-forward.svg";
-    private final RunFromService runFromService;
-
-    private BackendAPI backend;
+    private final transient  RunFromService runFromService;
+    private final transient BackendAPI backend;
 
     public RunFromAction() {
         this.backend = CentralLookup.getDefault().lookup(BackendAPI.class);
         this.backend.addUGSEventListener(this);
         this.runFromService = CentralLookup.getDefault().lookup(RunFromService.class);
-        setIcon(ImageUtilities.loadImageIcon(ICON_BASE, false));
         setEnabled(isEnabled());
     }
 
     @Override
     public void UGSEvent(UGSEvent cse) {
         if (cse.isStateChangeEvent()) {
-            java.awt.EventQueue.invokeLater(() -> setEnabled(isEnabled()));
+            EventQueue.invokeLater(() -> setEnabled(isEnabled()));
         }
     }
 
@@ -121,5 +116,10 @@ public final class RunFromAction extends CookieAction implements UGSEventListene
     @Override
     protected Class<?>[] cookieClasses() {
         return new Class[]{GcodeDataObject.class};
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_BASE;
     }
 }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RunFromHere.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/RunFromHere.java
@@ -60,7 +60,7 @@ public final class RunFromHere implements ActionListener {
     public void actionPerformed(ActionEvent ev) {
         Element root = EditorRegistry.lastFocusedComponent().getDocument().getDefaultRootElement();
         int caretPosition = EditorRegistry.lastFocusedComponent().getCaretPosition();
-        int line = root.getElementIndex(caretPosition);
+        int line = root.getElementIndex(caretPosition) - 1;
 
         try {
             runFromService.runFromLine(line);

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/TranslateToZeroAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/TranslateToZeroAction.java
@@ -1,6 +1,7 @@
 package com.willwinder.ugs.nbp.editor.actions;
 
 import com.willwinder.ugs.nbp.editor.GcodeDataObject;
+import com.willwinder.ugs.nbp.editor.GcodeLanguageConfig;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import com.willwinder.universalgcodesender.gcode.processors.TranslateProcessor;
@@ -15,13 +16,13 @@ import com.willwinder.universalgcodesender.utils.*;
 import com.willwinder.universalgcodesender.visualizer.GcodeViewParse;
 import com.willwinder.universalgcodesender.visualizer.LineSegment;
 import com.willwinder.universalgcodesender.visualizer.VisualizerUtils;
+import org.netbeans.api.editor.EditorActionRegistration;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
-import org.openide.util.ImageUtilities;
 import org.openide.util.actions.CookieAction;
 
 import java.io.File;
@@ -36,7 +37,7 @@ import java.util.stream.Stream;
         category = LocalizingService.CATEGORY_PROGRAM,
         id = "TranslateToZeroAction")
 @ActionRegistration(
-        iconBase = AbstractRotateAction.ICON_BASE,
+        iconBase = TranslateToZeroAction.ICON_BASE,
         displayName = TranslateToZeroAction.NAME,
         lazy = false)
 @ActionReferences({
@@ -44,18 +45,23 @@ import java.util.stream.Stream;
                 path = LocalizingService.MENU_PROGRAM,
                 position = 1221)
 })
+@EditorActionRegistration(
+        name = "translate-to-zero",
+        toolBarPosition = 13,
+        mimeType = GcodeLanguageConfig.MIME_TYPE,
+        iconResource = TranslateToZeroAction.ICON_BASE
+)
 public class TranslateToZeroAction extends CookieAction implements UGSEventListener {
 
-    private Logger logger = Logger.getLogger(TranslateToZeroAction.class.getSimpleName());
+    private static final Logger LOGGER = Logger.getLogger(TranslateToZeroAction.class.getSimpleName());
     public static final String NAME = "Translate to zero";
     public static final String ICON_BASE = "icons/translate.svg";
     public static final double ARC_SEGMENT_LENGTH = 0.5;
-    private transient BackendAPI backend;
+    private final transient BackendAPI backend;
 
     public TranslateToZeroAction() {
         this.backend = CentralLookup.getDefault().lookup(BackendAPI.class);
         this.backend.addUGSEventListener(this);
-        setIcon(ImageUtilities.loadImageIcon(ICON_BASE, false));
         setEnabled(isEnabled());
     }
 
@@ -94,7 +100,7 @@ public class TranslateToZeroAction extends CookieAction implements UGSEventListe
                 TranslateProcessor translateProcessor = new TranslateProcessor(offset);
                 backend.applyCommandProcessor(translateProcessor);
             } catch (Exception ex) {
-                logger.log(Level.SEVERE, "Couldn't translate gcode", ex);
+                LOGGER.log(Level.SEVERE, "Could not translate gcode", ex);
                 GUIHelpers.displayErrorDialog(ex.getLocalizedMessage());
             } finally {
                 LoaderDialogHelper.closeDialog();
@@ -147,5 +153,10 @@ public class TranslateToZeroAction extends CookieAction implements UGSEventListe
         }
 
         return result;
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_BASE;
     }
 }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/highlight/RunFromHereHighlightContainer.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/highlight/RunFromHereHighlightContainer.java
@@ -60,7 +60,7 @@ public class RunFromHereHighlightContainer extends AbstractHighlightsContainer i
 
         JEditorPane comp = panes[0];
         Element root = comp.getDocument().getDefaultRootElement();
-        Element element = root.getElement(lineNumber);
+        Element element = root.getElement(lineNumber + 1);
         bag.clear();
         if (element != null) {
             bag.addHighlight(0, element.getStartOffset(), highlightAttributes);

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/GcodeParserResult.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/GcodeParserResult.java
@@ -23,6 +23,7 @@ import org.netbeans.modules.parsing.api.Snapshot;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Gcode parser results holding all errors found
@@ -50,5 +51,9 @@ public class GcodeParserResult extends ParserResult {
     @Override
     protected void invalidate() {
         errorList.clear();
+    }
+
+    public void addAll(List<GcodeError> errors) {
+        errorList.addAll(errors);
     }
 }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/ErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/ErrorParser.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @author Joacim Breiler
  */
 public interface ErrorParser {
-    void handleToken(Token<GcodeTokenId> token, int line);
+    void handleToken(Token<?> token, int line);
 
     List<GcodeError> getErrors();
 }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/FeedRateMissingErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/FeedRateMissingErrorParser.java
@@ -33,29 +33,27 @@ public class FeedRateMissingErrorParser implements ErrorParser {
     private final FileObject fileObject;
     private int firstFeedRateLine = 0;
     private int firstMovementLine = 0;
-    private Token<GcodeTokenId> firstMovementToken;
-    private Token<GcodeTokenId> firstFeedRateToken;
+    private Token<?> firstMovementToken;
+    private Token<?> firstFeedRateToken;
 
     public FeedRateMissingErrorParser(FileObject fileObject) {
         this.fileObject = fileObject;
     }
 
     @Override
-    public void handleToken(Token<GcodeTokenId> token, int line) {
+    public void handleToken(Token<?> token, int line) {
         if (GcodeTokenId.MOVEMENT.equals(token.id())) {
             if (isMovementCommand(token) && firstMovementToken == null) {
                 firstMovementToken = token;
                 firstMovementLine = line;
             }
-        } else if (GcodeTokenId.PARAMETER.equals(token.id())) {
-            if (StringUtils.startsWithIgnoreCase(token.text(), "F") && firstFeedRateToken == null) {
-                firstFeedRateToken = token;
-                firstFeedRateLine = line;
-            }
+        } else if (GcodeTokenId.PARAMETER.equals(token.id()) && StringUtils.startsWithIgnoreCase(token.text(), "F") && firstFeedRateToken == null) {
+            firstFeedRateToken = token;
+            firstFeedRateLine = line;
         }
     }
 
-    private boolean isMovementCommand(Token<GcodeTokenId> token) {
+    private boolean isMovementCommand(Token<?> token) {
         return StringUtils.equalsIgnoreCase(token.text(), Code.G1.name()) ||
                 StringUtils.equalsIgnoreCase(token.text(), "G01") ||
                 StringUtils.equalsIgnoreCase(token.text(), Code.G2.name()) ||

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidG2CommandErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidG2CommandErrorParser.java
@@ -21,25 +21,20 @@ package com.willwinder.ugs.nbp.editor.parser.errors;
 import com.willwinder.ugs.nbp.editor.lexer.GcodeTokenId;
 import com.willwinder.ugs.nbp.editor.parser.GcodeError;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
-import com.willwinder.universalgcodesender.GrblController;
 import com.willwinder.universalgcodesender.TinyGController;
 import com.willwinder.universalgcodesender.gcode.util.Code;
 import com.willwinder.universalgcodesender.model.BackendAPI;
-import com.willwinder.universalgcodesender.types.GcodeCommand;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.modules.csl.api.Severity;
 import org.openide.filesystems.FileObject;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class InvalidG2CommandErrorParser implements ErrorParser {
     private final FileObject fileObject;
     private final BackendAPI backend;
-
-    private List<GcodeError> errorList = new ArrayList<>();
+    private final List<GcodeError> errorList = new ArrayList<>();
 
     public InvalidG2CommandErrorParser(FileObject fileObject) {
         this.fileObject = fileObject;
@@ -47,8 +42,8 @@ public class InvalidG2CommandErrorParser implements ErrorParser {
     }
 
     @Override
-    public void handleToken(Token<GcodeTokenId> token, int line) {
-        if (!(backend.getController() instanceof TinyGController)) {
+    public void handleToken(Token<?> token, int line) {
+        if (!(backend.isConnected() && backend.getController() instanceof TinyGController)) {
             return;
         }
 

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidGrblCommandErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidGrblCommandErrorParser.java
@@ -61,8 +61,8 @@ public class InvalidGrblCommandErrorParser implements ErrorParser {
     }
 
     @Override
-    public void handleToken(Token<GcodeTokenId> token, int line) {
-        if (!(backend.getController() instanceof GrblController)) {
+    public void handleToken(Token<?> token, int line) {
+        if (!(backend.isConnected() && backend.getController() instanceof GrblController)) {
             return;
         }
 

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/MovementInMachineCoordinatesErrorParser.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/parser/errors/MovementInMachineCoordinatesErrorParser.java
@@ -1,6 +1,5 @@
 package com.willwinder.ugs.nbp.editor.parser.errors;
 
-import com.willwinder.ugs.nbp.editor.lexer.GcodeTokenId;
 import com.willwinder.ugs.nbp.editor.parser.GcodeError;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.universalgcodesender.firmware.FirmwareSettingsException;
@@ -17,8 +16,7 @@ public class MovementInMachineCoordinatesErrorParser implements ErrorParser {
 
     private final FileObject fileObject;
     private final BackendAPI backend;
-
-    private List<GcodeError> errorList = new ArrayList<>();
+    private final List<GcodeError> errorList = new ArrayList<>();
 
     public MovementInMachineCoordinatesErrorParser(FileObject fileObject) {
         this.fileObject = fileObject;
@@ -27,7 +25,7 @@ public class MovementInMachineCoordinatesErrorParser implements ErrorParser {
     }
 
     @Override
-    public void handleToken(Token<GcodeTokenId> token, int line) {
+    public void handleToken(Token<?> token, int line) {
         if (StringUtils.equalsIgnoreCase("G53", token.text()) && !isHomingEnabled()) {
             int offset = token.offset(null);
             GcodeError error = new GcodeError("movement-in-machine-coordinates-without-homing",

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/renderer/EditorListener.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/renderer/EditorListener.java
@@ -25,13 +25,10 @@ import com.willwinder.ugs.nbm.visualizer.shared.RenderableUtils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import org.openide.util.Lookup;
 
-import javax.swing.JEditorPane;
+import javax.swing.*;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.CaretListener;
 import javax.swing.text.Element;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 
 /**
  * Listens for editor events to notify visualizer, puts changes on the
@@ -41,7 +38,6 @@ import java.util.Collections;
  */
 public class EditorListener implements CaretListener {
     private Highlight highlight = null;
-    private EditorPosition position = null;
 
     public EditorListener() {
         reset();
@@ -56,17 +52,8 @@ public class EditorListener implements CaretListener {
             int startIndex = map.getElementIndex(jep.getSelectionStart());
             int endIndex = map.getElementIndex(jep.getSelectionEnd());
 
-            Collection<Integer> selectedLines = new ArrayList<>();
-            for (int i = startIndex; i <= endIndex; i++) {
-                selectedLines.add(i);
-            }
-
             if (highlight != null) {
-                highlight.setHighlightedLines(selectedLines);
-            }
-
-            if (position != null) {
-                position.setLineNumber(endIndex);
+                highlight.setHighlightedLines(startIndex, endIndex);
             }
         }
     }
@@ -82,17 +69,10 @@ public class EditorListener implements CaretListener {
 
         if (gcodeModel != null) {
             if (highlight != null) {
-                highlight.setHighlightedLines(Collections.emptyList());
+                highlight.setHighlightedLines(0, 0);
             } else {
                 highlight = new Highlight(gcodeModel, Localization.getString("platform.visualizer.renderable.highlight"));
                 RenderableUtils.registerRenderable(highlight);
-            }
-
-            if (position != null) {
-                position.setLineNumber(-1);
-            } else {
-                position = new EditorPosition(gcodeModel, Localization.getString("platform.visualizer.renderable.editor-position"));
-                RenderableUtils.registerRenderable(position);
             }
         }
     }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/renderer/Highlight.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/renderer/Highlight.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2018 Will Winder
+    Copyright 2016-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -18,34 +18,45 @@
  */
 package com.willwinder.ugs.nbp.editor.renderer;
 
-import com.willwinder.ugs.nbm.visualizer.shared.Renderable;
-import static com.jogamp.opengl.GL.GL_LINES;
 import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GL2ES3;
 import com.jogamp.opengl.GLAutoDrawable;
 import com.willwinder.ugs.nbm.visualizer.options.VisualizerOptions;
 import com.willwinder.ugs.nbm.visualizer.renderables.GcodeModel;
-import static com.willwinder.ugs.nbm.visualizer.options.VisualizerOptions.VISUALIZER_OPTION_HIGHLIGHT;
+import com.willwinder.ugs.nbm.visualizer.shared.Renderable;
+import com.willwinder.universalgcodesender.gcode.util.Plane;
+import com.willwinder.universalgcodesender.gcode.util.PlaneFormatter;
+import com.willwinder.universalgcodesender.model.CNCPoint;
 import com.willwinder.universalgcodesender.model.Position;
-import com.willwinder.universalgcodesender.visualizer.LineSegment;
-import java.awt.Color;
+
+import java.awt.*;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.willwinder.ugs.nbm.visualizer.options.VisualizerOptions.VISUALIZER_OPTION_HIGHLIGHT;
+import static com.willwinder.universalgcodesender.gcode.GcodePreprocessorUtils.getAngle;
 
 /**
+ * Highlights the selected lines in the editor. It will attempt to buffer the lines with quads to make them more visible
+ * because GL's line width is platform dependant and is also deprecated.
  *
  * @author wwinder
  */
 public class Highlight extends Renderable {
 
-    private GcodeModel model;
+    public static final double LINE_WIDTH = 0.004d;
 
-    private Collection<Integer> highlightedLines = null;
-
-    private int numberOfVertices = -1;
-    private float[] lineVertexData = null;
+    private final GcodeModel model;
+    private final List<CNCPoint> points = Collections.synchronizedList(new ArrayList<>());
 
     // Preferences
-    private Color highlightColor;
+    private Color highlightColor = Color.YELLOW;
+    private double scaleFactor = 0.1;
+    private int startLine = 0;
+    private int endLine = 0;
 
     public Highlight(GcodeModel model, String title) {
         super(9, title);
@@ -54,9 +65,8 @@ public class Highlight extends Renderable {
     }
 
     @Override
-    final public void reloadPreferences(VisualizerOptions vo) {
+    public final void reloadPreferences(VisualizerOptions vo) {
         highlightColor = vo.getOptionForKey(VISUALIZER_OPTION_HIGHLIGHT).value;
-
     }
 
     @Override
@@ -76,64 +86,59 @@ public class Highlight extends Renderable {
 
     @Override
     public void init(GLAutoDrawable drawable) {
+        // Not used
     }
 
     @Override
     public void draw(GLAutoDrawable drawable, boolean idle, Position machineCoord, Position workCoord, Position focusMin, Position focusMax, double scaleFactor, Position mouseCoordinates, Position rotation) {
-        if (lineVertexData == null || highlightedLines == null || highlightedLines.isEmpty()) {
+        if (points.isEmpty() && startLine > 0 && endLine > 0) {
             return;
         }
 
-        GL2 gl = drawable.getGL().getGL2();
-
-        //gl.glEnable(GL2.GL_LINE_SMOOTH);
-        gl.glBegin(GL_LINES);
-        gl.glLineWidth(2.0f);
-
-        float[] c = VisualizerOptions.colorToFloatArray(Color.YELLOW);
-        for (int verts = 0; verts < (this.numberOfVertices * 3); ) {
-            gl.glColor4fv(c, 0);
-            gl.glVertex3d(lineVertexData[verts++], lineVertexData[verts++], lineVertexData[verts++]);
-            gl.glColor4fv(c, 0);
-            gl.glVertex3d(lineVertexData[verts++], lineVertexData[verts++], lineVertexData[verts++]);
+        // Scale was changed since last render, regenerate points
+        if (this.scaleFactor != scaleFactor) {
+            this.scaleFactor = scaleFactor;
+            generateBufferedLines();
         }
 
+        float[] c = VisualizerOptions.colorToFloatArray(highlightColor);
+        GL2 gl = drawable.getGL().getGL2();
+        gl.glBegin(GL2ES3.GL_QUADS);
+            gl.glColor4fv(c, 0);
+            points.forEach(point -> gl.glVertex3d(point.x, point.y, point.z));
         gl.glEnd();
     }
 
-    public void setHighlightedLines(Collection<Integer> lines) {
-        this.highlightedLines = lines;
 
-        if (lines.isEmpty()) {
-            this.numberOfVertices = -1;
-            this.lineVertexData = null;
+    public void setHighlightedLines(int startLine, int endLine) {
+        if( this.startLine == startLine && this.endLine == endLine) {
             return;
         }
 
-        ArrayList<LineSegment> highlights = new ArrayList<>();
-        int vertIndex = 0;
-        for (LineSegment ls : model.getLineList()) {
-            if (lines.contains(ls.getLineNumber() -1)) {
-                highlights.add(ls);
-            }
-        }
+        this.startLine = startLine;
+        this.endLine = endLine;
+        generateBufferedLines();
+    }
 
-        this.numberOfVertices = highlights.size() * 2;
-        this.lineVertexData = new float[numberOfVertices * 3];
+    private void generateBufferedLines() {
+        points.clear();
+        double offset = LINE_WIDTH / scaleFactor / 2d;
+        double halfPI = Math.PI / 2d;
+        List<CNCPoint> newPoints = model.getLineList().stream()
+                .filter(ls -> ls.getLineNumber() > startLine && ls.getLineNumber() - 1 <= endLine)
+                .flatMap(lineSegment -> {
+                    double angle = getAngle(lineSegment.getStart(), lineSegment.getEnd(), new PlaneFormatter(Plane.XY));
+                    Position xyOffset = new Position(offset * Math.cos(angle - halfPI), offset * Math.sin(angle - halfPI), 0.0);
+                    Position zOffset = new Position(0, 0, 0.01);
 
-        for (LineSegment ls : highlights) {
-            //System.out.println("Line number: " + ls.getLineNumber());
-            Position p1 = ls.getStart();
-            Position p2 = ls.getEnd();
+                    CNCPoint aPoint = new Position(lineSegment.getStart()).sub(xyOffset).add(zOffset);
+                    CNCPoint bPoint = new Position(lineSegment.getEnd()).sub(xyOffset).add(zOffset);
+                    CNCPoint cPoint = new Position(lineSegment.getEnd()).add(xyOffset).add(zOffset);
+                    CNCPoint dPoint = new Position(lineSegment.getStart()).add(xyOffset).add(zOffset);
+                    return Stream.of(aPoint, bPoint, cPoint, dPoint);
+                })
+                .collect(Collectors.toList());
 
-            // p1 location
-            lineVertexData[vertIndex++] = (float)p1.x;
-            lineVertexData[vertIndex++] = (float)p1.y;
-            lineVertexData[vertIndex++] = (float)p1.z;
-            //p2
-            lineVertexData[vertIndex++] = (float)p2.x;
-            lineVertexData[vertIndex++] = (float)p2.y;
-            lineVertexData[vertIndex++] = (float)p2.z;
-        }
+        points.addAll(newPoints);
     }
 }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/actions/Bundle.properties
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/actions/Bundle.properties
@@ -1,0 +1,4 @@
+rotate-quarter-left=Rotate left
+rotate-quarter-right=Rotate right
+mirror-gcode=Mirror
+translate-to-zero=Translate to zero

--- a/ugs-platform/ugs-platform-gcode-editor/src/test/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidGrblCommandErrorParserTest.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/test/java/com/willwinder/ugs/nbp/editor/parser/errors/InvalidGrblCommandErrorParserTest.java
@@ -26,6 +26,7 @@ public class InvalidGrblCommandErrorParserTest {
         BackendAPI backendAPI = mock(BackendAPI.class);
         IController grblController = mock(GrblController.class);
         when(backendAPI.getController()).thenReturn(grblController);
+        when(backendAPI.isConnected()).thenReturn(true);
 
         parser = new InvalidGrblCommandErrorParser(fileObject, backendAPI);
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
@@ -69,8 +69,6 @@ public class DesignerMain extends JFrame {
     }
 
     private JSplitPane createRightPanel(Controller controller) {
-        getContentPane().add(new ToolBox(controller), BorderLayout.NORTH);
-
         JSplitPane toolsSplit = new JSplitPane( JSplitPane.VERTICAL_SPLIT, new JScrollPane(new EntitiesTree(controller)), new SelectionSettingsPanel(controller));
         toolsSplit.setResizeWeight(0.9);
         return toolsSplit;

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntityGroup.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntityGroup.java
@@ -120,7 +120,12 @@ public class EntityGroup extends AbstractEntity implements EntityListener {
     }
 
     public void addAll(List<Entity> entities) {
-        entities.forEach(this::addChild);
+        entities.forEach(entity -> {
+            if (!containsChild(entity)) {
+                children.add(entity);
+                entity.addListener(this);
+            }
+        });
         invalidateCenter();
     }
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/DrawingContainer.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/DrawingContainer.java
@@ -23,7 +23,7 @@ import com.willwinder.ugs.nbp.designer.logic.ControllerEventType;
 import com.willwinder.ugs.nbp.designer.logic.ControllerListener;
 
 import javax.swing.*;
-import java.awt.GridLayout;
+import java.awt.*;
 
 /**
  * A simple container that contains a Drawing instance and keeps it
@@ -40,7 +40,7 @@ public class DrawingContainer extends JPanel implements ControllerListener {
 
     public DrawingContainer(Controller controller) {
         super();
-        setLayout(new GridLayout(0, 1));
+        setLayout(new BorderLayout());
         this.controller = controller;
         this.drawingMouseListener = new MouseListener(controller);
         setDrawing(this.controller.getDrawing());
@@ -51,7 +51,7 @@ public class DrawingContainer extends JPanel implements ControllerListener {
         JScrollPane scrollPane = new JScrollPane(d, ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
         scrollPane.getVerticalScrollBar().setUnitIncrement(5);
         scrollPane.getHorizontalScrollBar().setUnitIncrement(5);
-        add(scrollPane);
+        add(scrollPane, BorderLayout.CENTER);
         revalidate();
 
         d.addMouseListener(drawingMouseListener);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
@@ -18,6 +18,7 @@
  */
 package com.willwinder.ugs.nbp.designer.gui;
 
+import com.willwinder.ugs.nbp.core.ui.ToolBar;
 import com.willwinder.ugs.nbp.designer.actions.*;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.designer.logic.ControllerEventType;
@@ -33,10 +34,9 @@ import static org.openide.NotifyDescriptor.OK_OPTION;
 /**
  * @author Joacim Breiler
  */
-public class ToolBox extends JToolBar {
+public class ToolBox extends ToolBar {
 
     public ToolBox(Controller controller) {
-        super("Tools");
         setFloatable(false);
 
         JToggleButton select = new JToggleButton(new ToolSelectAction(controller));

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
@@ -36,15 +36,18 @@ import javax.swing.*;
 public class EntitiesTreeTopComponent extends TopComponent {
     private static final long serialVersionUID = 432423498723987873L;
 
-    private EntitiesTree entitiesTree;
-
     public EntitiesTreeTopComponent() {
         setMinimumSize(new java.awt.Dimension(50, 50));
         setPreferredSize(new java.awt.Dimension(200, 200));
         setLayout(new java.awt.BorderLayout());
         setDisplayName("Design objects");
+    }
+
+    @Override
+    protected void componentOpened() {
+        super.componentOpened();
+        removeAll();
         Controller controller = CentralLookup.getDefault().lookup(Controller.class);
-        entitiesTree = new EntitiesTree(controller);
-        add(new JScrollPane(entitiesTree));
+        add(new JScrollPane(new EntitiesTree(controller)));
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
@@ -1,9 +1,12 @@
 package com.willwinder.ugs.nbp.designer.platform;
 
 import com.willwinder.ugs.nbp.designer.gui.SelectionSettingsPanel;
+import com.willwinder.ugs.nbp.designer.gui.tree.EntitiesTree;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.windows.TopComponent;
+
+import javax.swing.*;
 
 @TopComponent.Description(
         preferredID = "SettingsTopComponent",
@@ -18,6 +21,12 @@ public class SettingsTopComponent extends TopComponent {
         setPreferredSize(new java.awt.Dimension(200, 200));
         setLayout(new java.awt.BorderLayout());
         setDisplayName("Cut settings");
+    }
+
+    @Override
+    protected void componentOpened() {
+        super.componentOpened();
+        removeAll();
         Controller controller = CentralLookup.getDefault().lookup(Controller.class);
         add(new SelectionSettingsPanel(controller));
     }

--- a/ugs-platform/ugs-platform-ugscore/pom.xml
+++ b/ugs-platform/ugs-platform-ugscore/pom.xml
@@ -19,6 +19,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publicPackages>
+                        <publicPackage>com.willwinder.ugs.nbp.core.ui</publicPackage>
                         <publicPackage>com.willwinder.ugs.nbp.core.actions</publicPackage>
                         <publicPackage>com.willwinder.ugs.nbp.core.services</publicPackage>
                     </publicPackages>

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/ui/ToolBar.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/ui/ToolBar.java
@@ -1,0 +1,63 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.core.ui;
+
+import org.openide.awt.ToolbarWithOverflow;
+
+import javax.swing.*;
+import javax.swing.plaf.ToolBarUI;
+import java.awt.*;
+
+/**
+ * A generic toolbar with overflow and the netbeans LaF.
+ *
+ * @author Joacim Breiler
+ */
+public class ToolBar extends ToolbarWithOverflow {
+
+    public static final String TOOLBAR_UI = "Nb.Toolbar.ui";
+
+    public ToolBar() {
+        super();
+        add(Box.createRigidArea(new Dimension(1, 32)));
+    }
+
+    @Override
+    public String getUIClassID() {
+        //For GTK and Aqua look and feels, NetBeans provide a custom toolbar UI -
+        //but we cannot override this globally or it will cause problems for
+        //the form editor & other things
+        if (UIManager.get(TOOLBAR_UI) != null) {
+            return TOOLBAR_UI;
+        } else {
+            return super.getUIClassID();
+        }
+    }
+
+    @Override
+    public String getName() {
+        //Required for Aqua L&F toolbar UI
+        return "editorToolbar";
+    }
+
+    @Override
+    public void setUI(ToolBarUI ui) {
+        super.setUI(ui);
+    }
+}

--- a/ugs-platform/ugs-platform-visualizer/pom.xml
+++ b/ugs-platform/ugs-platform-visualizer/pom.xml
@@ -59,7 +59,12 @@
             <version>${netbeans.version}</version>
             <type>jar</type>
         </dependency>
-
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-loaders</artifactId>
+            <version>${netbeans.version}</version>
+            <type>jar</type>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ugs-platform-ugslib</artifactId>

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/Visualizer2TopComponent.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/Visualizer2TopComponent.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2015-2018 Will Winder
+    Copyright 2015-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -38,6 +38,7 @@ import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
 
+import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 import java.util.logging.Level;
@@ -105,8 +106,16 @@ public final class Visualizer2TopComponent extends TopComponent {
         setName(VisualizerTitle);
         setToolTipText(VisualizerTooltip);
         super.componentOpened();
+
+        removeAll();
+        add(new VisualizerToolBar(), BorderLayout.NORTH);
         panel = makeWindow();
-        add(panel, BorderLayout.CENTER);
+
+        JPanel borderedPanel = new JPanel();
+        borderedPanel.setLayout(new BorderLayout());
+        borderedPanel.setBorder(BorderFactory.createLineBorder(Color.DARK_GRAY, 1));
+        borderedPanel.add(panel, BorderLayout.CENTER);
+        add(borderedPanel, BorderLayout.CENTER);
     }
 
     @Override

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/VisualizerToolBar.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/VisualizerToolBar.java
@@ -1,0 +1,58 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbm.visualizer;
+
+import com.willwinder.ugs.nbm.visualizer.actions.CameraResetPreset;
+import com.willwinder.ugs.nbm.visualizer.actions.CameraXPreset;
+import com.willwinder.ugs.nbm.visualizer.actions.CameraYPreset;
+import com.willwinder.ugs.nbm.visualizer.actions.CameraZPreset;
+import com.willwinder.ugs.nbp.core.actions.OutlineAction;
+import com.willwinder.ugs.nbp.core.ui.ToolBar;
+
+import javax.swing.*;
+
+/**
+ * A toolbar for visualizer actions
+ *
+ * @author Joacim Breiler
+ */
+public class VisualizerToolBar extends ToolBar {
+    public VisualizerToolBar() {
+        setFloatable(false);
+        initComponents();
+    }
+
+    private void initComponents() {
+        createAndAddButton(new CameraResetPreset());
+        createAndAddButton(new CameraXPreset());
+        createAndAddButton(new CameraYPreset());
+        createAndAddButton(new CameraZPreset());
+        addSeparator();
+        createAndAddButton(new OutlineAction());
+    }
+
+    private void createAndAddButton(Action action) {
+        JButton resetPresetButton = new JButton(action);
+        resetPresetButton.setText("");
+        resetPresetButton.setToolTipText((String) action.getValue(Action.SHORT_DESCRIPTION));
+        resetPresetButton.setContentAreaFilled(false);
+        resetPresetButton.setBorderPainted(false);
+        this.add(resetPresetButton);
+    }
+}

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraResetPreset.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraResetPreset.java
@@ -23,22 +23,22 @@ import com.willwinder.ugs.nbm.visualizer.shared.GcodeRenderer;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import com.willwinder.ugs.nbp.lib.services.TopComponentLocalizer;
 import com.willwinder.universalgcodesender.i18n.Localization;
-import javax.swing.Action;
-import org.openide.awt.ActionReferences;
-import org.openide.util.ImageUtilities;
-
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
 import org.openide.modules.OnStart;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
+
+import javax.swing.*;
 
 @ActionID(
         category = CameraResetPreset.CATEGORY,
         id = CameraResetPreset.ID
 )
 @ActionRegistration(
-        iconBase = CameraResetPreset.ICON_BASE,
+        iconBase = CameraResetPreset.SMALL_ICON_PATH,
         displayName = "--",
         lazy = false
 )
@@ -48,16 +48,17 @@ import org.openide.util.Lookup;
                 position = 1060)
 })
 public final class CameraResetPreset extends MoveCameraAction {
-    public static final String ICON_BASE = "icons/XYZ.png";
+    public static final String SMALL_ICON_PATH = "icons/XYZ.svg";
+    public static final String LARGE_ICON_PATH = "icons/XYZ24.svg";
     public static final String CATEGORY = LocalizingService.CATEGORY_VISUALIZER;
     public static final String ID = "com.willwinder.ugs.nbm.visualizer.actions.CameraResetPreset";
     public static final String NAME = Localization.getString("platform.visualizer.popup.presets.reset");
 
     @OnStart
     public static class Localizer extends TopComponentLocalizer {
-      public Localizer() {
-        super(LocalizingService.CATEGORY_VISUALIZER, ID, NAME);
-      }
+        public Localizer() {
+            super(LocalizingService.CATEGORY_VISUALIZER, ID, NAME);
+        }
     }
 
     public CameraResetPreset() {
@@ -65,9 +66,11 @@ public final class CameraResetPreset extends MoveCameraAction {
                 Lookup.getDefault().lookup(GcodeRenderer.class),
                 ROTATION_ISOMETRIC);
 
-        putValue("iconBase", ICON_BASE);
-        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE, false));
+        putValue("iconBase", SMALL_ICON_PATH);
+        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
+        putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", NAME);
         putValue(Action.NAME, NAME);
+        putValue(Action.SHORT_DESCRIPTION, "Resets camera preset");
     }
 }

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraXPreset.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraXPreset.java
@@ -38,7 +38,7 @@ import org.openide.util.Lookup;
         id = CameraXPreset.ID
 )
 @ActionRegistration(
-        iconBase = CameraXPreset.ICON_BASE,
+        iconBase = CameraXPreset.SMALL_ICON_PATH,
         displayName = "--",
         lazy = false
 )
@@ -48,7 +48,8 @@ import org.openide.util.Lookup;
                 position = 1060)
 })
 public final class CameraXPreset extends MoveCameraAction {
-    public static final String ICON_BASE = "icons/X.png";
+    public static final String SMALL_ICON_PATH = "icons/X.svg";
+    public static final String LARGE_ICON_PATH = "icons/X24.svg";
     public static final String CATEGORY = LocalizingService.CATEGORY_VISUALIZER;
     public static final String ID = "com.willwinder.ugs.nbm.visualizer.actions.CameraXPreset";
     public static final String NAME = Localization.getString("platform.visualizer.popup.presets.left");
@@ -65,9 +66,11 @@ public final class CameraXPreset extends MoveCameraAction {
                 Lookup.getDefault().lookup(GcodeRenderer.class),
                 ROTATION_LEFT);
 
-        putValue("iconBase", ICON_BASE);
-        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE, false));
+        putValue("iconBase", SMALL_ICON_PATH);
+        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
+        putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", NAME);
         putValue(Action.NAME, NAME);
+        putValue(Action.SHORT_DESCRIPTION, "Sets the camera to X preset");
     }
 }

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraYPreset.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraYPreset.java
@@ -38,7 +38,7 @@ import org.openide.util.Lookup;
         id = CameraYPreset.ID
 )
 @ActionRegistration(
-        iconBase = CameraYPreset.ICON_BASE,
+        iconBase = CameraYPreset.SMALL_ICON_PATH,
         displayName = "--",
         lazy = false
 )
@@ -48,7 +48,8 @@ import org.openide.util.Lookup;
                 position = 1060)
 })
 public final class CameraYPreset extends MoveCameraAction {
-    public static final String ICON_BASE = "icons/Y.png";
+    public static final String SMALL_ICON_PATH = "icons/Y.svg";
+    public static final String LARGE_ICON_PATH = "icons/Y24.svg";
     public static final String CATEGORY = LocalizingService.CATEGORY_VISUALIZER;
     public static final String ID = "com.willwinder.ugs.nbm.visualizer.actions.CameraYPreset";
     public static final String NAME = Localization.getString("platform.visualizer.popup.presets.front");
@@ -65,9 +66,11 @@ public final class CameraYPreset extends MoveCameraAction {
                 Lookup.getDefault().lookup(GcodeRenderer.class),
                 ROTATION_FRONT);
 
-        putValue("iconBase", ICON_BASE);
-        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE, false));
+        putValue("iconBase", SMALL_ICON_PATH);
+        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
+        putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", NAME);
         putValue(Action.NAME, NAME);
+        putValue(Action.SHORT_DESCRIPTION, "Sets the camera to Y preset");
     }
 }

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraZPreset.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/actions/CameraZPreset.java
@@ -38,7 +38,7 @@ import org.openide.util.Lookup;
         id = CameraZPreset.ID
 )
 @ActionRegistration(
-        iconBase = CameraZPreset.ICON_BASE,
+        iconBase = CameraZPreset.SMALL_ICON_PATH,
         displayName = "--",
         lazy = false
 )
@@ -48,7 +48,8 @@ import org.openide.util.Lookup;
                 position = 1060)
 })
 public final class CameraZPreset extends MoveCameraAction {
-    public static final String ICON_BASE = "icons/Z.png";
+    public static final String SMALL_ICON_PATH = "icons/Z.svg";
+    public static final String LARGE_ICON_PATH = "icons/Z24.svg";
     public static final String CATEGORY = LocalizingService.CATEGORY_VISUALIZER;
     public static final String ID = "com.willwinder.ugs.nbm.visualizer.actions.CameraZPreset";
     public static final String NAME = Localization.getString("platform.visualizer.popup.presets.top");
@@ -65,9 +66,11 @@ public final class CameraZPreset extends MoveCameraAction {
                 Lookup.getDefault().lookup(GcodeRenderer.class),
                 ROTATION_TOP);
 
-        putValue("iconBase", ICON_BASE);
-        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE, false));
+        putValue("iconBase", SMALL_ICON_PATH);
+        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
+        putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", NAME);
         putValue(Action.NAME, NAME);
+        putValue(Action.SHORT_DESCRIPTION, "Sets the camera to Z preset");
     }
 }


### PR DESCRIPTION
* Fixed icons on editor actions with correct sizes

* Added actions to editor toolbar
![image](https://user-images.githubusercontent.com/8962024/148655879-ce8fce11-c2e6-40a1-8282-807bbea329de.png)

* Added toolbar to visualizer
![image](https://user-images.githubusercontent.com/8962024/148655888-5dac7e23-8756-442e-afd3-08e8898ba3ad.png)

* Fixed visualizer highlight line width to work without deprecated OpenGL API:s for setting line width
![image](https://user-images.githubusercontent.com/8962024/148655897-0ca3d572-9878-49e2-bbb8-4365417f42c2.png)

* Now shows skipped lines in the editor as grayed out:
![image](https://user-images.githubusercontent.com/8962024/148655908-7d291e18-72b6-476b-a25d-61a479009cba.png)

* Error parser now parses gcode when file is loaded, fixed bug requiring the user to modify gcode for the parser to kick in.