### PR TITLE
Added listeners to commands to listen for when it completes.

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2020 Will Winder
+    Copyright 2013-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -75,7 +75,7 @@ public class GrblController extends AbstractController {
      */
     private boolean temporaryCheckSingleStepMode = false;
 
-    public GrblController(AbstractCommunicator comm) {
+    public GrblController(ICommunicator comm) {
         super(comm);
         
         this.commandCreator = new GcodeCommandCreator();
@@ -690,5 +690,10 @@ public class GrblController extends AbstractController {
             this.dispatchConsoleMessage(MessageType.INFO, String.format(">>> 0x%02x\n", realTimeCommand));
             this.comm.sendByteImmediately(realTimeCommand);
         }
+    }
+
+    @Override
+    protected void updateCommandFromResponse(GcodeCommand command, String response) {
+        GrblUtils.updateGcodeCommandFromResponse(command, response);
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblEsp32Controller.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblEsp32Controller.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Will Winder
+    Copyright 2021-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -32,6 +32,11 @@ public class GrblEsp32Controller extends GrblController {
 
     public GrblEsp32Controller() {
         super();
+        this.capabilities.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
+    }
+
+    public GrblEsp32Controller(ICommunicator communicator) {
+        super(communicator);
         this.capabilities.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2012-2020 Will Winder
+    Copyright 2012-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -654,5 +654,7 @@ public class GrblUtils {
             gcodeCommand.setOk(false);
             gcodeCommand.setError(true);
         }
+
+        gcodeCommand.setDone(true);
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/SmoothieController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/SmoothieController.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2019 Will Winder
+    Copyright 2016-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -309,5 +309,10 @@ public class SmoothieController extends AbstractController {
                 .setState(controllerState)
                 .build();
         dispatchStatusString(controllerStatus);
+    }
+
+    @Override
+    protected void updateCommandFromResponse(GcodeCommand command, String response) {
+        GrblUtils.updateGcodeCommandFromResponse(command, response);
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2020 Will Winder
+    Copyright 2013-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -447,5 +447,20 @@ public class TinyGController extends AbstractController {
             default:
                 return COMM_IDLE;
         }
+    }
+
+    @Override
+    protected void updateCommandFromResponse(GcodeCommand command, String response) {
+        JsonObject jo = TinyGUtils.jsonToObject(response);
+        command.setResponse(response);
+        if (TinyGUtils.isErrorResponse(jo)) {
+            command.setOk(false);
+            command.setError(true);
+        } else {
+            command.setOk(true);
+            command.setError(false);
+        }
+
+        command.setDone(true);
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2018 Will Winder
+    Copyright 2013-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -60,6 +60,7 @@ public class TinyGUtils {
     public static final String FIELD_STATUS_REPORT = "sr";
     private static final String FIELD_FIRMWARE_VERSION = "fv";
     private static final String FIELD_RESPONSE = "r";
+    private static final String FIELD_STATUS_ERROR = "err";
     private static final String FIELD_STATUS_REPORT_UNIT = "unit";
     private static final String FIELD_STATUS_REPORT_POSX = "posx";
     private static final String FIELD_STATUS_REPORT_POSY = "posy";
@@ -143,6 +144,10 @@ public class TinyGUtils {
 
     public static boolean isStatusResponse(JsonObject response) {
         return response.has(TinyGUtils.FIELD_STATUS_REPORT) && response.get(TinyGUtils.FIELD_STATUS_REPORT).isJsonObject();
+    }
+
+    public static boolean isErrorResponse(JsonObject response) {
+        return response.has(TinyGUtils.FIELD_RESPONSE) && response.get(TinyGUtils.FIELD_RESPONSE).getAsJsonObject().has(FIELD_STATUS_ERROR);
     }
 
     /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/types/CommandListener.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/types/CommandListener.java
@@ -1,0 +1,34 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.types;
+
+/**
+ * A command listener that can be registered on a command to receive when it
+ * is considered to be completed.
+ *
+ * @author Joacim Breiler
+ */
+public interface CommandListener {
+    /**
+     * When the command has been completed with either status ok, error or skipped.
+     *
+     * @param command the command that was completed
+     */
+    void onDone(GcodeCommand command);
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/ControllerUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/ControllerUtils.java
@@ -1,0 +1,67 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.utils;
+
+import com.willwinder.universalgcodesender.IController;
+import com.willwinder.universalgcodesender.types.CommandListener;
+import com.willwinder.universalgcodesender.types.GcodeCommand;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author Joacim Breiler
+ */
+public class ControllerUtils {
+
+    private static final int MAX_EXECUTION_TIME = 2000;
+
+    /**
+     * Sends a command and blocks the thread until the command is done - either with an ok or error.
+     *
+     * @param controller       the controller to send the command through
+     * @param command          a command to send
+     * @param maxExecutionTime the max number of milliseconds to wait before throwing a timeout error
+     * @throws Exception if the command could not be sent or a timeout occurred
+     */
+    public static void sendAndWaitForCompletion(IController controller, GcodeCommand command, long maxExecutionTime) throws Exception {
+        final AtomicBoolean isDone = new AtomicBoolean(false);
+        CommandListener listener = c -> isDone.set(c.isDone());
+        command.addListener(listener);
+        controller.sendCommandImmediately(command);
+
+        long startTime = System.currentTimeMillis();
+        while (!isDone.get()) {
+            if (System.currentTimeMillis() > startTime + maxExecutionTime) {
+                throw new RuntimeException("The command \"" + command.getCommandString() + "\" has timed out as it wasn't finished within " + maxExecutionTime + "ms");
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    /**
+     * Sends a command and blocks the thread until the command is done - either with an ok or error.
+     *
+     * @param controller the controller to send the command through
+     * @param command    a command
+     * @throws Exception if the command could not be sent or a timeout occurred
+     */
+    public static void sendAndWaitForCompletion(IController controller, GcodeCommand command) throws Exception {
+        sendAndWaitForCompletion(controller, command, MAX_EXECUTION_TIME);
+    }
+}

--- a/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/AbstractControllerTest.java
@@ -136,10 +136,10 @@ public class AbstractControllerTest {
         expect(expectLastCall()).anyTimes();
         instance.setControllerState(eq(ControllerState.CONNECTING));
         expect(expectLastCall()).once();
-        expect(mockCommunicator.isConnected()).andReturn(true).anyTimes();
         mockCommunicator.connect(or(eq(ConnectionDriver.JSERIALCOMM), eq(ConnectionDriver.JSSC)), eq(port), eq(portRate));
         expect(instance.isCommOpen()).andReturn(false).once();
         expect(instance.isCommOpen()).andReturn(true).anyTimes();
+        expect(mockCommunicator.isConnected()).andReturn(true).anyTimes();
         expect(instance.handlesAllStateChangeEvents()).andReturn(handleStateChange).anyTimes();
     }
     private void streamInstanceExpectUtility() throws Exception {

--- a/ugs-core/test/com/willwinder/universalgcodesender/G2CoreControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/G2CoreControllerTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018 Will Winder
+    Copyright 2018-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -31,6 +31,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -342,5 +344,18 @@ public class G2CoreControllerTest {
 
         // Then
         assertEquals("Should now consider send commands as a normal run state", ControllerState.RUN, controller.getControllerStatus().getState());
+    }
+
+    @Test
+    public void commandCompleteShouldDispatchCommandEvent() throws Exception {
+        AtomicBoolean eventDispatched = new AtomicBoolean(false);
+        GcodeCommand command = new GcodeCommand("{}");
+        command.addListener(c -> eventDispatched.set(true));
+
+        // Simulate sending and completing the command
+        controller.commandSent(command);
+        controller.commandComplete("{}");
+
+        assertTrue("Should have sent an event notifying that the command has completed", eventDispatched.get());
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2018 Will Winder
+    Copyright 2013-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.willwinder.universalgcodesender.GrblUtils.*;
 import static com.willwinder.universalgcodesender.model.CommunicatorState.*;
@@ -1034,6 +1035,23 @@ public class GrblControllerTest {
         // TODO: Test that command complete triggers a listener event.
 
         // TODO: Test that command complete triggers fileStreamComplete.
+    }
+
+    @Test
+    public void commandCompleteShouldDispatchCommandEvent() throws Exception {
+        GrblController instance = new GrblController(mgc);
+        instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
+        instance.rawResponseHandler("Grbl 1.1c");
+
+        AtomicBoolean eventDispatched = new AtomicBoolean(false);
+        GcodeCommand command = new GcodeCommand("blah");
+        command.addListener(c -> eventDispatched.set(true));
+
+        // Simulate sending and completing the command
+        instance.commandSent(command);
+        instance.commandComplete("ok");
+
+        assertTrue("Should have sent an event notifying that the command has completed", eventDispatched.get());
     }
 
     /**

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblEsp32ControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblEsp32ControllerTest.java
@@ -1,9 +1,31 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.universalgcodesender;
 
+import com.willwinder.universalgcodesender.types.GcodeCommand;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.willwinder.universalgcodesender.CapabilitiesConstants.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class GrblEsp32ControllerTest {
     @Test
@@ -35,4 +57,21 @@ public class GrblEsp32ControllerTest {
         assertFalse(instance.getCapabilities().hasCapability(C_AXIS));
     }
 
+    @Test
+    public void commandCompleteShouldDispatchCommandEvent() throws Exception {
+        ICommunicator communicator = mock(ICommunicator.class);
+        when(communicator.isConnected()).thenReturn(true);
+        GrblEsp32Controller instance = new GrblEsp32Controller(communicator);
+        instance.rawResponseHandler("Grbl 1.1c");
+
+        AtomicBoolean eventDispatched = new AtomicBoolean(false);
+        GcodeCommand command = new GcodeCommand("blah");
+        command.addListener(c -> eventDispatched.set(true));
+
+        // Simulate sending and completing the command
+        instance.commandSent(command);
+        instance.commandComplete(command.getCommandString());
+
+        assertTrue("Should have sent an event notifying that the command has completed", eventDispatched.get());
+    }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/SmoothieControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/SmoothieControllerTest.java
@@ -1,0 +1,49 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender;
+
+import com.willwinder.universalgcodesender.types.GcodeCommand;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SmoothieControllerTest {
+
+    @Test
+    public void commandCompleteShouldDispatchCommandEvent() throws Exception {
+        ICommunicator communicator = mock(ICommunicator.class);
+        when(communicator.isConnected()).thenReturn(true);
+        SmoothieController instance = new SmoothieController(communicator);
+        instance.rawResponseHandler("Smoothie");
+
+        AtomicBoolean eventDispatched = new AtomicBoolean(false);
+        GcodeCommand command = new GcodeCommand("blah");
+        command.addListener(c -> eventDispatched.set(true));
+
+        // Simulate sending and completing the command
+        instance.commandSent(command);
+        instance.commandComplete("ok");
+
+        assertTrue("Should have sent an event notifying that the command has completed", eventDispatched.get());
+    }
+}

--- a/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018 Will Winder
+    Copyright 2018-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -31,6 +31,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -266,5 +268,20 @@ public class TinyGControllerTest {
         assertEquals("G20G90G1X0.039Y0.079Z0.118F39.37", command.getCommandString());
         assertTrue(command.isGenerated());
         assertTrue(command.isTemporaryParserModalChange());
+    }
+
+    @Test
+    public void commandCompleteShouldDispatchCommandEvent() throws Exception {
+        when(communicator.isConnected()).thenReturn(true);
+
+        AtomicBoolean eventDispatched = new AtomicBoolean(false);
+        GcodeCommand command = new GcodeCommand("blah");
+        command.addListener(c -> eventDispatched.set(true));
+
+        // Simulate sending and completing the command
+        controller.commandSent(command);
+        controller.commandComplete("{}");
+
+        assertTrue("Should have sent an event notifying that the command has completed", eventDispatched.get());
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/types/GcodeCommandTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/types/GcodeCommandTest.java
@@ -1,0 +1,89 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.types;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class GcodeCommandTest {
+
+    @Test
+    public void shouldNotifyListenerWhenCommandIsDone() {
+        AtomicInteger timesListenerCalled = new AtomicInteger(0);
+        GcodeCommand command = new GcodeCommand("TEST");
+        command.addListener(c -> timesListenerCalled.incrementAndGet());
+
+        command.setOk(true);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setOk(false);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setSent(true);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setSent(false);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setSkipped(true);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setSkipped(false);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setError(false);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setError(true);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setDone(false);
+        assertEquals(0, timesListenerCalled.get());
+
+        command.setDone(true);
+        assertEquals(1, timesListenerCalled.get());
+    }
+
+    @Test
+    public void shouldOnlyNotifyListenersOnceWhenDone() {
+        AtomicInteger timesListenerCalled = new AtomicInteger(0);
+        GcodeCommand command = new GcodeCommand("TEST");
+        command.addListener(c -> timesListenerCalled.incrementAndGet());
+
+        command.setDone(true);
+        assertEquals(1, timesListenerCalled.get());
+
+        command.setDone(true);
+        assertEquals(1, timesListenerCalled.get());
+    }
+
+    @Test
+    public void shouldNotifyAllListenersOnceWhenDone() {
+        AtomicInteger timesListenerCalled = new AtomicInteger(0);
+        GcodeCommand command = new GcodeCommand("TEST");
+        command.addListener(c -> timesListenerCalled.incrementAndGet());
+        command.addListener(c -> timesListenerCalled.incrementAndGet());
+
+        command.setDone(true);
+        assertEquals(2, timesListenerCalled.get());
+    }
+}

--- a/ugs-core/test/com/willwinder/universalgcodesender/utils/ControllerUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/utils/ControllerUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.utils;
+
+import com.willwinder.universalgcodesender.IController;
+import com.willwinder.universalgcodesender.types.GcodeCommand;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class ControllerUtilsTest {
+
+    @Test
+    public void sendAndWaitForCompletionShouldBlockAndReturnWhenCommandIsDone() throws Exception {
+        IController controller = mock(IController.class);
+        GcodeCommand command = new GcodeCommand("blah");
+
+        AtomicBoolean isDoneBlocking = new AtomicBoolean(false);
+        Thread thread = new Thread(() -> {
+            try {
+                ControllerUtils.sendAndWaitForCompletion(controller, command, 1000);
+                isDoneBlocking.set(true);
+            } catch (Exception e) {
+                fail("Got unwanted exception" + e.getMessage());
+            }
+        });
+        thread.start();
+
+        // Wait for the command to be queued and sent
+        Thread.sleep(100);
+
+        // Simulate that the command has been completed
+        command.setDone(true);
+
+        // Wait for the command event has been processed
+        Thread.sleep(100);
+
+        assertTrue(isDoneBlocking.get());
+    }
+
+    @Test
+    public void sendAndWaitForCompletionShouldTimeOut() throws Exception {
+        IController controller = mock(IController.class);
+        GcodeCommand command = new GcodeCommand("blah");
+        assertThrows("The command \"blah\" has timed out as it wasn't finished within 100ms", RuntimeException.class, () -> ControllerUtils.sendAndWaitForCompletion(controller, command, 100));
+    }
+}


### PR DESCRIPTION
I started working on a new controller implementation and found a need for listening to if a command was completed.
This could be done using a `UGSEventListener` and listening for a CommandEvent in the application, but not from the controller. From the controller we have access to the `ControllerLisener` but would require to implement a rather large listener interface.

I propose to add a listener to the GcodeCommand, this would it make it possible to execute a command and wait for it to be completed:
```java
try {
  GcodeCommand command = new GcodeCommand("G0 X10 Y10");
  ControllerUtils.sendAndWaitForCompletion(controller, command, 1000); // Wait max 1000ms for the command to complete
  if (command.isOk()) {
    // Do something with the response
  }
} catch (RuntimeException e) {
  // The command has timed out
}
```