### PR TITLE
Added a feature for tracing bitmap images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <ugs.commons-cli.version>1.4</ugs.commons-cli.version>
     <ugs.easymock.version>3.4</ugs.easymock.version>
     <ugs.maven-assembly-plugin.version>2.5.3</ugs.maven-assembly-plugin.version>
+    <ugs.jide.version>3.7.12</ugs.jide.version>
 
     <!-- Sets the timestamp format -->
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>

--- a/ugs-platform/ugs-platform-plugin-designer/pom.xml
+++ b/ugs-platform/ugs-platform-plugin-designer/pom.xml
@@ -181,5 +181,10 @@
             <version>${netbeans.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.formdev</groupId>
+            <artifactId>jide-oss</artifactId>
+            <version>${ugs.jide.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SubtractAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SubtractAction.java
@@ -20,6 +20,7 @@ package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.entities.Entity;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.Cuttable;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Group;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.Path;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
@@ -53,7 +54,7 @@ public class SubtractAction extends AbstractAction implements SelectionListener 
         this.controller = controller;
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);
-        setEnabled(selectionManager.getSelection().size() == 2);
+        setEnabled(selectionManager.getSelection().size() >= 2);
     }
 
     @Override
@@ -67,7 +68,7 @@ public class SubtractAction extends AbstractAction implements SelectionListener 
     @Override
     public void onSelectionEvent(SelectionEvent selectionEvent) {
         SelectionManager selectionManager = controller.getSelectionManager();
-        setEnabled(selectionManager.getSelection().size() == 2);
+        setEnabled(selectionManager.getSelection().size() >= 2);
     }
 
     private class UndoableSubtractAction implements UndoableAction {
@@ -81,7 +82,16 @@ public class SubtractAction extends AbstractAction implements SelectionListener 
         @Override
         public void redo() {
             Area area = new Area(entities.get(0).getShape());
-            area.subtract(new Area(entities.get(1).getShape()));
+            for (int i = 1; i < entities.size(); i++) {
+                Entity entity = entities.get(i);
+                if (entity instanceof Group) {
+                   ((Group) entity).getAllChildren().forEach(groupEntity -> {
+                       area.subtract(new Area(groupEntity.getShape()));
+                   });
+                } else {
+                    area.subtract(new Area(entity.getShape()));
+                }
+            }
 
             path = new Path();
             if (entities.get(0) instanceof Cuttable) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/TraceImageAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/TraceImageAction.java
@@ -1,0 +1,65 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.actions;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.gui.imagetracer.ImageTracerDialog;
+import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.universalgcodesender.utils.ThreadHelper;
+import org.openide.util.ImageUtilities;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.util.List;
+
+/**
+ * @author Joacim Breiler
+ */
+public class TraceImageAction extends AbstractAction {
+
+    public static final String SMALL_ICON_PATH = "img/trace.svg";
+    public static final String LARGE_ICON_PATH = "img/trace24.svg";
+    private final transient Controller controller;
+
+    public TraceImageAction(Controller controller) {
+        putValue("iconBase", SMALL_ICON_PATH);
+        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
+        putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
+        putValue("menuText", "Trace image");
+        putValue(NAME, "Trace Image");
+        this.controller = controller;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        ImageTracerDialog dialog = new ImageTracerDialog();
+        ThreadHelper.invokeLater(() -> {
+            List<Entity> entities = dialog.showDialog();
+
+            if (entities != null && !entities.isEmpty()) {
+                AddAction addAction = new AddAction(controller, entities);
+                addAction.actionPerformed(e);
+                controller.getSelectionManager().addSelection(entities);
+                controller.getDrawing().repaint();
+                controller.setTool(Tool.SELECT);
+            }
+        });
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/AbstractEntity.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/AbstractEntity.java
@@ -24,6 +24,7 @@ import com.willwinder.ugs.nbp.designer.model.Size;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.Set;
@@ -37,6 +38,7 @@ public abstract class AbstractEntity implements Entity {
 
     private AffineTransform transform = new AffineTransform();
     private String name = "AbstractEntity";
+    private String description;
 
     protected AbstractEntity() {
         this(0, 0);
@@ -236,6 +238,16 @@ public abstract class AbstractEntity implements Entity {
 
     public String getName() {
         return this.name;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
     }
 
     public String toString() {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/Entity.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/Entity.java
@@ -241,4 +241,18 @@ public interface Entity {
      * @return a copy of the entity
      */
     Entity copy();
+
+    /**
+     * An optional description
+     *
+     * @param description
+     */
+    void setDescription(String description);
+
+    /**
+     * Returns an optional description
+     *
+     * @return the description or null
+     */
+    String getDescription();
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
@@ -68,6 +68,13 @@ public class ToolBox extends ToolBar {
         insertButton.setBorderPainted(false);
         add(insertButton);
 
+        insertButton = new JButton(new TraceImageAction(controller));
+        insertButton.setText("");
+        insertButton.setToolTipText("Traces a bitmap image");
+        insertButton.setContentAreaFilled(false);
+        insertButton.setBorderPainted(false);
+        add(insertButton);
+
         addSeparator();
 
         JButton flipHorizontal = new JButton(new FlipHorizontallyAction(controller));

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/ImageTracerDialog.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/ImageTracerDialog.java
@@ -1,0 +1,145 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.gui.imagetracer;
+
+import com.willwinder.ugs.nbp.designer.Throttler;
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Group;
+import com.willwinder.ugs.nbp.designer.io.svg.SvgReader;
+import com.willwinder.ugs.nbp.designer.model.Design;
+import com.willwinder.universalgcodesender.utils.ThreadHelper;
+import net.miginfocom.swing.MigLayout;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.List;
+
+/**
+ * @author Joacim Breiler
+ */
+public class ImageTracerDialog extends JDialog {
+    private List<Entity> entities = new ArrayList<>();
+    private final SVGCanvas svgCanvas = new SVGCanvas();
+    private final TraceSettingsPanel settingsPanel = new TraceSettingsPanel();
+    private final Throttler refreshThrottler;
+
+    private File selectedFile;
+    private String generatedSvgData;
+
+    public ImageTracerDialog() {
+        super((JFrame) null, true);
+        setTitle("Trace image");
+        setPreferredSize(new Dimension(700, 600));
+        setMinimumSize(new Dimension(500, 500));
+        setLayout(new MigLayout("fill, insets 5", "[170px][grow]", "[grow][20px]"));
+
+        svgCanvas.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY, 1));
+        add(settingsPanel, "grow");
+        add(svgCanvas, "grow, wrap");
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton openImage = new JButton("Open");
+        openImage.addActionListener(e -> openFile());
+        buttonPanel.add(openImage);
+
+        JButton cancelButton = new JButton("Cancel");
+        cancelButton.addActionListener(e -> dispose());
+        buttonPanel.add(cancelButton);
+
+        JButton okButton = new JButton("OK");
+        okButton.addActionListener(e -> ThreadHelper.invokeLater(this::generateEntities));
+        buttonPanel.add(okButton);
+        add(buttonPanel, "spanx, grow");
+
+        refreshThrottler = new Throttler(this::refreshSvg, 1000);
+        settingsPanel.addListener(e -> refreshThrottler.run());
+        setResizable(true);
+        pack();
+    }
+
+    private void refreshSvg() {
+        ThreadHelper.invokeLater(() -> {
+            if (selectedFile != null) {
+                generatedSvgData = TraceUtils.traceImage(selectedFile, settingsPanel.getSettings());
+                svgCanvas.setSvgData(generatedSvgData);
+            } else {
+                svgCanvas.setSVGDocument(null);
+            }
+        });
+    }
+
+    private void openFile() {
+        JFileChooser fileDialog = new JFileChooser();
+        fileDialog.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        fileDialog.addChoosableFileFilter(new FileNameExtensionFilter("PNG", "png"));
+        fileDialog.addChoosableFileFilter(new FileNameExtensionFilter("JPEG", "jpeg", "jpg"));
+        fileDialog.showOpenDialog(this);
+        setSelectedFile(fileDialog.getSelectedFile());
+    }
+
+    private void generateEntities() {
+        SvgReader svgReader = new SvgReader();
+        Optional<Design> designOptional = svgReader.read(new ByteArrayInputStream(generatedSvgData.getBytes(Charset.defaultCharset())));
+        designOptional.ifPresent(design -> {
+            Map<String, List<Entity>> entityLayersMap = new HashMap<>();
+            ((Group) design.getEntities().get(0)).getAllChildren().forEach(entity -> {
+                String layerId = StringUtils.substringBetween(entity.getDescription(), "l ", " ");
+                List<Entity> layerEntities = entityLayersMap.getOrDefault(layerId, new ArrayList<>());
+                layerEntities.add(entity);
+                entityLayersMap.put(layerId, layerEntities);
+            });
+
+            List<String> layerIds = new ArrayList<>(entityLayersMap.keySet());
+            Collections.reverse(layerIds);
+
+            entities = new ArrayList<>();
+            layerIds.forEach(layerId -> {
+                Group layerGroup = new Group();
+                layerGroup.setName(layerId);
+                layerGroup.addAll(entityLayersMap.get(layerId));
+                entities.add(layerGroup);
+            });
+            dispose();
+        });
+    }
+
+
+    private void setSelectedFile(File selectedFile) {
+        this.selectedFile = selectedFile;
+        refreshThrottler.run();
+    }
+
+    public static void main(String[] args) {
+        ImageTracerDialog insertShapeDialog = new ImageTracerDialog();
+        insertShapeDialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        insertShapeDialog.showDialog();
+    }
+
+    public List<Entity> showDialog() {
+        setVisible(true);
+        dispose();
+        return entities;
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/SVGCanvas.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/SVGCanvas.java
@@ -1,0 +1,71 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.gui.imagetracer;
+
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
+import org.apache.batik.bridge.ViewBox;
+import org.apache.batik.swing.JSVGCanvas;
+import org.apache.batik.util.XMLResourceDescriptor;
+import org.w3c.dom.svg.SVGDocument;
+import org.w3c.dom.svg.SVGPreserveAspectRatio;
+import org.w3c.dom.svg.SVGRect;
+import org.w3c.dom.svg.SVGSVGElement;
+
+import java.awt.geom.AffineTransform;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+
+/**
+ * @author Joacim Breiler
+ */
+public class SVGCanvas extends JSVGCanvas {
+    public SVGCanvas() {
+        super();
+    }
+
+    @Override
+    protected AffineTransform calculateViewingTransform(String svgElementIdentifier, SVGSVGElement svgElement) {
+        SVGRect svgElementBounds = svgElement.getBBox();
+        float[] svgElementBoundsVector = new float[]{
+                svgElementBounds.getX(),
+                svgElementBounds.getY(),
+                svgElementBounds.getWidth(),
+                svgElementBounds.getHeight()
+        };
+
+        return ViewBox.getPreserveAspectRatioTransform(
+                svgElementBoundsVector,
+                SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID,
+                true,
+                getWidth(),
+                getHeight()
+        );
+    }
+
+    public void setSvgData(String generatedSvgData) {
+        try{
+            String parser = XMLResourceDescriptor.getXMLParserClassName();
+            SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
+            SVGDocument document = factory.createSVGDocument("", new ByteArrayInputStream(generatedSvgData.getBytes(Charset.defaultCharset())));
+            setSVGDocument(document);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/TraceSettings.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/TraceSettings.java
@@ -1,0 +1,106 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.gui.imagetracer;
+
+/**
+ * @author Joacim Breiler
+ */
+public class TraceSettings {
+    private float lineThreshold;
+    private float quadThreshold;
+    private int pathOmit;
+    private int numberOfColors;
+    private int colorQuantize;
+    private int blurRadius;
+    private int blurDelta;
+    private int startColor;
+    private int endColor;
+
+    public float getLineThreshold() {
+        return lineThreshold;
+    }
+
+    public void setLineThreshold(float lineThreshold) {
+        this.lineThreshold = lineThreshold;
+    }
+
+    public float getQuadThreshold() {
+        return quadThreshold;
+    }
+
+    public void setQuadThreshold(float quadThreshold) {
+        this.quadThreshold = quadThreshold;
+    }
+
+    public int getPathOmit() {
+        return pathOmit;
+    }
+
+    public void setPathOmit(int pathOmit) {
+        this.pathOmit = pathOmit;
+    }
+
+    public int getNumberOfColors() {
+        return numberOfColors;
+    }
+
+    public void setNumberOfColors(int numberOfColors) {
+        this.numberOfColors = numberOfColors;
+    }
+
+    public int getColorQuantize() {
+        return colorQuantize;
+    }
+
+    public void setColorQuantize(int colorQuantize) {
+        this.colorQuantize = colorQuantize;
+    }
+
+    public int getBlurRadius() {
+        return blurRadius;
+    }
+
+    public void setBlurRadius(int blurRadius) {
+        this.blurRadius = blurRadius;
+    }
+
+    public int getBlurDelta() {
+        return blurDelta;
+    }
+
+    public void setBlurDelta(int blurDelta) {
+        this.blurDelta = blurDelta;
+    }
+
+    public int getStartColor() {
+        return startColor;
+    }
+
+    public void setStartColor(int startColor) {
+        this.startColor = startColor;
+    }
+
+    public int getEndColor() {
+        return endColor;
+    }
+
+    public void setEndColor(int endColor) {
+        this.endColor = endColor;
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/TraceSettingsPanel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/TraceSettingsPanel.java
@@ -1,0 +1,139 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.gui.imagetracer;
+
+import com.jidesoft.swing.RangeSlider;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Joacim Breiler
+ */
+public class TraceSettingsPanel extends JPanel {
+    private JSlider colors = new JSlider(2, 10, 5);
+    private JSlider lineThreshold = new JSlider(0, 100, 0);
+    private JSlider curveThreshold = new JSlider(0, 100, 0);
+    private JSlider colorsQuantization = new JSlider(1, 100, 1);
+    private JSlider pathOmit = new JSlider(0, 100, 0);
+    private JSlider blurRadius = new JSlider(0, 5, 0);
+    private JSlider blurDelta = new JSlider(0, 1014, 0);
+    private RangeSlider colorRange = new RangeSlider(0, 255, 0, 255);
+    private final List<ChangeListener> listenerList = new ArrayList<>();
+
+    public TraceSettingsPanel() {
+        setLayout(new MigLayout("fill, insets 0, wrap 1"));
+
+        colors.addChangeListener(this::updateValues);
+        colors.setSnapToTicks(true);
+        add(new JLabel("Number of layers"));
+        add(colors);
+
+        colorRange.addChangeListener(this::updateValues);
+        colorRange.setMinorTickSpacing(10);
+        colorRange.setSnapToTicks(true);
+        add(new JLabel("Color range"));
+        add(colorRange);
+
+        colorsQuantization.addChangeListener(this::updateValues);
+        colorsQuantization.setSnapToTicks(true);
+        add(new JLabel("Color quantization"));
+        add(colorsQuantization);
+
+        add(new JSeparator(JSeparator.HORIZONTAL), "grow");
+
+        lineThreshold.addChangeListener(this::updateValues);
+        lineThreshold.setMinorTickSpacing(5);
+        lineThreshold.setSnapToTicks(true);
+        add(new JLabel("Smooth lines"));
+        add(lineThreshold);
+
+        curveThreshold.addChangeListener(this::updateValues);
+        curveThreshold.setMinorTickSpacing(5);
+        curveThreshold.setSnapToTicks(true);
+        add(new JLabel("Smooth curves"));
+        add(curveThreshold);
+
+        pathOmit.addChangeListener(this::updateValues);
+        pathOmit.setSnapToTicks(true);
+        add(new JLabel("Filter noise"));
+        add(pathOmit);
+
+        add(new JSeparator(JSeparator.HORIZONTAL), "grow");
+
+
+        blurRadius.addChangeListener(this::updateValues);
+        blurRadius.setSnapToTicks(true);
+        add(new JLabel("Blur radius"));
+        add(blurRadius);
+
+        blurDelta.addChangeListener(this::updateValues);
+        blurDelta.setSnapToTicks(true);
+        add(new JLabel("Blur delta"));
+        add(blurDelta);
+    }
+
+    private void updateValues(ChangeEvent e) {
+            if(colorRange.getHighValue() == colorRange.getMinimum()) {
+                colorRange.setHighValue(colorRange.getMinimum() + 20);
+            } else if(colorRange.getLowValue() == colorRange.getMaximum()) {
+                colorRange.setLowValue(colorRange.getMaximum() - 20);
+            }
+
+        if (!((JSlider) e.getSource()).getValueIsAdjusting()) {
+            listenerList.forEach(l -> l.stateChanged(e));
+        }
+    }
+
+    public TraceSettings getSettings() {
+        TraceSettings settings =  new TraceSettings();
+        settings.setLineThreshold(Integer.valueOf(lineThreshold.getValue()).floatValue() / 10f);
+        settings.setQuadThreshold(Integer.valueOf(curveThreshold.getValue()).floatValue() / 10f);
+        settings.setPathOmit(pathOmit.getValue());
+        settings.setNumberOfColors(colors.getValue());
+        settings.setColorQuantize(colorsQuantization.getValue());
+        settings.setBlurRadius(blurRadius.getValue());
+        settings.setBlurDelta(blurDelta.getValue());
+        settings.setStartColor(colorRange.getLowValue());
+        settings.setEndColor(colorRange.getHighValue());
+        return settings;
+    }
+
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        lineThreshold.setEnabled(enabled);
+        curveThreshold.setEnabled(enabled);
+        pathOmit.setEnabled(enabled);
+        colors.setEnabled(enabled);
+        colorsQuantization.setEnabled(enabled);
+        blurRadius.setEnabled(enabled);
+        blurDelta.setEnabled(enabled);
+        colorRange.setEnabled(enabled);
+    }
+
+    public void addListener(ChangeListener listener) {
+        listenerList.add(listener);
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/TraceUtils.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/imagetracer/TraceUtils.java
@@ -1,0 +1,88 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.gui.imagetracer;
+
+import jankovicsandras.imagetracer.ImageTracer;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.HashMap;
+
+/**
+ * @author Joacim Breiler
+ */
+public class TraceUtils {
+
+    public static String traceImage(File selectedFile, TraceSettings settingsPanel) {
+        // Options
+        HashMap<String, Float> options = new HashMap<>();
+
+        // Tracing
+        options.put("ltres", settingsPanel.getLineThreshold());
+        options.put("qtres", settingsPanel.getQuadThreshold());
+        options.put("pathomit", Integer.valueOf(settingsPanel.getPathOmit()).floatValue());
+
+        // Color quantization
+        options.put("colorsampling", 0f); // 1f means true ; 0f means false: starting with generated palette
+        int numberOfColors = settingsPanel.getNumberOfColors();
+        options.put("numberofcolors", Integer.valueOf(numberOfColors).floatValue());
+        options.put("mincolorratio", 0f);
+        options.put("colorquantcycles", Integer.valueOf(settingsPanel.getColorQuantize()).floatValue());
+
+        // SVG rendering
+        options.put("scale", 1f);
+        options.put("roundcoords", 0f); // 1f means rounded to 1 decimal places, like 7.3 ; 3f means rounded to 3 places, like 7.356 ; etc.
+        options.put("lcpr", 0f);
+        options.put("qcpr", 0f);
+        options.put("desc", 1f); // 1f means true ; 0f means false: SVG descriptions deactivated
+        options.put("viewbox", 0f); // 1f means true ; 0f means false: fixed width and height
+
+        // Selective Gauss Blur
+        options.put("blurradius", Integer.valueOf(settingsPanel.getBlurRadius()).floatValue()); // 0f means deactivated; 1f .. 5f : blur with this radius
+        options.put("blurdelta", Integer.valueOf(settingsPanel.getBlurDelta()).floatValue()); // smaller than this RGB difference will be blurred
+
+
+        try {
+            BufferedImage img = ImageIO.read(selectedFile);
+            BufferedImage gray = new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_BYTE_GRAY);
+            Graphics2D g = gray.createGraphics();
+            g.drawImage(img, 0, 0, null);
+
+            byte[][] palette = generatePalette(numberOfColors, settingsPanel.getStartColor(), settingsPanel.getEndColor());
+            return ImageTracer.imageToSVG(gray, options, palette);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not trace image", e);
+        }
+    }
+
+    private static byte[][] generatePalette(int numberOfColors, int startColorValue, int endColorValue) {
+        int step = (startColorValue - endColorValue) / numberOfColors;
+        byte[][] palette = new byte[numberOfColors][4];
+        for (int colorcnt = 0; colorcnt < numberOfColors; colorcnt++) {
+            int value = endColorValue + (colorcnt * step);
+            palette[colorcnt][0] = (byte) (-128 + value); // R
+            palette[colorcnt][1] = (byte) (-128 + value); // G
+            palette[colorcnt][2] = (byte) (-128 + value); // B
+            palette[colorcnt][3] = (byte) 127;              // A
+        }
+        return palette;
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/svg/SvgReader.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/svg/SvgReader.java
@@ -177,6 +177,10 @@ public class SvgReader implements GVTTreeBuilderListener, DesignReader {
                     if (id != null) {
                         createdShape.setName(createdShape.getName() + " (" + id.getFirstChild().getNodeValue() + ")");
                     }
+                    Node desc = node.getAttributes().getNamedItem("desc");
+                    if (desc != null) {
+                        createdShape.setDescription(desc.getFirstChild().getNodeValue());
+                    }
                     createdShape.setTransform(groupTransform);
                     group.addChild(createdShape);
                 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
@@ -35,19 +35,22 @@ import javax.swing.*;
 @TopComponent.Registration(mode = "bottom_left", openAtStartup = false)
 public class EntitiesTreeTopComponent extends TopComponent {
     private static final long serialVersionUID = 432423498723987873L;
+    private final EntitiesTree entitesTree;
 
     public EntitiesTreeTopComponent() {
         setMinimumSize(new java.awt.Dimension(50, 50));
         setPreferredSize(new java.awt.Dimension(200, 200));
         setLayout(new java.awt.BorderLayout());
         setDisplayName("Design objects");
+
+        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        entitesTree = new EntitiesTree(controller);
     }
 
     @Override
     protected void componentOpened() {
         super.componentOpened();
         removeAll();
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
-        add(new JScrollPane(new EntitiesTree(controller)));
+        add(new JScrollPane(entitesTree));
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
@@ -1,13 +1,31 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.ugs.nbp.designer.platform;
 
 import com.willwinder.ugs.nbp.designer.gui.SelectionSettingsPanel;
-import com.willwinder.ugs.nbp.designer.gui.tree.EntitiesTree;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.windows.TopComponent;
 
-import javax.swing.*;
-
+/**
+ * @author Joacim Breiler
+ */
 @TopComponent.Description(
         preferredID = "SettingsTopComponent",
         persistenceType = TopComponent.PERSISTENCE_NEVER
@@ -15,19 +33,22 @@ import javax.swing.*;
 @TopComponent.Registration(mode = "top_left", openAtStartup = false)
 public class SettingsTopComponent extends TopComponent {
     private static final long serialVersionUID = 324234398723987873L;
+    private SelectionSettingsPanel selectionSettingsPanel;
 
     public SettingsTopComponent() {
         setMinimumSize(new java.awt.Dimension(50, 50));
         setPreferredSize(new java.awt.Dimension(200, 200));
         setLayout(new java.awt.BorderLayout());
         setDisplayName("Cut settings");
+
+        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        selectionSettingsPanel = new SelectionSettingsPanel(controller);
     }
 
     @Override
     protected void componentOpened() {
         super.componentOpened();
         removeAll();
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
-        add(new SelectionSettingsPanel(controller));
+        add(selectionSettingsPanel);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsSaveCookie.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsSaveCookie.java
@@ -1,3 +1,21 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.ugs.nbp.designer.platform;
 
 import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignWriter;
@@ -6,16 +24,16 @@ import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.openide.cookies.SaveCookie;
-import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileStateInvalidException;
-import org.openide.loaders.SaveAsCapable;
 import org.openide.util.ImageUtilities;
 
 import javax.swing.*;
 import java.awt.*;
 import java.io.File;
-import java.io.IOException;
 
+/**
+ * @author Joacim Breiler
+ */
 public class UgsSaveCookie implements Icon, SaveCookie {
     private final UgsDataObject dataObject;
     private final Icon icon = ImageUtilities.loadImageIcon("img/new.svg", false);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/jankovicsandras/imagetracer/ImageTracer.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/jankovicsandras/imagetracer/ImageTracer.java
@@ -1,0 +1,992 @@
+/*
+	ImageTracer.java
+	(Desktop version with javax.imageio. See ImageTracerAndroid.java for the Android version.)
+	Simple raster image tracer and vectorizer written in Java. This is a port of imagetracer.js.
+	by András Jankovics 2015, 2016
+	andras@jankovics.net
+
+ */
+
+/*
+
+The Unlicense / PUBLIC DOMAIN
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to http://unlicense.org/
+
+ */
+package jankovicsandras.imagetracer;
+
+import java.awt.image.BufferedImage;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import javax.imageio.ImageIO;
+
+public class ImageTracer{
+
+	public static String versionnumber = "1.1.2";
+
+	public ImageTracer(){}
+
+	public static void main (String[] args){
+		try{
+
+			if(args.length<1){
+				System.out.println("ERROR: there's no input filename. Basic usage: \r\n\r\njava -jar ImageTracer.jar <filename>"+
+						"\r\n\r\nor\r\n\r\njava -jar ImageTracer.jar help");
+			} else if(arraycontains(args,"help")>-1){
+				System.out.println("Example usage:\r\n\r\njava -jar ImageTracer.jar <filename> outfilename test.svg "+
+						"ltres 1 qtres 1 pathomit 8 colorsampling 1 numberofcolors 16 mincolorratio 0.02 colorquantcycles 3 "+
+						"scale 1 simplifytolerance 0 roundcoords 1 lcpr 0 qcpr 0 desc 1 viewbox 0 blurradius 0 blurdelta 20 \r\n"+
+						"\r\nOnly <filename> is mandatory, if some of the other optional parameters are missing, they will be set to these defaults. "+
+						"\r\nWarning: if outfilename is not specified, then <filename>.svg will be overwritten."+
+						"\r\nSee https://github.com/jankovicsandras/imagetracerjava for details. \r\nThis is version "+versionnumber);
+			} else {
+
+				// Parameter parsing
+				String outfilename = args[0]+".svg";
+				HashMap<String,Float> options = new HashMap<String,Float>();
+				String[] parameternames = {"ltres","qtres","pathomit","colorsampling","numberofcolors","mincolorratio","colorquantcycles","scale","simplifytolerance","roundcoords","lcpr","qcpr","desc","viewbox","blurradius","blurdelta","outfilename"};
+				int j = -1; float f = -1;
+				for (String parametername : parameternames) {
+					j = arraycontains(args,parametername);
+					if(j>-1){
+						if(parametername=="outfilename"){
+							if( j < (args.length-1)){ outfilename = args[j+1]; }
+						}else{
+							f = parsenext(args,j); if(f>-1){ options.put(parametername, new Float(f)); }
+						}
+					}
+				}// End of parameternames loop
+
+				// Loading image, tracing, rendering SVG, saving SVG file
+				saveString(outfilename,imageToSVG(args[0],options,null));
+
+			}// End of parameter parsing and processing
+
+		}catch(Exception e){ e.printStackTrace(); }
+	}// End of main()
+
+
+	public static int arraycontains (String [] arr, String str){
+		for(int j=0; j<arr.length; j++ ){ if(arr[j].toLowerCase().equals(str)){ return j; } } return -1;
+	}
+
+
+	public static float parsenext (String [] arr, int i){
+		if(i<(arr.length-1)){ try{ return Float.parseFloat(arr[i+1]); }catch(Exception e){} } return -1;
+	}
+
+
+	// Container for the color-indexed image before and tracedata after vectorizing
+	public static class IndexedImage{
+		public int width, height;
+		public int [][] array; // array[x][y] of palette colors
+		public byte [][] palette;// array[palettelength][4] RGBA color palette
+		public ArrayList<ArrayList<ArrayList<Double[]>>> layers;// tracedata
+
+		public IndexedImage(int [][] marray, byte [][] mpalette){
+			array = marray; palette = mpalette;
+			width = marray[0].length-2; height = marray.length-2;// Color quantization adds +2 to the original width and height
+		}
+	}
+
+
+	// https://developer.mozilla.org/en-US/docs/Web/API/ImageData
+	public static class ImageData{
+		public int width, height;
+		public byte[] data; // raw byte data: R G B A R G B A ...
+		public ImageData(int mwidth, int mheight, byte[] mdata){
+			width = mwidth; height = mheight; data = mdata;
+		}
+	}
+
+
+	// Saving a String as a file
+	public static void saveString (String filename, String str) throws Exception {
+		File file = new File(filename);
+		// if file doesnt exists, then create it
+		if(!file.exists()){ file.createNewFile(); }
+		FileWriter fw = new FileWriter(file.getAbsoluteFile());
+		BufferedWriter bw = new BufferedWriter(fw);
+		bw.write(str);
+		bw.close();
+	}
+
+
+	// Loading a file to ImageData, ARGB byte order
+	public static ImageData loadImageData (String filename) throws Exception {
+		BufferedImage image = ImageIO.read(new File(filename));
+		return loadImageData(image);
+	}
+	public static ImageData loadImageData (BufferedImage image) throws Exception {
+		int width = image.getWidth(); int height = image.getHeight();
+		int[] rawdata = image.getRGB(0, 0, width, height, null, 0, width);
+		byte[] data = new byte[rawdata.length*4];
+		for(int i=0; i<rawdata.length; i++){
+			data[(i*4)+3] = bytetrans((byte)(rawdata[i] >>> 24));
+			data[i*4  ] = bytetrans((byte)(rawdata[i] >>> 16));
+			data[(i*4)+1] = bytetrans((byte)(rawdata[i] >>> 8));
+			data[(i*4)+2] = bytetrans((byte)(rawdata[i]));
+		}
+		return new ImageData(width,height,data);
+	}
+
+
+	// The bitshift method in loadImageData creates signed bytes where -1 -> 255 unsigned ; -128 -> 128 unsigned ;
+	// 127 -> 127 unsigned ; 0 -> 0 unsigned ; These will be converted to -128 (representing 0 unsigned) ...
+	// 127 (representing 255 unsigned) and tosvgcolorstr will add +128 to create RGB values 0..255
+	public static byte bytetrans (byte b){
+		if(b<0){ return (byte)(b+128); }else{ return (byte)(b-128); }
+	}
+
+
+	////////////////////////////////////////////////////////////
+	//
+	//  User friendly functions
+	//
+	////////////////////////////////////////////////////////////
+
+	// Loading an image from a file, tracing when loaded, then returning the SVG String
+	public static String imageToSVG (String filename, HashMap<String,Float> options, byte [][] palette) throws Exception{
+		options = checkoptions(options);
+		ImageData imgd = loadImageData(filename);
+		return imagedataToSVG(imgd,options,palette);
+	}// End of imageToSVG()
+	public static String imageToSVG (BufferedImage image, HashMap<String,Float> options, byte [][] palette) throws Exception{
+		options = checkoptions(options);
+		ImageData imgd = loadImageData(image);
+		return imagedataToSVG(imgd,options,palette);
+	}// End of imageToSVG()
+
+
+	// Tracing ImageData, then returning the SVG String
+	public static String imagedataToSVG (ImageData imgd, HashMap<String,Float> options, byte [][] palette){
+		options = checkoptions(options);
+		IndexedImage ii = imagedataToTracedata(imgd,options,palette);
+		return getsvgstring(ii, options);
+	}// End of imagedataToSVG()
+
+
+	// Loading an image from a file, tracing when loaded, then returning IndexedImage with tracedata in layers
+	public IndexedImage imageToTracedata (String filename, HashMap<String,Float> options, byte [][] palette) throws Exception{
+		options = checkoptions(options);
+		ImageData imgd = loadImageData(filename);
+		return imagedataToTracedata(imgd,options,palette);
+	}// End of imageToTracedata()
+	public IndexedImage imageToTracedata (BufferedImage image, HashMap<String,Float> options, byte [][] palette) throws Exception{
+		options = checkoptions(options);
+		ImageData imgd = loadImageData(image);
+		return imagedataToTracedata(imgd,options,palette);
+	}// End of imageToTracedata()
+
+
+	// Tracing ImageData, then returning IndexedImage with tracedata in layers
+	public static IndexedImage imagedataToTracedata (ImageData imgd, HashMap<String,Float> options, byte [][] palette){
+		// 1. Color quantization
+		IndexedImage ii = colorquantization(imgd, palette, options);
+		// 2. Layer separation and edge detection
+		int[][][] rawlayers = layering(ii);
+		// 3. Batch pathscan
+		ArrayList<ArrayList<ArrayList<Integer[]>>> bps = batchpathscan(rawlayers,(int)(Math.floor(options.get("pathomit"))));
+		// 4. Batch interpollation
+		ArrayList<ArrayList<ArrayList<Double[]>>> bis = batchinternodes(bps);
+		// 5. Batch tracing
+		ii.layers = batchtracelayers(bis,options.get("ltres"),options.get("qtres"));
+		return ii;
+	}// End of imagedataToTracedata()
+
+
+	// creating options object, setting defaults for missing values
+	public static HashMap<String,Float> checkoptions (HashMap<String,Float> options){
+		if(options==null){ options = new HashMap<String,Float>(); }
+		// Tracing
+		if(!options.containsKey("ltres")){ options.put("ltres",1f); }
+		if(!options.containsKey("qtres")){ options.put("qtres",1f); }
+		if(!options.containsKey("pathomit")){ options.put("pathomit",8f); }
+		// Color quantization
+		if(!options.containsKey("colorsampling")){ options.put("colorsampling",1f); }
+		if(!options.containsKey("numberofcolors")){ options.put("numberofcolors",16f); }
+		if(!options.containsKey("mincolorratio")){ options.put("mincolorratio",0.02f); }
+		if(!options.containsKey("colorquantcycles")){ options.put("colorquantcycles",3f); }
+		// SVG rendering
+		if(!options.containsKey("scale")){ options.put("scale",1f); }
+		if(!options.containsKey("simplifytolerance")){ options.put("simplifytolerance",0f); }
+		if(!options.containsKey("roundcoords")){ options.put("roundcoords",1f); }
+		if(!options.containsKey("lcpr")){ options.put("lcpr",0f); }
+		if(!options.containsKey("qcpr")){ options.put("qcpr",0f); }
+		if(!options.containsKey("desc")){ options.put("desc",1f); }
+		if(!options.containsKey("viewbox")){ options.put("viewbox",0f); }
+		// Blur
+		if(!options.containsKey("blurradius")){ options.put("blurradius",0f); }
+		if(!options.containsKey("blurdelta")){ options.put("blurdelta",20f); }
+
+		return options;
+	}// End of checkoptions()
+
+
+	////////////////////////////////////////////////////////////
+	//
+	//  Vectorizing functions
+	//
+	////////////////////////////////////////////////////////////
+
+	// 1. Color quantization repeated "cycles" times, based on K-means clustering
+	// https://en.wikipedia.org/wiki/Color_quantization    https://en.wikipedia.org/wiki/K-means_clustering
+	public static IndexedImage colorquantization (ImageData imgd, byte [][] palette, HashMap<String,Float> options){
+		int numberofcolors = (int)Math.floor(options.get("numberofcolors")); float minratio = options.get("mincolorratio"); int cycles = (int)Math.floor(options.get("colorquantcycles"));
+		// Creating indexed color array arr which has a boundary filled with -1 in every direction
+		int [][] arr = new int[imgd.height+2][imgd.width+2];
+		for(int j=0; j<(imgd.height+2); j++){ arr[j][0] = -1; arr[j][imgd.width+1 ] = -1; }
+		for(int i=0; i<(imgd.width+2) ; i++){ arr[0][i] = -1; arr[imgd.height+1][i] = -1; }
+
+		int idx=0, cd,cdl,ci,c1,c2,c3,c4;
+
+		// Use custom palette if pal is defined or sample or generate custom length palette
+		if(palette==null){
+			if(options.get("colorsampling")!=0){
+				palette = samplepalette(numberofcolors,imgd);
+			}else{
+				palette = generatepalette(numberofcolors);
+			}
+		}
+
+		// Selective Gaussian blur preprocessing
+		if( options.get("blurradius") > 0 ){ imgd = blur( imgd, options.get("blurradius"), options.get("blurdelta") ); }
+
+		long [][] paletteacc = new long[palette.length][5];
+
+		// Repeat clustering step "cycles" times
+		for(int cnt=0;cnt<cycles;cnt++){
+
+			// Average colors from the second iteration
+			if(cnt>0){
+				// averaging paletteacc for palette
+				float ratio;
+				for(int k=0;k<palette.length;k++){
+					// averaging
+					if(paletteacc[k][3]>0){
+						palette[k][0] = (byte) (-128 + (paletteacc[k][0] / paletteacc[k][4]));
+						palette[k][1] = (byte) (-128 + (paletteacc[k][1] / paletteacc[k][4]));
+						palette[k][2] = (byte) (-128 + (paletteacc[k][2] / paletteacc[k][4]));
+						palette[k][3] = (byte) (-128 + (paletteacc[k][3] / paletteacc[k][4]));
+					}
+					ratio = (float)( (double)(paletteacc[k][4]) / (double)(imgd.width*imgd.height) );
+
+					// Randomizing a color, if there are too few pixels and there will be a new cycle
+					if( (ratio<minratio) && (cnt<(cycles-1)) ){
+						palette[k][0] = (byte) (-128+Math.floor(Math.random()*255));
+						palette[k][1] = (byte) (-128+Math.floor(Math.random()*255));
+						palette[k][2] = (byte) (-128+Math.floor(Math.random()*255));
+						palette[k][3] = (byte) (-128+Math.floor(Math.random()*255));
+					}
+
+				}// End of palette loop
+			}// End of Average colors from the second iteration
+
+			// Reseting palette accumulator for averaging
+			for(int i=0;i<palette.length;i++){
+				paletteacc[i][0]=0;
+				paletteacc[i][1]=0;
+				paletteacc[i][2]=0;
+				paletteacc[i][3]=0;
+				paletteacc[i][4]=0;
+			}
+
+			// loop through all pixels
+			for(int j=0;j<imgd.height;j++){
+				for(int i=0;i<imgd.width;i++){
+
+					idx = ((j*imgd.width)+i)*4;
+
+					// find closest color from palette by measuring (rectilinear) color distance between this pixel and all palette colors
+					cdl = 256+256+256+256; ci=0;
+					for(int k=0;k<palette.length;k++){
+
+						// In my experience, https://en.wikipedia.org/wiki/Rectilinear_distance works better than https://en.wikipedia.org/wiki/Euclidean_distance
+						c1 = Math.abs(palette[k][0]-imgd.data[idx]);
+						c2 = Math.abs(palette[k][1]-imgd.data[idx+1]);
+						c3 = Math.abs(palette[k][2]-imgd.data[idx+2]);
+						c4 = Math.abs(palette[k][3]-imgd.data[idx+3]);
+						cd = c1+c2+c3+(c4*4); // weighted alpha seems to help images with transparency
+
+						// Remember this color if this is the closest yet
+						if(cd<cdl){ cdl = cd; ci = k; }
+
+					}// End of palette loop
+
+					// add to palettacc
+					paletteacc[ci][0] += 128+imgd.data[idx];
+					paletteacc[ci][1] += 128+imgd.data[idx+1];
+					paletteacc[ci][2] += 128+imgd.data[idx+2];
+					paletteacc[ci][3] += 128+imgd.data[idx+3];
+					paletteacc[ci][4]++;
+
+					arr[j+1][i+1] = ci;
+				}// End of i loop
+			}// End of j loop
+
+		}// End of Repeat clustering step "cycles" times
+
+		return new IndexedImage(arr, palette);
+	}// End of colorquantization
+
+
+	// Generating a palette with numberofcolors, array[numberofcolors][4] where [i][0] = R ; [i][1] = G ; [i][2] = B ; [i][3] = A
+	public static byte[][] generatepalette (int numberofcolors){
+		byte [][] palette = new byte[numberofcolors][4];
+		if(numberofcolors<8){
+
+			// Grayscale
+			double graystep = 255.0/(double)(numberofcolors-1);
+			for(byte ccnt=0;ccnt<numberofcolors;ccnt++){
+				palette[ccnt][0] = (byte)(-128+Math.round(ccnt*graystep));
+				palette[ccnt][1] = (byte)(-128+Math.round(ccnt*graystep));
+				palette[ccnt][2] = (byte)(-128+Math.round(ccnt*graystep));
+				palette[ccnt][3] = (byte)127;
+			}
+
+		}else{
+
+			// RGB color cube
+			int colorqnum = (int) Math.floor(Math.pow(numberofcolors, 1.0/3.0)); // Number of points on each edge on the RGB color cube
+			int colorstep = (int) Math.floor(255/(colorqnum-1)); // distance between points
+			int ccnt = 0;
+			for(int rcnt=0;rcnt<colorqnum;rcnt++){
+				for(int gcnt=0;gcnt<colorqnum;gcnt++){
+					for(int bcnt=0;bcnt<colorqnum;bcnt++){
+						palette[ccnt][0] = (byte)(-128+(rcnt*colorstep));
+						palette[ccnt][1] = (byte)(-128+(gcnt*colorstep));
+						palette[ccnt][2] = (byte)(-128+(bcnt*colorstep));
+						palette[ccnt][3] = (byte)127;
+						ccnt++;
+					}// End of blue loop
+				}// End of green loop
+			}// End of red loop
+
+			// Rest is random
+			for(int rcnt=ccnt;rcnt<numberofcolors;rcnt++){
+				palette[ccnt][0] = (byte)(-128+Math.floor(Math.random()*255));
+				palette[ccnt][1] = (byte)(-128+Math.floor(Math.random()*255));
+				palette[ccnt][2] = (byte)(-128+Math.floor(Math.random()*255));
+				palette[ccnt][3] = (byte)(-128+Math.floor(Math.random()*255));
+			}
+
+		}// End of numberofcolors check
+
+		return palette;
+	};// End of generatepalette()
+
+
+	public static byte[][] samplepalette (int numberofcolors, ImageData imgd){
+		int idx=0; byte [][] palette = new byte[numberofcolors][4];
+		for(int i=0; i<numberofcolors; i++){
+			idx = (int) (Math.floor( (Math.random() * imgd.data.length) / 4 ) * 4);
+			palette[i][0] = imgd.data[idx  ];
+			palette[i][1] = imgd.data[idx+1];
+			palette[i][2] = imgd.data[idx+2];
+			palette[i][3] = imgd.data[idx+3];
+		}
+		return palette;
+	}// End of samplepalette()
+
+
+	// 2. Layer separation and edge detection
+	// Edge node types ( ▓:light or 1; ░:dark or 0 )
+	// 12  ░░  ▓░  ░▓  ▓▓  ░░  ▓░  ░▓  ▓▓  ░░  ▓░  ░▓  ▓▓  ░░  ▓░  ░▓  ▓▓
+	// 48  ░░  ░░  ░░  ░░  ░▓  ░▓  ░▓  ░▓  ▓░  ▓░  ▓░  ▓░  ▓▓  ▓▓  ▓▓  ▓▓
+	//     0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15
+	//
+	public static int[][][] layering (IndexedImage ii){
+		// Creating layers for each indexed color in arr
+		int val=0, aw = ii.array[0].length, ah = ii.array.length, n1,n2,n3,n4,n5,n6,n7,n8;
+		int[][][] layers = new int[ii.palette.length][ah][aw];
+
+		// Looping through all pixels and calculating edge node type
+		for(int j=1; j<(ah-1); j++){
+			for(int i=1; i<(aw-1); i++){
+
+				// This pixel's indexed color
+				val = ii.array[j][i];
+
+				// Are neighbor pixel colors the same?
+				n1 = ii.array[j-1][i-1]==val ? 1 : 0;
+				n2 = ii.array[j-1][i  ]==val ? 1 : 0;
+				n3 = ii.array[j-1][i+1]==val ? 1 : 0;
+				n4 = ii.array[j  ][i-1]==val ? 1 : 0;
+				n5 = ii.array[j  ][i+1]==val ? 1 : 0;
+				n6 = ii.array[j+1][i-1]==val ? 1 : 0;
+				n7 = ii.array[j+1][i  ]==val ? 1 : 0;
+				n8 = ii.array[j+1][i+1]==val ? 1 : 0;
+
+				// this pixel"s type and looking back on previous pixels
+				layers[val][j+1][i+1] = 1 + (n5 * 2) + (n8 * 4) + (n7 * 8) ;
+				if(n4==0){ layers[val][j+1][i  ] = 0 + 2 + (n7 * 4) + (n6 * 8) ; }
+				if(n2==0){ layers[val][j  ][i+1] = 0 + (n3*2) + (n5 * 4) + 8 ; }
+				if(n1==0){ layers[val][j  ][i  ] = 0 + (n2*2) + 4 + (n4 * 8) ; }
+
+			}// End of i loop
+		}// End of j loop
+
+		return layers;
+	}// End of layering()
+
+
+	// Lookup tables for pathscan
+	static byte [] pathscan_dir_lookup = {0,0,3,0, 1,0,3,0, 0,3,3,1, 0,3,0,0};
+	static boolean [] pathscan_holepath_lookup = {false,false,false,false, false,false,false,true, false,false,false,true, false,true,true,false };
+	// pathscan_combined_lookup[ arr[py][px] ][ dir ] = [nextarrpypx, nextdir, deltapx, deltapy];
+	static byte [][][] pathscan_combined_lookup = {
+			{{-1,-1,-1,-1}, {-1,-1,-1,-1}, {-1,-1,-1,-1}, {-1,-1,-1,-1}},// arr[py][px]==0 is invalid
+			{{ 0, 1, 0,-1}, {-1,-1,-1,-1}, {-1,-1,-1,-1}, { 0, 2,-1, 0}},
+			{{-1,-1,-1,-1}, {-1,-1,-1,-1}, { 0, 1, 0,-1}, { 0, 0, 1, 0}},
+			{{ 0, 0, 1, 0}, {-1,-1,-1,-1}, { 0, 2,-1, 0}, {-1,-1,-1,-1}},
+
+			{{-1,-1,-1,-1}, { 0, 0, 1, 0}, { 0, 3, 0, 1}, {-1,-1,-1,-1}},
+			{{13, 3, 0, 1}, {13, 2,-1, 0}, { 7, 1, 0,-1}, { 7, 0, 1, 0}},
+			{{-1,-1,-1,-1}, { 0, 1, 0,-1}, {-1,-1,-1,-1}, { 0, 3, 0, 1}},
+			{{ 0, 3, 0, 1}, { 0, 2,-1, 0}, {-1,-1,-1,-1}, {-1,-1,-1,-1}},
+
+			{{ 0, 3, 0, 1}, { 0, 2,-1, 0}, {-1,-1,-1,-1}, {-1,-1,-1,-1}},
+			{{-1,-1,-1,-1}, { 0, 1, 0,-1}, {-1,-1,-1,-1}, { 0, 3, 0, 1}},
+			{{11, 1, 0,-1}, {14, 0, 1, 0}, {14, 3, 0, 1}, {11, 2,-1, 0}},
+			{{-1,-1,-1,-1}, { 0, 0, 1, 0}, { 0, 3, 0, 1}, {-1,-1,-1,-1}},
+
+			{{ 0, 0, 1, 0}, {-1,-1,-1,-1}, { 0, 2,-1, 0}, {-1,-1,-1,-1}},
+			{{-1,-1,-1,-1}, {-1,-1,-1,-1}, { 0, 1, 0,-1}, { 0, 0, 1, 0}},
+			{{ 0, 1, 0,-1}, {-1,-1,-1,-1}, {-1,-1,-1,-1}, { 0, 2,-1, 0}},
+			{{-1,-1,-1,-1}, {-1,-1,-1,-1}, {-1,-1,-1,-1}, {-1,-1,-1,-1}}// arr[py][px]==15 is invalid
+	};
+
+
+	// 3. Walking through an edge node array, discarding edge node types 0 and 15 and creating paths from the rest.
+	// Walk directions (dir): 0 > ; 1 ^ ; 2 < ; 3 v
+	// Edge node types ( ▓:light or 1; ░:dark or 0 )
+	// ░░  ▓░  ░▓  ▓▓  ░░  ▓░  ░▓  ▓▓  ░░  ▓░  ░▓  ▓▓  ░░  ▓░  ░▓  ▓▓
+	// ░░  ░░  ░░  ░░  ░▓  ░▓  ░▓  ░▓  ▓░  ▓░  ▓░  ▓░  ▓▓  ▓▓  ▓▓  ▓▓
+	// 0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15
+	//
+	public static ArrayList<ArrayList<Integer[]>> pathscan (int [][] arr,float pathomit){
+		ArrayList<ArrayList<Integer[]>> paths = new ArrayList<ArrayList<Integer[]>>();
+		ArrayList<Integer[]> thispath;
+		int px=0,py=0,w=arr[0].length,h=arr.length,dir=0;
+		boolean pathfinished=true, holepath = false;
+		byte[] lookuprow;
+
+		for(int j=0;j<h;j++){
+			for(int i=0;i<w;i++){
+				if((arr[j][i]!=0)&&(arr[j][i]!=15)){
+
+					// Init
+					px = i; py = j;
+					paths.add(new ArrayList<Integer[]>());
+					thispath = paths.get(paths.size()-1);
+					pathfinished = false;
+
+					// fill paths will be drawn, but hole paths are also required to remove unnecessary edge nodes
+					dir = pathscan_dir_lookup[ arr[py][px] ]; holepath = pathscan_holepath_lookup[ arr[py][px] ];
+
+					// Path points loop
+					while(!pathfinished){
+
+						// New path point
+						thispath.add(new Integer[3]);
+						thispath.get(thispath.size()-1)[0] = px-1;
+						thispath.get(thispath.size()-1)[1] = py-1;
+						thispath.get(thispath.size()-1)[2] = arr[py][px];
+
+						// Next: look up the replacement, direction and coordinate changes = clear this cell, turn if required, walk forward
+						lookuprow = pathscan_combined_lookup[ arr[py][px] ][ dir ];
+						arr[py][px] = lookuprow[0]; dir = lookuprow[1]; px += lookuprow[2]; py += lookuprow[3];
+
+						// Close path
+						if(((px-1)==thispath.get(0)[0])&&((py-1)==thispath.get(0)[1])){
+							pathfinished = true;
+							// Discarding 'hole' type paths and paths shorter than pathomit
+							if( (holepath) || (thispath.size()<pathomit) ){
+								paths.remove(thispath);
+							}
+						}
+
+					}// End of Path points loop
+
+				}// End of Follow path
+
+			}// End of i loop
+		}// End of j loop
+
+		return paths;
+	}// End of pathscan()
+
+
+	// 3. Batch pathscan
+	public static ArrayList<ArrayList<ArrayList<Integer[]>>> batchpathscan (int [][][] layers, float pathomit){
+		ArrayList<ArrayList<ArrayList<Integer[]>>> bpaths = new ArrayList<ArrayList<ArrayList<Integer[]>>>();
+		for (int[][] layer : layers) {
+			bpaths.add(pathscan(layer,pathomit));
+		}
+		return bpaths;
+	}
+
+
+	// 4. interpolating between path points for nodes with 8 directions ( East, SouthEast, S, SW, W, NW, N, NE )
+	public static ArrayList<ArrayList<Double[]>> internodes (ArrayList<ArrayList<Integer[]>> paths){
+		ArrayList<ArrayList<Double[]>> ins = new ArrayList<ArrayList<Double[]>>();
+		ArrayList<Double[]> thisinp;
+		Double[] thispoint, nextpoint = new Double[2];
+		Integer[] pp1, pp2, pp3;
+		int palen=0,nextidx=0,nextidx2=0;
+
+		// paths loop
+		for(int pacnt=0; pacnt<paths.size(); pacnt++){
+			ins.add(new ArrayList<Double[]>());
+			thisinp = ins.get(ins.size()-1);
+			palen = paths.get(pacnt).size();
+			// pathpoints loop
+			for(int pcnt=0;pcnt<palen;pcnt++){
+
+				// interpolate between two path points
+				nextidx = (pcnt+1)%palen; nextidx2 = (pcnt+2)%palen;
+				thisinp.add(new Double[3]);
+				thispoint = thisinp.get(thisinp.size()-1);
+				pp1 = paths.get(pacnt).get(pcnt);
+				pp2 = paths.get(pacnt).get(nextidx);
+				pp3 = paths.get(pacnt).get(nextidx2);
+				thispoint[0] = (pp1[0]+pp2[0]) / 2.0;
+				thispoint[1] = (pp1[1]+pp2[1]) / 2.0;
+				nextpoint[0] = (pp2[0]+pp3[0]) / 2.0;
+				nextpoint[1] = (pp2[1]+pp3[1]) / 2.0;
+
+				// line segment direction to the next point
+				if(thispoint[0] < nextpoint[0]){
+					if     (thispoint[1] < nextpoint[1]){ thispoint[2] = 1.0; }// SouthEast
+					else if(thispoint[1] > nextpoint[1]){ thispoint[2] = 7.0; }// NE
+					else                                { thispoint[2] = 0.0; } // E
+				}else if(thispoint[0] > nextpoint[0]){
+					if     (thispoint[1] < nextpoint[1]){ thispoint[2] = 3.0; }// SW
+					else if(thispoint[1] > nextpoint[1]){ thispoint[2] = 5.0; }// NW
+					else                                { thispoint[2] = 4.0; }// W
+				}else{
+					if     (thispoint[1] < nextpoint[1]){ thispoint[2] = 2.0; }// S
+					else if(thispoint[1] > nextpoint[1]){ thispoint[2] = 6.0; }// N
+					else                                { thispoint[2] = 8.0; }// center, this should not happen
+				}
+
+			}// End of pathpoints loop
+		}// End of paths loop
+		return ins;
+	}// End of internodes()
+
+
+	// 4. Batch interpollation
+	static ArrayList<ArrayList<ArrayList<Double[]>>> batchinternodes (ArrayList<ArrayList<ArrayList<Integer[]>>> bpaths){
+		ArrayList<ArrayList<ArrayList<Double[]>>> binternodes = new ArrayList<ArrayList<ArrayList<Double[]>>>();
+		for(int k=0; k<bpaths.size(); k++) {
+			binternodes.add(internodes(bpaths.get(k)));
+		}
+		return binternodes;
+	}
+
+
+	// 5. tracepath() : recursively trying to fit straight and quadratic spline segments on the 8 direction internode path
+
+	// 5.1. Find sequences of points with only 2 segment types
+	// 5.2. Fit a straight line on the sequence
+	// 5.3. If the straight line fails (an error>ltreshold), find the point with the biggest error
+	// 5.4. Fit a quadratic spline through errorpoint (project this to get controlpoint), then measure errors on every point in the sequence
+	// 5.5. If the spline fails (an error>qtreshold), find the point with the biggest error, set splitpoint = (fitting point + errorpoint)/2
+	// 5.6. Split sequence and recursively apply 5.2. - 5.7. to startpoint-splitpoint and splitpoint-endpoint sequences
+	// 5.7. TODO? If splitpoint-endpoint is a spline, try to add new points from the next sequence
+
+	// This returns an SVG Path segment as a double[7] where
+	// segment[0] ==1.0 linear  ==2.0 quadratic interpolation
+	// segment[1] , segment[2] : x1 , y1
+	// segment[3] , segment[4] : x2 , y2 ; middle point of Q curve, endpoint of L line
+	// segment[5] , segment[6] : x3 , y3 for Q curve, should be 0.0 , 0.0 for L line
+	//
+	// path type is discarded, no check for path.size < 3 , which should not happen
+
+	public static ArrayList<Double[]> tracepath (ArrayList<Double[]> path, float ltreshold, float qtreshold){
+		int pcnt=0, seqend=0; double segtype1, segtype2;
+		ArrayList<Double[]> smp = new ArrayList<Double[]>();
+		//Double [] thissegment;
+		int pathlength = path.size();
+
+		while(pcnt<pathlength){
+			// 5.1. Find sequences of points with only 2 segment types
+			segtype1 = path.get(pcnt)[2]; segtype2 = -1; seqend=pcnt+1;
+			while(
+					((path.get(seqend)[2]==segtype1) || (path.get(seqend)[2]==segtype2) || (segtype2==-1))
+					&& (seqend<(pathlength-1))){
+				if((path.get(seqend)[2]!=segtype1) && (segtype2==-1)){ segtype2 = path.get(seqend)[2];}
+				seqend++;
+			}
+			if(seqend==(pathlength-1)){ seqend = 0; }
+
+			// 5.2. - 5.6. Split sequence and recursively apply 5.2. - 5.6. to startpoint-splitpoint and splitpoint-endpoint sequences
+			smp.addAll(fitseq(path,ltreshold,qtreshold,pcnt,seqend));
+			// 5.7. TODO? If splitpoint-endpoint is a spline, try to add new points from the next sequence
+
+			// forward pcnt;
+			if(seqend>0){ pcnt = seqend; }else{ pcnt = pathlength; }
+
+		}// End of pcnt loop
+
+		return smp;
+
+	}// End of tracepath()
+
+
+	// 5.2. - 5.6. recursively fitting a straight or quadratic line segment on this sequence of path nodes,
+	// called from tracepath()
+	public static ArrayList<Double[]> fitseq (ArrayList<Double[]> path, float ltreshold, float qtreshold, int seqstart, int seqend){
+		ArrayList<Double[]> segment = new ArrayList<Double[]>();
+		Double [] thissegment;
+		int pathlength = path.size();
+
+		// return if invalid seqend
+		if((seqend>pathlength)||(seqend<0)){return segment;}
+
+		int errorpoint=seqstart;
+		boolean curvepass=true;
+		double px, py, dist2, errorval=0;
+		double tl = (seqend-seqstart); if(tl<0){ tl += pathlength; }
+		double vx = (path.get(seqend)[0]-path.get(seqstart)[0]) / tl,
+				vy = (path.get(seqend)[1]-path.get(seqstart)[1]) / tl;
+
+		// 5.2. Fit a straight line on the sequence
+		int pcnt = (seqstart+1)%pathlength;
+		double pl;
+		while(pcnt != seqend){
+			pl = pcnt-seqstart; if(pl<0){ pl += pathlength; }
+			px = path.get(seqstart)[0] + (vx * pl); py = path.get(seqstart)[1] + (vy * pl);
+			dist2 = ((path.get(pcnt)[0]-px)*(path.get(pcnt)[0]-px)) + ((path.get(pcnt)[1]-py)*(path.get(pcnt)[1]-py));
+			if(dist2>ltreshold){curvepass=false;}
+			if(dist2>errorval){ errorpoint=pcnt; errorval=dist2; }
+			pcnt = (pcnt+1)%pathlength;
+		}
+
+		// return straight line if fits
+		if(curvepass){
+			segment.add(new Double[7]);
+			thissegment = segment.get(segment.size()-1);
+			thissegment[0] = 1.0;
+			thissegment[1] = path.get(seqstart)[0];
+			thissegment[2] = path.get(seqstart)[1];
+			thissegment[3] = path.get(seqend)[0];
+			thissegment[4] = path.get(seqend)[1];
+			thissegment[5] = 0.0;
+			thissegment[6] = 0.0;
+			return segment;
+		}
+
+		// 5.3. If the straight line fails (an error>ltreshold), find the point with the biggest error
+		int fitpoint = errorpoint; curvepass = true; errorval = 0;
+
+		// 5.4. Fit a quadratic spline through this point, measure errors on every point in the sequence
+		// helpers and projecting to get control point
+		double t=(fitpoint-seqstart)/tl, t1=(1.0-t)*(1.0-t), t2=2.0*(1.0-t)*t, t3=t*t;
+		double cpx = (((t1*path.get(seqstart)[0]) + (t3*path.get(seqend)[0])) - path.get(fitpoint)[0])/-t2 ,
+				cpy = (((t1*path.get(seqstart)[1]) + (t3*path.get(seqend)[1])) - path.get(fitpoint)[1])/-t2 ;
+
+		// Check every point
+		pcnt = seqstart+1;
+		while(pcnt != seqend){
+
+			t=(pcnt-seqstart)/tl; t1=(1.0-t)*(1.0-t); t2=2.0*(1.0-t)*t; t3=t*t;
+			px = (t1 * path.get(seqstart)[0]) + (t2 * cpx) + (t3 * path.get(seqend)[0]);
+			py = (t1 * path.get(seqstart)[1]) + (t2 * cpy) + (t3 * path.get(seqend)[1]);
+
+			dist2 = ((path.get(pcnt)[0]-px)*(path.get(pcnt)[0]-px)) + ((path.get(pcnt)[1]-py)*(path.get(pcnt)[1]-py));
+
+			if(dist2>qtreshold){curvepass=false;}
+			if(dist2>errorval){ errorpoint=pcnt; errorval=dist2; }
+			pcnt = (pcnt+1)%pathlength;
+		}
+
+		// return spline if fits
+		if(curvepass){
+			segment.add(new Double[7]);
+			thissegment = segment.get(segment.size()-1);
+			thissegment[0] = 2.0;
+			thissegment[1] = path.get(seqstart)[0];
+			thissegment[2] = path.get(seqstart)[1];
+			thissegment[3] = cpx;
+			thissegment[4] = cpy;
+			thissegment[5] = path.get(seqend)[0];
+			thissegment[6] = path.get(seqend)[1];
+			return segment;
+		}
+
+		// 5.5. If the spline fails (an error>qtreshold), find the point with the biggest error,
+		// set splitpoint = (fitting point + errorpoint)/2
+		int splitpoint = (fitpoint + errorpoint)/2;
+
+		// 5.6. Split sequence and recursively apply 5.2. - 5.6. to startpoint-splitpoint and splitpoint-endpoint sequences
+		segment = fitseq(path,ltreshold,qtreshold,seqstart,splitpoint);
+		segment.addAll(fitseq(path,ltreshold,qtreshold,splitpoint,seqend));
+		return segment;
+
+	}// End of fitseq()
+
+
+	// 5. Batch tracing paths
+	public static ArrayList<ArrayList<Double[]>> batchtracepaths (ArrayList<ArrayList<Double[]>> internodepaths, float ltres,float qtres){
+		ArrayList<ArrayList<Double[]>> btracedpaths = new ArrayList<ArrayList<Double[]>>();
+		for(int k=0; k<internodepaths.size(); k++){
+			btracedpaths.add(tracepath(internodepaths.get(k),ltres,qtres) );
+		}
+		return btracedpaths;
+	}
+
+
+	// 5. Batch tracing layers
+	public static ArrayList<ArrayList<ArrayList<Double[]>>> batchtracelayers (ArrayList<ArrayList<ArrayList<Double[]>>> binternodes, float ltres, float qtres){
+		ArrayList<ArrayList<ArrayList<Double[]>>> btbis = new ArrayList<ArrayList<ArrayList<Double[]>>>();
+		for(int k=0; k<binternodes.size(); k++){
+			btbis.add( batchtracepaths( binternodes.get(k),ltres,qtres) );
+		}
+		return btbis;
+	}
+
+
+	////////////////////////////////////////////////////////////
+	//
+	//  SVG Drawing functions
+	//
+	////////////////////////////////////////////////////////////
+
+	public static float roundtodec (float val, float places){
+		return (float)(Math.round(val*Math.pow(10,places))/Math.pow(10,places));
+	}
+
+
+	// Getting SVG path element string from a traced path
+	public static void svgpathstring (StringBuilder sb, String desc, ArrayList<Double[]> segments, String colorstr, HashMap<String,Float> options){
+		float scale = options.get("scale"), lcpr = options.get("lcpr"), qcpr = options.get("qcpr"), roundcoords = (float) Math.floor(options.get("roundcoords"));
+		// Path
+		sb.append("<path ").append(desc).append(colorstr).append("d=\"" ).append("M ").append(segments.get(0)[1]*scale).append(" ").append(segments.get(0)[2]*scale).append(" ");
+
+		if( roundcoords == -1 ){
+			for(int pcnt=0;pcnt<segments.size();pcnt++){
+				if(segments.get(pcnt)[0]==1.0){
+					sb.append("L ").append(segments.get(pcnt)[3]*scale).append(" ").append(segments.get(pcnt)[4]*scale).append(" ");
+				}else{
+					sb.append("Q ").append(segments.get(pcnt)[3]*scale).append(" ").append(segments.get(pcnt)[4]*scale).append(" ").append(segments.get(pcnt)[5]*scale).append(" ").append(segments.get(pcnt)[6]*scale).append(" ");
+				}
+			}
+		}else{
+			for(int pcnt=0;pcnt<segments.size();pcnt++){
+				if(segments.get(pcnt)[0]==1.0){
+					sb.append("L ").append(roundtodec((float)(segments.get(pcnt)[3]*scale),roundcoords)).append(" ")
+					.append(roundtodec((float)(segments.get(pcnt)[4]*scale),roundcoords)).append(" ");
+				}else{
+					sb.append("Q ").append(roundtodec((float)(segments.get(pcnt)[3]*scale),roundcoords)).append(" ")
+					.append(roundtodec((float)(segments.get(pcnt)[4]*scale),roundcoords)).append(" ")
+					.append(roundtodec((float)(segments.get(pcnt)[5]*scale),roundcoords)).append(" ")
+					.append(roundtodec((float)(segments.get(pcnt)[6]*scale),roundcoords)).append(" ");
+				}
+			}
+		}// End of roundcoords check
+
+		sb.append("Z\" />");
+
+		// Rendering control points
+		for(int pcnt=0;pcnt<segments.size();pcnt++){
+			if((lcpr>0)&&(segments.get(pcnt)[0]==1.0)){
+				sb.append( "<circle cx=\"").append(segments.get(pcnt)[3]*scale).append("\" cy=\"").append(segments.get(pcnt)[4]*scale).append("\" r=\"").append(lcpr).append("\" fill=\"white\" stroke-width=\"").append(lcpr*0.2).append("\" stroke=\"black\" />");
+			}
+			if((qcpr>0)&&(segments.get(pcnt)[0]==2.0)){
+				sb.append( "<circle cx=\"").append(segments.get(pcnt)[3]*scale).append("\" cy=\"").append(segments.get(pcnt)[4]*scale).append("\" r=\"").append(qcpr).append("\" fill=\"cyan\" stroke-width=\"").append(qcpr*0.2).append("\" stroke=\"black\" />");
+				sb.append( "<circle cx=\"").append(segments.get(pcnt)[5]*scale).append("\" cy=\"").append(segments.get(pcnt)[6]*scale).append("\" r=\"").append(qcpr).append("\" fill=\"white\" stroke-width=\"").append(qcpr*0.2).append("\" stroke=\"black\" />");
+				sb.append( "<line x1=\"").append(segments.get(pcnt)[1]*scale).append("\" y1=\"").append(segments.get(pcnt)[2]*scale).append("\" x2=\"").append(segments.get(pcnt)[3]*scale).append("\" y2=\"").append(segments.get(pcnt)[4]*scale).append("\" stroke-width=\"").append(qcpr*0.2).append("\" stroke=\"cyan\" />");
+				sb.append( "<line x1=\"").append(segments.get(pcnt)[3]*scale).append("\" y1=\"").append(segments.get(pcnt)[4]*scale).append("\" x2=\"").append(segments.get(pcnt)[5]*scale).append("\" y2=\"").append(segments.get(pcnt)[6]*scale).append("\" stroke-width=\"").append(qcpr*0.2).append("\" stroke=\"cyan\" />");
+			}// End of quadratic control points
+		}
+
+	}// End of svgpathstring()
+
+
+	// Converting tracedata to an SVG string, paths are drawn according to a Z-index
+	// the optional lcpr and qcpr are linear and quadratic control point radiuses
+	public static String getsvgstring (IndexedImage ii, HashMap<String,Float> options){
+		options = checkoptions(options);
+		// SVG start
+		int w = (int) (ii.width * options.get("scale")), h = (int) (ii.height * options.get("scale"));
+		String viewboxorviewport = options.get("viewbox")!=0 ? "viewBox=\"0 0 "+w+" "+h+"\" " : "width=\""+w+"\" height=\""+h+"\" ";
+		StringBuilder svgstr = new StringBuilder("<svg "+viewboxorviewport+"version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" ");
+		if(options.get("desc")!=0){ svgstr.append("desc=\"Created with ImageTracer.java version "+ImageTracer.versionnumber+"\" "); }
+		svgstr.append(">");
+
+		// creating Z-index
+		TreeMap <Double,Integer[]> zindex = new TreeMap <Double,Integer[]>();
+		double label;
+		// Layer loop
+		for(int k=0; k<ii.layers.size(); k++) {
+
+			// Path loop
+			for(int pcnt=0; pcnt<ii.layers.get(k).size(); pcnt++){
+
+				// Label (Z-index key) is the startpoint of the path, linearized
+				label = (ii.layers.get(k).get(pcnt).get(0)[2] * w) + ii.layers.get(k).get(pcnt).get(0)[1];
+				// Creating new list if required
+				if(!zindex.containsKey(label)){ zindex.put(label,new Integer[2]); }
+				// Adding layer and path number to list
+				zindex.get(label)[0] = new Integer(k);
+				zindex.get(label)[1] = new Integer(pcnt);
+			}// End of path loop
+
+		}// End of layer loop
+
+		// Sorting Z-index is not required, TreeMap is sorted automatically
+
+		// Drawing
+		// Z-index loop
+		String thisdesc = "";
+		for(Entry<Double, Integer[]> entry : zindex.entrySet()) {
+			if(options.get("desc")!=0){ thisdesc = "desc=\"l "+entry.getValue()[0]+" p "+entry.getValue()[1]+"\" "; }else{ thisdesc = ""; }
+			svgpathstring(svgstr,
+					thisdesc,
+					ii.layers.get(entry.getValue()[0]).get(entry.getValue()[1]),
+					tosvgcolorstr(ii.palette[entry.getValue()[0]]),
+					options);
+		}
+
+		// SVG End
+		svgstr.append("</svg>");
+
+		return svgstr.toString();
+
+	}// End of getsvgstring()
+
+
+	static String tosvgcolorstr (byte[] c){
+		return "fill=\"rgb("+(c[0]+128)+","+(c[1]+128)+","+(c[2]+128)+")\" stroke=\"rgb("+(c[0]+128)+","+(c[1]+128)+","+(c[2]+128)+")\" stroke-width=\"1\" opacity=\""+((c[3]+128)/255.0)+"\" ";
+	}
+
+
+	// Gaussian kernels for blur
+	static double[][] gks = { {0.27901,0.44198,0.27901}, {0.135336,0.228569,0.272192,0.228569,0.135336}, {0.086776,0.136394,0.178908,0.195843,0.178908,0.136394,0.086776},
+			{0.063327,0.093095,0.122589,0.144599,0.152781,0.144599,0.122589,0.093095,0.063327}, {0.049692,0.069304,0.089767,0.107988,0.120651,0.125194,0.120651,0.107988,0.089767,0.069304,0.049692} };
+
+
+	// Selective Gaussian blur for preprocessing
+	static ImageData blur (ImageData imgd, float rad, float del){
+		int i,j,k,d,idx;
+		double racc,gacc,bacc,aacc,wacc;
+		ImageData imgd2 = new ImageData(imgd.width,imgd.height,new byte[imgd.width*imgd.height*4]);
+
+		// radius and delta limits, this kernel
+		int radius = (int)Math.floor(rad); if(radius<1){ return imgd; } if(radius>5){ radius = 5; }
+		int delta = (int)Math.abs(del); if(delta>1024){ delta = 1024; }
+		double[] thisgk = gks[radius-1];
+
+		// loop through all pixels, horizontal blur
+		for( j=0; j < imgd.height; j++ ){
+			for( i=0; i < imgd.width; i++ ){
+
+				racc = 0; gacc = 0; bacc = 0; aacc = 0; wacc = 0;
+				// gauss kernel loop
+				for( k = -radius; k < (radius+1); k++){
+					// add weighted color values
+					if( ((i+k) > 0) && ((i+k) < imgd.width) ){
+						idx = ((j*imgd.width)+i+k)*4;
+						racc += imgd.data[idx  ] * thisgk[k+radius];
+						gacc += imgd.data[idx+1] * thisgk[k+radius];
+						bacc += imgd.data[idx+2] * thisgk[k+radius];
+						aacc += imgd.data[idx+3] * thisgk[k+radius];
+						wacc += thisgk[k+radius];
+					}
+				}
+				// The new pixel
+				idx = ((j*imgd.width)+i)*4;
+				imgd2.data[idx  ] = (byte) Math.floor(racc / wacc);
+				imgd2.data[idx+1] = (byte) Math.floor(gacc / wacc);
+				imgd2.data[idx+2] = (byte) Math.floor(bacc / wacc);
+				imgd2.data[idx+3] = (byte) Math.floor(aacc / wacc);
+
+			}// End of width loop
+		}// End of horizontal blur
+
+		// copying the half blurred imgd2
+		byte[] himgd = imgd2.data.clone();
+
+		// loop through all pixels, vertical blur
+		for( j=0; j < imgd.height; j++ ){
+			for( i=0; i < imgd.width; i++ ){
+
+				racc = 0; gacc = 0; bacc = 0; aacc = 0; wacc = 0;
+				// gauss kernel loop
+				for( k = -radius; k < (radius+1); k++){
+					// add weighted color values
+					if( ((j+k) > 0) && ((j+k) < imgd.height) ){
+						idx = (((j+k)*imgd.width)+i)*4;
+						racc += himgd[idx  ] * thisgk[k+radius];
+						gacc += himgd[idx+1] * thisgk[k+radius];
+						bacc += himgd[idx+2] * thisgk[k+radius];
+						aacc += himgd[idx+3] * thisgk[k+radius];
+						wacc += thisgk[k+radius];
+					}
+				}
+				// The new pixel
+				idx = ((j*imgd.width)+i)*4;
+				imgd2.data[idx  ] = (byte) Math.floor(racc / wacc);
+				imgd2.data[idx+1] = (byte) Math.floor(gacc / wacc);
+				imgd2.data[idx+2] = (byte) Math.floor(bacc / wacc);
+				imgd2.data[idx+3] = (byte) Math.floor(aacc / wacc);
+
+			}// End of width loop
+		}// End of vertical blur
+
+		// Selective blur: loop through all pixels
+		for( j=0; j < imgd.height; j++ ){
+			for( i=0; i < imgd.width; i++ ){
+
+				idx = ((j*imgd.width)+i)*4;
+				// d is the difference between the blurred and the original pixel
+				d = Math.abs(imgd2.data[idx  ] - imgd.data[idx  ]) + Math.abs(imgd2.data[idx+1] - imgd.data[idx+1]) +
+						Math.abs(imgd2.data[idx+2] - imgd.data[idx+2]) + Math.abs(imgd2.data[idx+3] - imgd.data[idx+3]);
+				// selective blur: if d>delta, put the original pixel back
+				if(d>delta){
+					imgd2.data[idx  ] = imgd.data[idx  ];
+					imgd2.data[idx+1] = imgd.data[idx+1];
+					imgd2.data[idx+2] = imgd.data[idx+2];
+					imgd2.data[idx+3] = imgd.data[idx+3];
+				}
+			}
+		}// End of Selective blur
+
+		return imgd2;
+
+	}// End of blur()
+
+
+}// End of ImageTracer class

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/resources/img/trace.svg
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/resources/img/trace.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="trace.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1118"
+     inkscape:window-height="760"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="12.12"
+     inkscape:cx="-8.1334377"
+     inkscape:cy="7.4983498"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:5;stroke-opacity:1"
+     id="rect4145"
+     width="12.561888"
+     height="12.561881"
+     x="1.5775577"
+     y="1.6439769" />
+  <path
+     d="m 3.2555557,11.947222 9.5083293,0 L 9.9055552,8.1361106 7.3388887,11.461111 5.5305555,8.9916664 Z M 2.1666673,15 Q 1.7,15 1.35,14.65 1,14.3 1,13.833334 L 1,2.1666666 Q 1,1.7 1.35,1.35 1.7,1 2.1666673,1 L 13.833327,1 Q 14.3,1 14.65,1.35 15,1.7 15,2.1666666 L 15,13.833334 Q 15,14.3 14.65,14.65 14.3,15 13.833327,15 Z m 0,-1.166666 11.6666597,0 q 0,0 0,0 0,0 0,0 l 0,-11.6666674 q 0,0 0,0 0,0 0,0 l -11.6666597,0 q 0,0 0,0 0,0 0,0 l 0,11.6666674 q 0,0 0,0 0,0 0,0 z m 0,-11.6666674 q 0,0 0,0 0,0 0,0 l 0,11.6666674 q 0,0 0,0 0,0 0,0 0,0 0,0 0,0 0,0 l 0,-11.6666674 q 0,0 0,0 0,0 0,0 z"
+     id="path4"
+     style="fill:#353a40;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/resources/img/trace24.svg
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/resources/img/trace24.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="trace24.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1118"
+     inkscape:window-height="760"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="23.25"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:5;stroke-opacity:1"
+     id="rect4133"
+     width="17.79661"
+     height="17.79661"
+     x="3.1864407"
+     y="3.0169492" />
+  <path
+     d="m 5.2222222,17.638888 13.5833338,0 -4.083334,-5.444444 -3.666666,4.75 -2.5833342,-3.527777 z M 3.6666667,22 Q 3,22 2.5,21.5 2,21 2,20.333333 L 2,3.6666667 Q 2,3 2.5,2.5 3,2 3.6666667,2 L 20.333333,2 Q 21,2 21.5,2.5 22,3 22,3.6666667 L 22,20.333333 Q 22,21 21.5,21.5 21,22 20.333333,22 Z m 0,-1.666667 16.6666663,0 q 0,0 0,0 0,0 0,0 l 0,-16.6666663 q 0,0 0,0 0,0 0,0 l -16.6666663,0 q 0,0 0,0 0,0 0,0 l 0,16.6666663 q 0,0 0,0 0,0 0,0 z m 0,-16.6666663 q 0,0 0,0 0,0 0,0 l 0,16.6666663 q 0,0 0,0 0,0 0,0 0,0 0,0 0,0 0,0 l 0,-16.6666663 q 0,0 0,0 0,0 0,0 z"
+     id="path4"
+     style="fill:#353a40;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/resources/img/trace32.svg
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/resources/img/trace32.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="32"
+   width="32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="trace32.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1118"
+     inkscape:window-height="760"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="16.271186"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:5;stroke-opacity:1"
+     id="rect4133"
+     width="25.09322"
+     height="25.09322"
+     x="3.2457628"
+     y="3.3050852" />
+  <path
+     d="m 6.5111111,23.894444 19.0166669,0 -5.716667,-7.622222 -5.133333,6.65 -3.616667,-4.938888 z M 4.3333334,30 Q 3.4,30 2.7,29.3 2,28.6 2,27.666666 L 2,4.3333336 Q 2,3.4 2.7,2.7 3.4,2 4.3333334,2 L 27.666666,2 Q 28.6,2 29.3,2.7 30,3.4 30,4.3333336 L 30,27.666666 Q 30,28.6 29.3,29.3 28.6,30 27.666666,30 Z m 0,-2.333334 23.3333326,0 q 0,0 0,0 0,0 0,0 l 0,-23.3333324 q 0,0 0,0 0,0 0,0 l -23.3333326,0 q 0,0 0,0 0,0 0,0 l 0,23.3333324 q 0,0 0,0 0,0 0,0 z m 0,-23.3333324 q 0,0 0,0 0,0 0,0 l 0,23.3333324 q 0,0 0,0 0,0 0,0 0,0 0,0 0,0 0,0 l 0,-23.3333324 q 0,0 0,0 0,0 0,0 z"
+     id="path4"
+     style="fill:#353a40;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
Added a new feature for tracing bitmaps to vector graphics. Here is a small demo on how to import a image and adjust different settings to get a nice vectorized image:
![image_tracing](https://user-images.githubusercontent.com/8962024/165890566-ff790f41-da67-4be3-9069-3e0ef1d32acd.gif)

I am using the class [imagetracerjava](https://github.com/jankovicsandras/imagetracerjava) by András Jankovics (@jankovicsandras)

The settings works as the following:
* **Number of layers** - this will try to separate a number of colors to different layers. The minimum is two. 
* **Color range** - Filters which colors to work with - essentially this will brighten or darken the image, cutting off darker or lighter colors to work with.
* **Color quantization** - the defined number of layers will generate a color palette to use. This value will force near colors to that palette
* **Smooth lines** - If a line segment is jagged or will contain many points this setting will smoothen those lines out.
* **Smooth curves** - If curve segments are short, this setting will try to even those out making longer smother curves
* **Filter noise** - if there are many fine grained details creating small objects this setting will filter those out
* **Blur radius** - how large area in pixels that should be blurred. This setting can help to filter out noise or make lines smoother.
* **Blur delta** - how much of the pixels in the blur area should be blurred
