### PR TITLE
Bugfix/entity remove bug

### DIFF
--- a/.codebeatignore
+++ b/.codebeatignore
@@ -1,1 +1,2 @@
 ugs-platform/ugs-platform-plugin-designer/src/main/java/org/kabeja/**
+ugs-platform/ugs-platform-plugin-designer/src/main/java/jankovicsandras/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: focal
 language: java
 os: linux
-jdk: openjdk13
 
 # Prevent running default install script
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 - curl -fL https://getcli.jfrog.io | sh
 
 script:
-  - jdk_switcher use openjdk13
+  - echo "${JAVA_HOME}"
   # Default to a snapshot build
   - export REVISION="2.0"
   - export CHANGELIST="-SNAPSHOT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
 - curl -fL https://getcli.jfrog.io | sh
 
 script:
+  - jdk_switcher use openjdk13
   # Default to a snapshot build
   - export REVISION="2.0"
   - export CHANGELIST="-SNAPSHOT"

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/AddAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/AddAction.java
@@ -23,6 +23,7 @@ import com.willwinder.ugs.nbp.designer.logic.Controller;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -56,7 +57,7 @@ public class AddAction extends AbstractAction implements DrawAction, UndoableAct
      */
     public AddAction(Controller controller, List<Entity> entities) {
         this.controller = controller;
-        this.entities = entities;
+        this.entities = new ArrayList<>(entities);
     }
 
     public void execute() {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ChangeCutSettingsAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ChangeCutSettingsAction.java
@@ -24,6 +24,7 @@ import com.willwinder.ugs.nbp.designer.logic.Controller;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -42,7 +43,7 @@ public class ChangeCutSettingsAction extends AbstractAction implements UndoableA
     private final List<Cuttable> cuttableList;
 
     public ChangeCutSettingsAction(Controller controller, List<Cuttable> cuttableList, double startDepth, double targetDepth, CutType cutType) {
-        this.cuttableList = cuttableList;
+        this.cuttableList = new ArrayList<>(cuttableList);
         previousStartDepth = cuttableList.stream().map(Cuttable::getStartDepth).collect(Collectors.toList());
         previousCutDepth = cuttableList.stream().map(Cuttable::getTargetDepth).collect(Collectors.toList());
         previousCutType = cuttableList.stream().map(Cuttable::getCutType).collect(Collectors.toList());

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/DeleteAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/DeleteAction.java
@@ -31,6 +31,8 @@ import org.openide.util.ImageUtilities;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -98,7 +100,7 @@ public class DeleteAction extends AbstractAction implements SelectionListener {
 
         public UndoableDeleteAction(Drawing drawing, List<Entity> entities) {
             this.drawing = drawing;
-            this.entities = entities;
+            this.entities = new ArrayList<>(entities);
         }
 
         @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ResizeAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ResizeAction.java
@@ -1,0 +1,62 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.actions;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.entities.EntityGroup;
+import com.willwinder.ugs.nbp.designer.entities.controls.Location;
+import com.willwinder.ugs.nbp.designer.entities.controls.ResizeUtils;
+import com.willwinder.ugs.nbp.designer.model.Size;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ResizeAction implements an action where all the entities in a
+ * given selection are resized.
+ *
+ * @author Joacim Breiler
+ */
+public class ResizeAction implements UndoableAction {
+    private final Location location;
+    private final List<Entity> entities;
+    private final Size originalSize;
+    private final Size newSize;
+
+    public ResizeAction(List<Entity> entities, Location location, Size originalSize, Size newSize) {
+        this.entities = new ArrayList<>(entities);
+        this.location = location;
+        this.originalSize = originalSize;
+        this.newSize = newSize;
+    }
+
+    @Override
+    public void redo() {
+        EntityGroup entityGroup = new EntityGroup();
+        entityGroup.addAll(entities);
+        ResizeUtils.performScaling(entityGroup, location, originalSize, newSize);
+    }
+
+    @Override
+    public void undo() {
+        EntityGroup entityGroup = new EntityGroup();
+        entityGroup.addAll(entities);
+        ResizeUtils.performScaling(entityGroup, location, newSize, originalSize);
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolZoomAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolZoomAction.java
@@ -20,6 +20,7 @@ package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import org.openide.awt.StatusDisplayer;
 import org.openide.util.ImageUtilities;
 
 import javax.swing.*;
@@ -44,6 +45,7 @@ public class ToolZoomAction extends AbstractAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        StatusDisplayer.getDefault().setStatusText("Click to Zoom in, SHIFT + Click to Zoom out");
         controller.setTool(Tool.ZOOM);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntityGroup.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntityGroup.java
@@ -154,18 +154,18 @@ public class EntityGroup extends AbstractEntity implements EntityListener {
         invalidateCenter();
     }
 
-    public boolean containsChild(Entity node) {
-        return children.contains(node);
+    public boolean containsChild(Entity entity) {
+        return children.contains(entity);
     }
 
+    /**
+     * Removes a direct child entity from the group. If it exists as a grand child it will be left alone.
+     *
+     * @param entity the entity to remove
+     */
     public void removeChild(Entity entity) {
         entity.removeListener(this);
         children.remove(entity);
-        children.stream()
-                .filter(EntityGroup.class::isInstance)
-                .map(EntityGroup.class::cast)
-                .forEach(c -> c.removeChild(entity));
-
         invalidateCenter();
     }
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/CreateEllipseControl.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/CreateEllipseControl.java
@@ -96,8 +96,6 @@ public class CreateEllipseControl extends AbstractControl {
 
         Ellipse ellipse = new Ellipse(startX, startY);
         ellipse.setSize(new Size(endX - startX, endY - startY));
-        AddAction addAction = new AddAction(controller, ellipse);
-        addAction.actionPerformed(new ActionEvent(this, 0, ""));
         controller.addEntity(ellipse);
     }
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/CreateRectangleControl.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/CreateRectangleControl.java
@@ -96,8 +96,6 @@ public class CreateRectangleControl extends AbstractControl {
         Rectangle rectangle = new Rectangle(startX, startY);
         rectangle.setWidth(endX - startX);
         rectangle.setHeight(endY - startY);
-        AddAction addAction = new AddAction(controller, rectangle);
-        addAction.actionPerformed(new ActionEvent(this, 0, ""));
         controller.addEntity(rectangle);
     }
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/CreateTextControl.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/CreateTextControl.java
@@ -91,8 +91,6 @@ public class CreateTextControl extends AbstractControl {
         double startY = Math.min(startPosition.getY(), endPosition.getY());
 
         Text text = new Text(startX, startY);
-        AddAction addAction = new AddAction(controller, text);
-        addAction.actionPerformed(new ActionEvent(this, 0, ""));
         controller.addEntity(text);
         controller.setTool(Tool.SELECT);
         controller.getSelectionManager().addSelection(text);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/ResizeUtils.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/ResizeUtils.java
@@ -1,0 +1,53 @@
+/*
+    Copyright 2022 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.entities.controls;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.model.Size;
+
+import java.awt.geom.Point2D;
+
+public class ResizeUtils {
+    public static Point2D getDeltaMovement(Location location, Size size, Size newSize) {
+        Size deltaSize = new Size(size.getWidth() - newSize.getWidth(), size.getHeight() - newSize.getHeight());
+        Point2D movement = new Point2D.Double(0, 0);
+        if (location == Location.BOTTOM_LEFT) {
+            movement.setLocation(deltaSize.getWidth(), deltaSize.getHeight());
+        } else if (location == Location.BOTTOM_RIGHT) {
+            movement.setLocation(0, deltaSize.getHeight());
+        } else if (location == Location.TOP_LEFT) {
+            movement.setLocation(deltaSize.getWidth(), 0);
+        } else if (location == Location.LEFT) {
+            movement.setLocation(deltaSize.getWidth(), 0);
+        } else if (location == Location.BOTTOM) {
+            movement.setLocation(0, deltaSize.getHeight());
+        }
+        return movement;
+    }
+
+    public static void performScaling(Entity target, Location location, Size originalSize, Size newSize) {
+        // Do not scale if the entity will become too small after operation
+        if (newSize.getWidth() < 1 || newSize.getHeight() < 1) {
+            return;
+        }
+
+        target.move(getDeltaMovement(location, originalSize, newSize));
+        target.setSize(newSize);
+    }
+}


### PR DESCRIPTION
When a group and an entity within the group is selected, and then deselecting the group the entity is removed. This is because of the EntityGroup removing children recursively.

Some actions couldn't be undone and this was because the actions didn't store its own lists of the entites.

Added an action for resizing which now makes it possible to undo/redo the resizing operation