### PR TITLE
GRBL controller will now detect if coordinates contains ABC-coordinates and add it as a controller capability

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/AbstractController.java
@@ -345,10 +345,9 @@ public abstract class AbstractController implements CommunicatorListener, IContr
         this.setControllerState(ControllerState.CONNECTING);
 
         if (isCommOpen()) {
-            this.openCommAfterEvent();
-
-            this.dispatchConsoleMessage(MessageType.INFO,
+            dispatchConsoleMessage(MessageType.INFO,
                     "**** Connected to " + port + " @ " + portRate + " baud ****\n");
+            openCommAfterEvent();
         }
 
         connectionWatchTimer.start();

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -561,14 +561,14 @@ public class GrblUtils {
                     reportingUnits);
 
             // Add in optional axes.
-            if (matcher.group(6) != null) {
-                result.c = Double.parseDouble(matcher.group(6));
+            if (matcher.group(4) != null) {
+                result.a = Double.parseDouble(matcher.group(4));
             }
             if (matcher.group(5) != null) {
                 result.b = Double.parseDouble(matcher.group(5));
             }
-            if (matcher.group(4) != null) {
-                result.a = Double.parseDouble(matcher.group(4));
+            if (matcher.group(6) != null) {
+                result.c = Double.parseDouble(matcher.group(6));
             }
 
             return result;

--- a/ugs-core/src/com/willwinder/universalgcodesender/connection/ResponseMessageHandler.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/connection/ResponseMessageHandler.java
@@ -18,6 +18,8 @@
  */
 package com.willwinder.universalgcodesender.connection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -47,7 +49,7 @@ public class ResponseMessageHandler {
      * @param response a complete or part of a response message
      */
     public void handleResponse(String response) {
-        inputBuffer.append(response);
+        inputBuffer.append(StringUtils.remove(response, '\r'));
 
         // Only continue if there is a line terminator and split out command(response).
         if (!inputBuffer.toString().contains("\n")) {
@@ -56,7 +58,7 @@ public class ResponseMessageHandler {
 
         // Split with the -1 option will give an empty string at
         // the end if there is a terminator there as well.
-        String[] messages = inputBuffer.toString().split("\\r?\\n", -1);
+        String[] messages = inputBuffer.toString().split("\\n", -1);
         for (int i = 0; i < messages.length; i++) {
             // Make sure this isn't the last command.
             if ((i + 1) < messages.length) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/CNCPoint.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/CNCPoint.java
@@ -383,9 +383,13 @@ public class CNCPoint {
   public boolean equals(CNCPoint t1)
   {
     try {
-      return(this.x == t1.x && this.y == t1.y && this.z == t1.z && this.a == t1.a && this.b == t1.b && this.c == t1.c);
+      return equals(this.x, t1.x) && equals(this.y, t1.y) && equals(this.z, t1.z) && equals(this.a, t1.a) && equals(this.b, t1.b) && equals(this.c, t1.c);
     }
     catch (NullPointerException e2) {return false;}
+  }
+
+  protected boolean equals(double v1, double v2) {
+    return (Double.isNaN(v1) && Double.isNaN(v2)) || v1 == v2;
   }
 
   /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/Position.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/Position.java
@@ -38,12 +38,12 @@ public class Position extends CNCPoint {
     }
 
     public Position(double x, double y, double z) {
-        super(x, y, z, 0, 0, 0);
+        super(x, y, z, Double.NaN, Double.NaN, Double.NaN);
         this.units = Units.UNKNOWN;
     }
 
     public Position(double x, double y, double z, Units units) {
-        super(x, y, z, 0, 0, 0);
+        super(x, y, z, Double.NaN, Double.NaN, Double.NaN);
         this.units = units;
     }
 
@@ -121,25 +121,27 @@ public class Position extends CNCPoint {
 
     /**
      * Determine if the motion between Positions is a Z plunge.
+     *
      * @param next the Position to compare with the current object.
      * @return True if it only requires a Z motion to reach next.
      */
     public boolean isZMotionTo(Position next) {
-        return (this.z != next.z) &&
-                (this.x == next.x) &&
-                (this.y == next.y) &&
-                (this.a == next.a) &&
-                (this.b == next.b) &&
-                (this.c == next.c);
+        return !equals(this.z, next.z) &&
+                equals(this.x, next.x) &&
+                equals(this.y, next.y) &&
+                equals(this.a, next.a) &&
+                equals(this.b, next.b) &&
+                equals(this.c, next.c);
     }
 
     /**
      * Determine if the motion between Positions contains a rotation.
+     *
      * @param next the Position to compare with the current object.
      * @return True if a rotation occurs
      */
     public boolean hasRotationTo(Position next) {
-        return (this.a != next.a) || (this.b != next.b) || (this.c != next.c);
+        return !equals(this.a, next.a) || !equals(this.b, next.b) || equals(this.c, next.c);
     }
 
     /**
@@ -148,7 +150,9 @@ public class Position extends CNCPoint {
      * @return true if the position contains rotations
      */
     public boolean hasRotation() {
-        return a != 0 || b != 0 || c != 0;
+        return (a != 0 && !Double.isNaN(a)) ||
+                (b != 0 && !Double.isNaN(b)) ||
+                (c != 0 && !Double.isNaN(c));
     }
 
     public void set(Axis axis, double value) {
@@ -169,7 +173,7 @@ public class Position extends CNCPoint {
     /**
      * Rotates this point around the center with the given angle in radians and returns a new position
      *
-     * @param center the XY position to rotate around
+     * @param center  the XY position to rotate around
      * @param radians the radians to rotate clock wise
      * @return a new rotated position
      */
@@ -178,7 +182,7 @@ public class Position extends CNCPoint {
         double sinA = Math.sin(radians);
 
         return new Position(
-                center.x + (cosA * (x -  center.x) + sinA * (y - center.y)),
+                center.x + (cosA * (x - center.x) + sinA * (y - center.y)),
                 center.y + (-sinA * (x - center.x) + cosA * (y - center.y)),
                 z,
                 units);

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
@@ -81,12 +81,14 @@ public class SettingsFactory {
             // Save json file.
             File jsonFile = getSettingsFile();
             try (FileWriter fileWriter = new FileWriter(jsonFile)) {
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                Gson gson = new GsonBuilder()
+                        .setPrettyPrinting()
+                        .serializeSpecialFloatingPointValues()
+                        .create();
                 fileWriter.write(gson.toJson(settings, Settings.class));
             }
          } catch (Exception e) {
-            e.printStackTrace();
-            logger.warning(Localization.getString("settings.log.saveerror"));
+            logger.log(Level.SEVERE, Localization.getString("settings.log.saveerror"), e);
         }
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerUtils.java
@@ -186,28 +186,38 @@ public class VisualizerUtils {
 
     public static void expandRotationalLineSegment(Position start, PointSegment endSegment, List<LineSegment> ret) {
         double maxDegreesPerStep = 5;
-        double deltaA = endSegment.point().a - start.a;
-        double deltaB = endSegment.point().b - start.b;
-        double deltaC = endSegment.point().c - start.c;
+        double deltaA = defaultZero(endSegment.point().a) - defaultZero(start.a);
+        double deltaB = defaultZero(endSegment.point().b) - defaultZero(start.b);
+        double deltaC = defaultZero(endSegment.point().c) - defaultZero(start.c);
         double steps = Math.max(Math.abs(deltaA), Math.max(Math.abs(deltaB), Math.abs(deltaC))) / maxDegreesPerStep;
 
         Position startPoint = start;
         for (int i = 0; i < steps; i++) {
             Position end = new Position(endSegment.point());
             if (deltaA != 0) {
-                end.setA(start.a + ((deltaA / steps) * i));
+                end.setA(defaultZero(start.a) + ((deltaA / steps) * i));
             }
             if (deltaB != 0) {
-                end.setB(start.b + ((deltaB / steps) * i));
+                end.setB(defaultZero(start.b) + ((deltaB / steps) * i));
             }
             if (deltaC != 0) {
-                end.setC(start.c + ((deltaC / steps) * i));
+                end.setC(defaultZero(start.c) + ((deltaC / steps) * i));
             }
             ret.add(createLineSegment(startPoint, end, endSegment));
             startPoint = end;
         }
 
         ret.add(createLineSegment(startPoint, endSegment.point(), endSegment));
+    }
+
+    /**
+     * If a double value is NaN this method will return a zero.
+     *
+     * @param value a value that is either a double or a Double.NaN
+     * @return a zero or a double.
+     */
+    private static double defaultZero(double value) {
+        return Double.isNaN(value) ? 0 : value;
     }
 
     private static double sinIfNotZero(double angle) {
@@ -250,13 +260,13 @@ public class VisualizerUtils {
             return position;
         }
 
-        Position result = new Position(position.x, position.y, position.z, position.getUnits());
+        Position result = new Position(position.x, position.y, position.z, 0, 0, 0, position.getUnits());
         double sx = position.x;
         double sy = position.y;
         double sz = position.z;
-        double sa = position.a;
-        double sb = position.b;
-        double sc = position.c;
+        double sa = defaultZero(position.a);
+        double sb = defaultZero(position.b);
+        double sc = defaultZero(position.c);
         double sSinA = sinIfNotZero(sa);
         double sCosA = cosIfNotZero(sa);
         double sSinB = sinIfNotZero(sb);

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -1386,6 +1386,52 @@ public class GrblControllerTest {
     }
 
     @Test
+    public void controllerShouldGetAxisCapabilitiesOnStatusStringWithMachinePosition() throws Exception {
+        // Given
+        GrblController instance = new GrblController(mgc);
+        instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
+        instance.rawResponseHandler(VERSION_GRBL_1_1F);
+
+        assertFalse("We should not start with A axis capabilities", instance.getCapabilities().hasCapability(CapabilitiesConstants.A_AXIS));
+        assertFalse("We should not start with B axis capabilities", instance.getCapabilities().hasCapability(CapabilitiesConstants.B_AXIS));
+        assertFalse("We should not start with C axis capabilities", instance.getCapabilities().hasCapability(CapabilitiesConstants.C_AXIS));
+
+        // When
+        instance.rawResponseHandler("<Idle|MPos:1.000,2.000,3.000,4.000,5.000,6.0000|FS:0,0|Pn:XYZ>");
+
+        // Then
+        assertTrue("We should now have A axis capability", instance.getCapabilities().hasCapability(CapabilitiesConstants.A_AXIS));
+        assertTrue("We should now have B axis capability", instance.getCapabilities().hasCapability(CapabilitiesConstants.B_AXIS));
+        assertTrue("We should now have C axis capability", instance.getCapabilities().hasCapability(CapabilitiesConstants.C_AXIS));
+        assertEquals(4, instance.getControllerStatus().getMachineCoord().a, 0.1);
+        assertEquals(5, instance.getControllerStatus().getMachineCoord().b, 0.1);
+        assertEquals(6, instance.getControllerStatus().getMachineCoord().c, 0.1);
+    }
+
+    @Test
+    public void controllerShouldGetAxisCapabilitiesOnStatusStringWithWorkPosition() throws Exception {
+        // Given
+        GrblController instance = new GrblController(mgc);
+        instance.openCommPort(getSettings().getConnectionDriver(), "foo", 2400);
+        instance.rawResponseHandler(VERSION_GRBL_1_1F);
+
+        assertFalse("We should not start with A axis capabilities", instance.getCapabilities().hasCapability(CapabilitiesConstants.A_AXIS));
+        assertFalse("We should not start with B axis capabilities", instance.getCapabilities().hasCapability(CapabilitiesConstants.B_AXIS));
+        assertFalse("We should not start with C axis capabilities", instance.getCapabilities().hasCapability(CapabilitiesConstants.C_AXIS));
+
+        // When
+        instance.rawResponseHandler("<Idle|WPos:1.000,2.000,3.000,4.000,5.000,6.0000|FS:0,0|Pn:XYZ>");
+
+        // Then
+        assertTrue("We should now have A axis capability", instance.getCapabilities().hasCapability(CapabilitiesConstants.A_AXIS));
+        assertTrue("We should now have B axis capability", instance.getCapabilities().hasCapability(CapabilitiesConstants.B_AXIS));
+        assertTrue("We should now have C axis capability", instance.getCapabilities().hasCapability(CapabilitiesConstants.C_AXIS));
+        assertEquals(4, instance.getControllerStatus().getWorkCoord().a, 0.1);
+        assertEquals(5, instance.getControllerStatus().getWorkCoord().b, 0.1);
+        assertEquals(6, instance.getControllerStatus().getWorkCoord().c, 0.1);
+    }
+
+    @Test
     public void versionStringShouldResetStatus() throws Exception {
         // Given
         GrblController instance = initializeAndConnectController("foo", 2400, VERSION_GRBL_1_1F);

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -466,7 +466,7 @@ public class GrblUtilsTest {
 
         assertEquals(new Position(1.1, 2.2, 3.3, MM), controllerStatus.getMachineCoord());
         assertEquals(new Position(4.4, 5.5, 6.6, MM), controllerStatus.getWorkCoord());
-        assertEquals(new Position(0, 0, 0, MM), controllerStatus.getWorkCoordinateOffset());
+        assertEquals(new Position(0, 0, 0, 0, 0, 0, MM), controllerStatus.getWorkCoordinateOffset());
     }
 
     @Test
@@ -599,9 +599,9 @@ public class GrblUtilsTest {
 
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
 
-        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 5.5, 0.0, MM), controllerStatus.getMachineCoord());
-        assertEquals(new Position(7.7, 8.8, 9.9, 10.10, 11.11, 0.0, MM), controllerStatus.getWorkCoord());
-        assertEquals(new Position(13.13, 14.14, 15.15, 16.16, 17.17, 0.0, MM), controllerStatus.getWorkCoordinateOffset());
+        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 5.5, Double.NaN, MM), controllerStatus.getMachineCoord());
+        assertEquals(new Position(7.7, 8.8, 9.9, 10.10, 11.11, Double.NaN, MM), controllerStatus.getWorkCoord());
+        assertEquals(new Position(13.13, 14.14, 15.15, 16.16, 17.17, Double.NaN, MM), controllerStatus.getWorkCoordinateOffset());
         assertTrue(controllerStatus.getEnabledPins().A);
         assertTrue(controllerStatus.getEnabledPins().B);
         assertFalse(controllerStatus.getEnabledPins().C);
@@ -618,9 +618,9 @@ public class GrblUtilsTest {
 
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
 
-        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 0.0, 0.0, MM), controllerStatus.getMachineCoord());
-        assertEquals(new Position(7.7, 8.8, 9.9, 10.10, 0.0, 0.0, MM), controllerStatus.getWorkCoord());
-        assertEquals(new Position(13.13, 14.14, 15.15, 16.16, 0.0, 0.0, MM), controllerStatus.getWorkCoordinateOffset());
+        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, Double.NaN, Double.NaN, MM), controllerStatus.getMachineCoord());
+        assertEquals(new Position(7.7, 8.8, 9.9, 10.10, Double.NaN, Double.NaN, MM), controllerStatus.getWorkCoord());
+        assertEquals(new Position(13.13, 14.14, 15.15, 16.16, Double.NaN, Double.NaN, MM), controllerStatus.getWorkCoordinateOffset());
 
         assertTrue(controllerStatus.getEnabledPins().A);
         assertFalse(controllerStatus.getEnabledPins().B);
@@ -641,9 +641,9 @@ public class GrblUtilsTest {
         String ThreeAxis = "[PRB:1.1,2.2,3.3:1]";
         assertEquals(new Position(1.1, 2.2, 3.3, MM), GrblUtils.parseProbePosition(ThreeAxis, MM));
         String FourAxis = "[PRB:1.1,2.2,3.3,4.4:1]";
-        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 0.0, 0.0, MM), GrblUtils.parseProbePosition(FourAxis, MM));
+        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, Double.NaN, Double.NaN, MM), GrblUtils.parseProbePosition(FourAxis, MM));
         String FiveAxis = "[PRB:1.1,2.2,3.3,4.4,5.5:1]";
-        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 5.5, 0.0, MM), GrblUtils.parseProbePosition(FiveAxis, MM));
+        assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 5.5, Double.NaN, MM), GrblUtils.parseProbePosition(FiveAxis, MM));
         String SixAxis = "[PRB:1.1,2.2,3.3,4.4,5.5,6.6:1]";
         assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 5.5, 6.6, MM), GrblUtils.parseProbePosition(SixAxis, MM));
     }

