### PR TITLE
Connect/disconnect will now allow to abort a failed connection 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
     <commons-csv.version>1.9.0</commons-csv.version>
     <gson.version>2.8.7</gson.version>
     <jmf.version>2.1.1e</jmf.version>
-    <vecmath.version>1.5.2</vecmath.version>
     <zxing.version>3.4.0</zxing.version>
     <qrgen.version>1.4</qrgen.version>
     <jacoco.version>0.8.7</jacoco.version>

--- a/ugs-classic/src/main/java/com/willwinder/universalgcodesender/MainWindow.java
+++ b/ugs-classic/src/main/java/com/willwinder/universalgcodesender/MainWindow.java
@@ -1603,7 +1603,6 @@ public class MainWindow extends JFrame implements UGSEventListener {
         
         switch (backend.getControllerState()) {
             case DISCONNECTED:
-            case UNKNOWN:
                 this.updateConnectionControlsStateOpen(false);
                 this.updateWorkflowControls(false);
                 this.setStatusColorForState(ControllerState.UNKNOWN);
@@ -1611,6 +1610,7 @@ public class MainWindow extends JFrame implements UGSEventListener {
             case IDLE:
             case CHECK:
             case ALARM:
+            case CONNECTING:
                 this.updateConnectionControlsStateOpen(true);
                 this.updateWorkflowControls(true);
                 break;

--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractCommunicator.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractCommunicator.java
@@ -81,8 +81,8 @@ public abstract class AbstractCommunicator implements ICommunicator {
     //do common operations (related to the connection, that is shared by all communicators)
     @Override
     public void connect(ConnectionDriver connectionDriver, String name, int baud) throws Exception {
+        String url = connectionDriver.getProtocol() + name + ":" + baud;
         if (connection == null) {
-            String url = connectionDriver.getProtocol() + name + ":" + baud;
             connection = ConnectionFactory.getConnection(url);
             logger.info("Connecting to controller using class: " + connection.getClass().getSimpleName() + " with url " + url);
         }
@@ -99,7 +99,9 @@ public abstract class AbstractCommunicator implements ICommunicator {
         this.eventThread.start();
 
         //open it
-        connection.openPort();
+        if (!connection.openPort()) {
+           throw new Exception("Could not connect to controller on port " + url);
+        }
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -382,6 +382,7 @@ public abstract class AbstractController implements CommunicatorListener, IContr
         // No point in checking response, it throws an exception on errors.
         this.comm.connect(connectionDriver, port, portRate);
         this.setCurrentState(COMM_IDLE);
+        this.setControllerState(ControllerState.CONNECTING);
 
         if (isCommOpen()) {
             this.openCommAfterEvent();
@@ -392,6 +393,8 @@ public abstract class AbstractController implements CommunicatorListener, IContr
 
         return isCommOpen();
     }
+
+    protected abstract void setControllerState(ControllerState controllerState);
 
     @Override
     public Boolean closeCommPort() throws Exception {
@@ -415,6 +418,7 @@ public abstract class AbstractController implements CommunicatorListener, IContr
         this.comm.disconnect();
 
         this.closeCommAfterEvent();
+        this.setControllerState(ControllerState.DISCONNECTED);
         return true;
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -51,6 +51,7 @@ import static com.willwinder.universalgcodesender.model.UnitUtils.scaleUnits;
 public abstract class AbstractController implements CommunicatorListener, IController {
     private static final Logger logger = Logger.getLogger(AbstractController.class.getName());
     private final GcodeParser parser = new GcodeParser();
+    private final ConnectionWatchTimer connectionWatchTimer = new ConnectionWatchTimer(this);
 
     // These abstract objects are initialized in concrete class.
     protected final ICommunicator comm;
@@ -95,7 +96,6 @@ public abstract class AbstractController implements CommunicatorListener, IContr
     // Maintain the current state given actions performed.
     // Concrete classes with a status field should override getControlState.
     private CommunicatorState currentState = COMM_DISCONNECTED;
-
 
     /** API Interface. */
 
@@ -391,6 +391,7 @@ public abstract class AbstractController implements CommunicatorListener, IContr
                     "**** Connected to " + port + " @ " + portRate + " baud ****\n");
         }
 
+        connectionWatchTimer.start();
         return isCommOpen();
     }
 
@@ -399,7 +400,7 @@ public abstract class AbstractController implements CommunicatorListener, IContr
     @Override
     public Boolean closeCommPort() throws Exception {
         // Already closed.
-        if (!isCommOpen()) {
+        if (!isCommOpen() && getControllerStatus().getState() == ControllerState.DISCONNECTED) {
             return true;
         }
 
@@ -419,6 +420,7 @@ public abstract class AbstractController implements CommunicatorListener, IContr
 
         this.closeCommAfterEvent();
         this.setControllerState(ControllerState.DISCONNECTED);
+        this.connectionWatchTimer.stop();
         return true;
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/ConnectionWatchTimer.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/ConnectionWatchTimer.java
@@ -1,0 +1,81 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender;
+
+import com.willwinder.universalgcodesender.utils.ThreadHelper;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Checks if the controller is still connected. If not this will attempt to
+ * disconnect the controller and clean up controller resources.
+ *
+ * @author Joacim Breiler
+ */
+public class ConnectionWatchTimer {
+    private static final Logger LOGGER = Logger.getLogger(ConnectionWatchTimer.class.getName());
+    private static final long INTERVAL = 2000;
+
+    private final IController controller;
+    private ScheduledFuture<?> timer;
+
+    public ConnectionWatchTimer(IController controller) {
+        this.controller = controller;
+    }
+
+    /**
+     * Begin issuing status request commands.
+     */
+    public void start() {
+        if (timer != null) {
+            timer.cancel(false);
+        }
+
+        timer = ThreadHelper.scheduleAtFixedRate(() -> {
+            if (!controller.getCommunicator().isConnected()) {
+                LOGGER.log(Level.SEVERE, "The connection was interrupted, attempting to clean up resources");
+                disconnect();
+                stop();
+            }
+        }, INTERVAL);
+    }
+
+    /**
+     * Checks if the controller is still connected
+     */
+    private void disconnect() {
+        try {
+            controller.closeCommPort();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed attempt to disconnect controller", e);
+        }
+    }
+
+    /**
+     * Stop issuing status request commands.
+     */
+    public void stop() {
+        if (timer != null) {
+            timer.cancel(false);
+            timer = null;
+        }
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -520,7 +520,7 @@ public class GrblUtils {
             case "sleep":
                 return ControllerState.SLEEP;
             default:
-                return ControllerState.UNKNOWN;
+                return ControllerState.DISCONNECTED;
         }
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/StatusPollTimer.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/StatusPollTimer.java
@@ -1,6 +1,24 @@
+/*
+    Copyright 2013-2020 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.universalgcodesender;
 
-import javax.swing.*;
+import javax.swing.Timer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -16,8 +34,8 @@ public class StatusPollTimer {
     private static final Logger LOGGER = Logger.getLogger(StatusPollTimer.class.getName());
     private static final int MAX_OUTSTANDING_POLLS = 20;
 
+    private final IController controller;
     private Timer timer;
-    private IController controller;
     private int outstandingPolls;
 
     public StatusPollTimer(IController controller) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -72,8 +72,17 @@ public class TinyGController extends AbstractController {
         firmwareSettings = new TinyGFirmwareSettings(this);
         communicator.addListener(firmwareSettings);
 
-        controllerStatus = new ControllerStatus(ControllerState.UNKNOWN, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(0, 0, 0, UnitUtils.Units.MM));
+        controllerStatus = new ControllerStatus(ControllerState.DISCONNECTED, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(0, 0, 0, UnitUtils.Units.MM));
         firmwareVersion = "TinyG unknown version";
+    }
+
+    @Override
+    protected void setControllerState(ControllerState controllerState) {
+        controllerStatus = ControllerStatusBuilder
+                .newInstance(controllerStatus)
+                .setState(controllerState)
+                .build();
+        dispatchStatusString(controllerStatus);
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
@@ -245,7 +245,7 @@ public class TinyGUtils {
     private static ControllerState getState(int state) {
         switch (state) {
             case 0: // Machine is initializing
-                return ControllerState.UNKNOWN;
+                return ControllerState.CONNECTING;
             case 1: // Machine is ready for use
                 return ControllerState.IDLE;
             case 2: // Machine is in alarm state

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/JSerialCommConnection.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/JSerialCommConnection.java
@@ -53,6 +53,10 @@ public class JSerialCommConnection extends AbstractConnection implements SerialP
             throw new ConnectionException("The connection wasn't initialized");
         }
 
+        if (serialPort.isOpen()) {
+            throw new ConnectionException("Can not connect, serial port is already open");
+        }
+
         return serialPort.openPort();
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerState.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerState.java
@@ -78,6 +78,11 @@ public enum ControllerState {
     DISCONNECTED,
 
     /**
+     * When attempting to establish a connection to the controller
+     */
+    CONNECTING,
+
+    /**
      * When the machine is in an unknown state
      */
     UNKNOWN

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -814,7 +814,7 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
         } catch (Exception e) {
             logger.log(Level.INFO, "Exception in openCommConnection.", e);
             throw new Exception(Localization.getString("mainWindow.error.connection")
-                    + " (" + e.getClass().getName() + "): " + e.getMessage());
+                    + ": " + e.getMessage());
         }
         return connected;
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/ThreadHelper.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/ThreadHelper.java
@@ -46,6 +46,17 @@ public class ThreadHelper {
     }
 
     /**
+     * Schedules a timer that will be executed at a fixed interval given in milliseconds
+     *
+     * @param command the command to execute
+     * @param interval the interval in milliseconds
+     * @return the future of the timer
+     */
+    static public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long interval) {
+        return scheduledExecutor.scheduleAtFixedRate(command, 0, interval, TimeUnit.MILLISECONDS);
+    }
+
+    /**
      * This method will wait for the given supplier to become true.
      * It will wait for the maximum given timeout and units and then throw a
      * timeout exception

--- a/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
@@ -135,6 +135,8 @@ public class AbstractControllerTest {
         expect(expectLastCall()).anyTimes();
         mockMessageService.dispatchMessage(anyObject(), anyString());
         expect(expectLastCall()).anyTimes();
+        instance.setControllerState(eq(ControllerState.CONNECTING));
+        expect(expectLastCall()).once();
         mockCommunicator.connect(or(eq(ConnectionDriver.JSERIALCOMM), eq(ConnectionDriver.JSSC)), eq(port), eq(portRate));
         expect(instance.isCommOpen()).andReturn(false).once();
         expect(instance.isCommOpen()).andReturn(true).anyTimes();

--- a/ugs-core/test/com/willwinder/universalgcodesender/G2CoreControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/G2CoreControllerTest.java
@@ -139,7 +139,7 @@ public class G2CoreControllerTest {
 
     @Test
     public void rawResponseWithStatusReportStateFromControllerShouldUpdateControllerState() {
-        assertEquals("The controller should begin in an unkown state", ControllerState.UNKNOWN, controller.getControllerStatus().getState());
+        assertEquals("The controller should begin in an disconnected state", ControllerState.DISCONNECTED, controller.getControllerStatus().getState());
 
         ControllerListener controllerListener = mock(ControllerListener.class);
         controller.addListener(controllerListener);

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -238,7 +238,7 @@ public class GrblControllerTest {
         GrblController instance = new GrblController(mgc);
         instance.openCommPort(getSettings().getConnectionDriver(), "blah", 1234);
         instance.rawResponseHandler("Grbl 0.9");
-        assertEquals(ControllerState.UNKNOWN, instance.getControllerStatus().getState());
+        assertEquals(ControllerState.CONNECTING, instance.getControllerStatus().getState());
 
         instance.performHomingCycle();
         assertEquals(ControllerState.HOME, instance.getControllerStatus().getState());
@@ -248,7 +248,7 @@ public class GrblControllerTest {
      * Test of issueSoftReset method, of class GrblController.
      */
     @Test
-    public void testIssueSoftReset() throws IOException, Exception {
+    public void testIssueSoftReset() throws Exception {
         System.out.println("issueSoftReset");
         GrblController instance = new GrblController(mgc);
 
@@ -1416,7 +1416,7 @@ public class GrblControllerTest {
 
         // Then
         assertEquals(COMM_IDLE, instance.getControlState());
-        assertEquals(ControllerState.UNKNOWN, instance.getControllerStatus().getState());
+        assertEquals(ControllerState.CONNECTING, instance.getControllerStatus().getState());
     }
 
     /**

--- a/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
@@ -106,7 +106,7 @@ public class TinyGControllerTest {
 
     @Test
     public void rawResponseWithStatusReportStateFromControllerShouldUpdateControllerState() {
-        assertEquals("The controller should begin in an unkown state", ControllerState.UNKNOWN, controller.getControllerStatus().getState());
+        assertEquals("The controller should begin in an disconnected state", ControllerState.DISCONNECTED, controller.getControllerStatus().getState());
 
         ControllerListener controllerListener = mock(ControllerListener.class);
         controller.addListener(controllerListener);

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
@@ -415,7 +415,7 @@ public class ProbeService implements UGSEventListener {
         if (evt instanceof ControllerStateEvent) {
             ControllerStateEvent controllerStateEvent = (ControllerStateEvent) evt;
             ControllerState state = controllerStateEvent.getState();
-            if (state == ControllerState.DISCONNECTED || state == ControllerState.UNKNOWN) {
+            if (state == ControllerState.DISCONNECTED) {
                 resetProbe();
             } else if (state == ControllerState.IDLE) {
                 // Finalize

--- a/ugs-platform/ugs-platform-plugin-dro/src/main/java/com/willwinder/ugs/nbp/dro/panels/MachineStatusPanel.java
+++ b/ugs-platform/ugs-platform-plugin-dro/src/main/java/com/willwinder/ugs/nbp/dro/panels/MachineStatusPanel.java
@@ -209,10 +209,6 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Axis
 
     private Timer createTimer() {
         return new Timer((int) REFRESH_RATE.toMillis(), (ae) -> EventQueue.invokeLater(() -> {
-            if (!backend.isConnected()) {
-                activeStateValueLabel.setText(OFFLINE);
-                activeStatePanel.setBackground(Color.BLACK);
-            }
             GcodeState state = backend.getGcodeState();
             if (state == null) {
                 gStatesLabel.setText("--");
@@ -265,7 +261,7 @@ public class MachineStatusPanel extends JPanel implements UGSEventListener, Axis
             });
 
             // Clear out the status color.
-            this.updateStatePanel(ControllerState.UNKNOWN);
+            this.updateStatePanel(ControllerState.DISCONNECTED);
             resetStatePinComponents();
             return;
         }

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/actions/ConnectDisconnectAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/actions/ConnectDisconnectAction.java
@@ -20,6 +20,7 @@ package com.willwinder.ugs.nbp.core.actions;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.UGSEvent;
@@ -84,16 +85,16 @@ public class ConnectDisconnectAction extends AbstractAction implements UGSEventL
     }
 
     private void updateIconAndText() {
-        if (backend.isConnected()) {
-            putValue(NAME, LocalizingService.ConnectDisconnectTitleDisconnect);
-            putValue("menuText", LocalizingService.ConnectDisconnectTitleDisconnect);
-            putValue("iconBase", ICON_BASE);
-            putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE, false));
-        } else {
+        if (backend.getControllerState() == ControllerState.DISCONNECTED) {
             putValue(NAME, LocalizingService.ConnectDisconnectTitleConnect);
             putValue("menuText", LocalizingService.ConnectDisconnectTitleConnect);
             putValue("iconBase", ICON_BASE_DISCONNECT);
             putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE_DISCONNECT, false));
+        } else {
+            putValue(NAME, LocalizingService.ConnectDisconnectTitleDisconnect);
+            putValue("menuText", LocalizingService.ConnectDisconnectTitleDisconnect);
+            putValue("iconBase", ICON_BASE);
+            putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE, false));
         }
     }
 
@@ -114,7 +115,7 @@ public class ConnectDisconnectAction extends AbstractAction implements UGSEventL
 
     private void connect() {
         logger.log(Level.INFO, "openclose button, connection open: {0}", backend.isConnected());
-        if (!backend.isConnected()) {
+        if (backend.getControllerState() == ControllerState.DISCONNECTED) {
             Settings s = backend.getSettings();
 
             String firmware = s.getFirmwareVersion();
@@ -133,7 +134,7 @@ public class ConnectDisconnectAction extends AbstractAction implements UGSEventL
                 backend.disconnect();
             } catch (Exception e) {
                 String message = e.getMessage();
-                if(StringUtils.isEmpty(message)) {
+                if (StringUtils.isEmpty(message)) {
                     message = "Got an unknown error while disconnecting, see log for more details";
                     logger.log(Level.SEVERE, "Got an unknown error while disconnecting", e);
                 }


### PR DESCRIPTION
When trying to connect to a controller on the wrong port it was no longer possible to disconnect. The user needed to restart the software.

Made it possible to disconnect from a failed connection. Also added a connection watcher to watch if the serial port was closed and clean up the controller resources.