### PR TITLE
Clear status report commands in TinyG

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -207,8 +207,9 @@ public class TinyGController extends AbstractController {
         } else if (TinyGGcodeCommand.isOkErrorResponse(response)) {
             if (jo.get("r").getAsJsonObject().has(TinyGUtils.FIELD_STATUS_REPORT)) {
                 updateControllerStatus(jo.get("r").getAsJsonObject());
-                checkStreamFinished();
-            } else if (getActiveCommand().isPresent()) {
+            }
+
+            if (getActiveCommand().isPresent()) {
                 try {
                     commandComplete(response);
                 } catch (Exception e) {
@@ -362,7 +363,7 @@ public class TinyGController extends AbstractController {
 
         setCurrentState(CommunicatorState.COMM_DISCONNECTED);
         controllerStatus = ControllerStatusBuilder.newInstance(controllerStatus)
-                .setState(ControllerState.DISCONNECTED)
+                .setState(ControllerState.CONNECTING)
                 .build();
 
         dispatchStatusString(controllerStatus);

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGUtils.java
@@ -101,8 +101,9 @@ public class TinyGUtils {
     }
 
     public static boolean isTinyGVersion(JsonObject response) {
-        if (response.has(FIELD_RESPONSE)) {
-            JsonObject jo = response.getAsJsonObject(FIELD_RESPONSE);
+        Optional<JsonObject> responseObjectOptional = getResponseObject(response);
+        if (responseObjectOptional.isPresent()) {
+            JsonObject jo = responseObjectOptional.get();
             if (jo.has(FIELD_FIRMWARE_VERSION)) {
                 return true;
             }
@@ -111,8 +112,9 @@ public class TinyGUtils {
     }
 
     public static double getVersion(JsonObject response) {
-        if (response.has(FIELD_RESPONSE)) {
-            JsonObject jo = response.getAsJsonObject(FIELD_RESPONSE);
+        Optional<JsonObject> responseObjectOptional = getResponseObject(response);
+        if (responseObjectOptional.isPresent()) {
+            JsonObject jo = responseObjectOptional.get();
             if (jo.has(FIELD_FIRMWARE_VERSION)) {
                 return jo.get(FIELD_FIRMWARE_VERSION).getAsDouble();
             }
@@ -121,8 +123,9 @@ public class TinyGUtils {
     }
 
     public static boolean isRestartingResponse(JsonObject response) {
-        if (response.has(FIELD_RESPONSE)) {
-            JsonObject jo = response.getAsJsonObject(FIELD_RESPONSE);
+        Optional<JsonObject> responseObjectOptional = getResponseObject(response);
+        if (responseObjectOptional.isPresent()) {
+            JsonObject jo = responseObjectOptional.get();
             if (jo.has("msg")) {
                 String msg = jo.get("msg").getAsString();
                 return StringUtils.equals(msg, "Loading configs from EEPROM");
@@ -132,14 +135,24 @@ public class TinyGUtils {
     }
 
     public static boolean isReadyResponse(JsonObject response) {
-        if (response.has(FIELD_RESPONSE)) {
-            JsonObject jo = response.getAsJsonObject(FIELD_RESPONSE);
+        Optional<JsonObject> responseObjectOptional = getResponseObject(response);
+        if (responseObjectOptional.isPresent()) {
+            JsonObject jo = responseObjectOptional.get();
             if (jo.has("msg")) {
                 String msg = jo.get("msg").getAsString();
                 return StringUtils.equals(msg, "SYSTEM READY");
             }
         }
         return false;
+    }
+
+    private static Optional<JsonObject> getResponseObject(JsonObject response) {
+        if (response.has(FIELD_RESPONSE)) {
+            return Optional.of(response.getAsJsonObject(FIELD_RESPONSE));
+        } else if (response.has(FIELD_STATUS_REPORT)) {
+            return Optional.of(response.getAsJsonObject(FIELD_STATUS_REPORT));
+        }
+        return Optional.empty();
     }
 
     public static boolean isStatusResponse(JsonObject response) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/TinyGControllerTest.java
@@ -35,9 +35,16 @@ import org.mockito.MockitoAnnotations;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test TinyG controller implementation
@@ -104,6 +111,20 @@ public class TinyGControllerTest {
 
         // Then
         verify(controllerListener, times(1)).commandComplete(any());
+    }
+
+    @Test
+    public void rawResponseWithResultAndStatusReportShouldCompleteCommand() throws Exception {
+        controller = spy(controller);
+        when(communicator.isConnected()).thenReturn(true);
+        controller.commandSent(new GcodeCommand("blah"));
+        assertTrue(controller.getActiveCommand().isPresent());
+
+        String response = "{\"r\": {\"sr\": {\"stat\": 1}}}";
+        controller.rawResponseHandler(response);
+
+        verify(controller, times(1)).commandComplete(response);
+        assertFalse(controller.getActiveCommand().isPresent());
     }
 
     @Test


### PR DESCRIPTION
Make sure commands that responds with a status report is also cleared in TinyG-controllers. When resetting the controller it will get the status connecting.