--- a/ugs-core/test/com/willwinder/universalgcodesender/visualizer/VisualizerUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/visualizer/VisualizerUtilsTest.java
@@ -8,13 +8,22 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class VisualizerUtilsTest {
 
+    public static void assertPosition(double x, double y, double z, double a, double b, double c, Position position) {
+        assertEquals("Expected position X", x, position.x, 0.1d);
+        assertEquals("Expected position Y", y, position.y, 0.1d);
+        assertEquals("Expected position Z", z, position.z, 0.1d);
+        assertEquals("Expected position A", a, position.a, 0.1d);
+        assertEquals("Expected position B", b, position.b, 0.1d);
+        assertEquals("Expected position C", c, position.c, 0.1d);
+    }
+
     @Test
     public void toCartesianShouldNotApplyRotationIfZero() {
-        Position position = new Position(10, 11, 12, UnitUtils.Units.MM);
+        Position position = new Position(10, 11, 12, 0, 0, 0, UnitUtils.Units.MM);
         Position position1 = VisualizerUtils.toCartesian(position);
         assertEquals(10d, position1.x, 0.1);
         assertEquals(11d, position1.y, 0.1);
@@ -65,6 +74,60 @@ public class VisualizerUtilsTest {
     }
 
     @Test
+    public void expandRotationalLineSegmentWithoutABCAxesShouldBeIgnored() {
+        Position startPosition = new Position(0, 0, 10, UnitUtils.Units.MM);
+        Position endPosition = new Position(0, 0, 10, UnitUtils.Units.MM);
+        PointSegment endSegment = new PointSegment(endPosition, 0);
+
+        List<LineSegment> result = new ArrayList<>();
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
+
+        assertEquals(1, result.size());
+        assertPosition(0, 0, 10, Double.NaN, Double.NaN, Double.NaN, result.get(0).getEnd());
+    }
+
+    @Test
+    public void expandRotationalLineSegmentWithStartingAShouldBeIgnored() {
+        Position startPosition = new Position(0, 0, 10, 0, Double.NaN, Double.NaN, UnitUtils.Units.MM);
+        Position endPosition = new Position(0, 0, 10, UnitUtils.Units.MM);
+        PointSegment endSegment = new PointSegment(endPosition, 0);
+
+        List<LineSegment> result = new ArrayList<>();
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
+
+        assertEquals(1, result.size());
+        assertPosition(0, 0, 10, Double.NaN, Double.NaN, Double.NaN, result.get(0).getEnd());
+    }
+
+    @Test
+    public void expandRotationalLineSegmentWithEndingAZeroShouldBeZero() {
+        Position startPosition = new Position(0, 0, 10,  UnitUtils.Units.MM);
+        Position endPosition = new Position(0, 0, 10, 0, Double.NaN, Double.NaN, UnitUtils.Units.MM);
+        PointSegment endSegment = new PointSegment(endPosition, 0);
+
+        List<LineSegment> result = new ArrayList<>();
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
+
+        assertEquals(1, result.size());
+        assertPosition(0, 0, 10, 0.0, Double.NaN, Double.NaN, result.get(0).getEnd());
+    }
+
+    @Test
+    public void expandRotationalLineSegmentWithEndingAShouldBeInterpolated() {
+        Position startPosition = new Position(0, 0, 10,  UnitUtils.Units.MM);
+        Position endPosition = new Position(0, 0, 10, 10, Double.NaN, Double.NaN, UnitUtils.Units.MM);
+        PointSegment endSegment = new PointSegment(endPosition, 0);
+
+        List<LineSegment> result = new ArrayList<>();
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
+
+        assertEquals(3, result.size());
+        assertPosition(0, 0, 10, 0, Double.NaN, Double.NaN, result.get(0).getEnd());
+        assertPosition(0, 0, 10, 5.0, Double.NaN, Double.NaN, result.get(1).getEnd());
+        assertPosition(0, 0, 10, 10.0, Double.NaN, Double.NaN, result.get(2).getEnd());
+    }
+
+    @Test
     public void expandRotationalLineSegmentRotationAroundAShouldInterpolateWithFiveDegreeSteps() {
         Position startPosition = new Position(0, 0, 10, 0, 0, 0, UnitUtils.Units.MM);
         Position endPosition = new Position(0, 0, 10, 90, 0, 0, UnitUtils.Units.MM);
@@ -74,10 +137,10 @@ public class VisualizerUtilsTest {
         VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
-        assertPosition(0,0,10,0,0,0, result.get(0).getEnd());
-        assertPosition(0,0,10,5,0,0, result.get(1).getEnd());
-        assertPosition(0,0,10,10,0,0, result.get(2).getEnd());
-        assertPosition(0,0,10,90,0,0, result.get(18).getEnd());
+        assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
+        assertPosition(0, 0, 10, 5, 0, 0, result.get(1).getEnd());
+        assertPosition(0, 0, 10, 10, 0, 0, result.get(2).getEnd());
+        assertPosition(0, 0, 10, 90, 0, 0, result.get(18).getEnd());
     }
 
     @Test
@@ -90,10 +153,10 @@ public class VisualizerUtilsTest {
         VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
-        assertPosition(0,0,10,0,0,0, result.get(0).getEnd());
-        assertPosition(0,0,10,0,5,0, result.get(1).getEnd());
-        assertPosition(0,0,10,0,10,0, result.get(2).getEnd());
-        assertPosition(0,0,10,0,90,0, result.get(18).getEnd());
+        assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
+        assertPosition(0, 0, 10, 0, 5, 0, result.get(1).getEnd());
+        assertPosition(0, 0, 10, 0, 10, 0, result.get(2).getEnd());
+        assertPosition(0, 0, 10, 0, 90, 0, result.get(18).getEnd());
     }
 
     @Test
@@ -106,10 +169,10 @@ public class VisualizerUtilsTest {
         VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
-        assertPosition(0,0,10,0,0,0, result.get(0).getEnd());
-        assertPosition(0,0,10,0,0,5, result.get(1).getEnd());
-        assertPosition(0,0,10,0,0,10, result.get(2).getEnd());
-        assertPosition(0,0,10,0,0,90, result.get(18).getEnd());
+        assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
+        assertPosition(0, 0, 10, 0, 0, 5, result.get(1).getEnd());
+        assertPosition(0, 0, 10, 0, 0, 10, result.get(2).getEnd());
+        assertPosition(0, 0, 10, 0, 0, 90, result.get(18).getEnd());
     }
 
     @Test
@@ -122,21 +185,12 @@ public class VisualizerUtilsTest {
         VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(7, result.size());
-        assertPosition(0,0,10,0,0,0, result.get(0).getEnd());
-        assertPosition(0,0,10,1.6,3.3,5, result.get(1).getEnd());
-        assertPosition(0,0,10,3.3,6.6,10, result.get(2).getEnd());
-        assertPosition(0,0,10,5,10,15, result.get(3).getEnd());
-        assertPosition(0,0,10,6.6,13.3,20, result.get(4).getEnd());
-        assertPosition(0,0,10,8.3,16.6,25, result.get(5).getEnd());
-        assertPosition(0,0,10,10,20,30, result.get(6).getEnd());
-    }
-
-    public static void assertPosition(double x, double y, double z, double a, double b, double c, Position position) {
-        assertEquals("Expected position X", x, position.x, 0.1d);
-        assertEquals("Expected position Y", y, position.y, 0.1d);
-        assertEquals("Expected position Z", z, position.z, 0.1d);
-        assertEquals("Expected position A", a, position.a, 0.1d);
-        assertEquals("Expected position B", b, position.b, 0.1d);
-        assertEquals("Expected position C", c, position.c, 0.1d);
+        assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
+        assertPosition(0, 0, 10, 1.6, 3.3, 5, result.get(1).getEnd());
+        assertPosition(0, 0, 10, 3.3, 6.6, 10, result.get(2).getEnd());
+        assertPosition(0, 0, 10, 5, 10, 15, result.get(3).getEnd());
+        assertPosition(0, 0, 10, 6.6, 13.3, 20, result.get(4).getEnd());
+        assertPosition(0, 0, 10, 8.3, 16.6, 25, result.get(5).getEnd());
+        assertPosition(0, 0, 10, 10, 20, 30, result.get(6).getEnd());
     }
 }

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/renderables/Tool.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/renderables/Tool.java
@@ -77,9 +77,15 @@ public final class Tool extends Renderable {
             gl.glTranslated(position.x, position.y, position.z);
             gl.glScaled(scale, scale, scale);
 
-            gl.glRotated(workCoord.a, 1.0d, 0.0d, 0.0d);   //X
-            gl.glRotated(workCoord.b, 0.0d, 1.0d, 0.0d);   //Y
-            gl.glRotated(workCoord.c, 0.0d, 0.0d, 1.0d);   //Z
+            if (!Double.isNaN(workCoord.a)) {
+                gl.glRotated(workCoord.a, 1.0d, 0.0d, 0.0d);   //X
+            }
+            if (!Double.isNaN(workCoord.b)) {
+                gl.glRotated(workCoord.b, 0.0d, 1.0d, 0.0d);   //Y
+            }
+            if (!Double.isNaN(workCoord.c)) {
+                gl.glRotated(workCoord.c, 0.0d, 0.0d, 1.0d);   //Z
+            }
 
             gl.glColor4fv(VisualizerOptions.colorToFloatArray(toolColor), 0);
             glu.gluQuadricNormals(gq, GLU.GLU_SMOOTH);


### PR DESCRIPTION
Made an attempt to make GRBL recognize extra coordinates for ABC-axes, adding them as capabilities if the status report contains them.

Here is an example of a grblHAL-controller. It also works with [grbl-mega-5x](https://github.com/fra589/grbl-Mega-5X):
![2022-07-12 19-28-49 2022-07-12 19_32_51](https://user-images.githubusercontent.com/8962024/178556196-637e12ce-ed65-4cb5-8a00-f79e0cdef1f6.gif)

Related issues: #1399, #1068, #1626
