### PR TITLE
Fixed problem with the entity tree not expanding its rows when starting

### DIFF
--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
@@ -5,6 +5,7 @@ import com.willwinder.ugs.nbp.designer.actions.UndoManager;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.gui.*;
 import com.willwinder.ugs.nbp.designer.gui.tree.EntitiesTree;
+import com.willwinder.ugs.nbp.designer.gui.tree.EntityTreeModel;
 import com.willwinder.ugs.nbp.designer.io.svg.SvgReader;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
@@ -68,7 +69,8 @@ public class DesignerMain extends JFrame {
     }
 
     private JSplitPane createRightPanel(Controller controller) {
-        JSplitPane toolsSplit = new JSplitPane( JSplitPane.VERTICAL_SPLIT, new JScrollPane(new EntitiesTree(controller)), new SelectionSettingsPanel(controller));
+        EntityTreeModel entityTreeModel = new EntityTreeModel(controller);
+        JSplitPane toolsSplit = new JSplitPane( JSplitPane.VERTICAL_SPLIT, new JScrollPane(new EntitiesTree(controller, entityTreeModel)), new SelectionSettingsPanel(controller));
         toolsSplit.setResizeWeight(0.9);
         return toolsSplit;
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/selection/SelectionManager.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/selection/SelectionManager.java
@@ -119,9 +119,7 @@ public class SelectionManager extends AbstractEntity implements EntityListener {
 
 
     public void removeSelectionListener(SelectionListener selectionListener) {
-        if (!listeners.contains(selectionListener)) {
-            listeners.remove(selectionListener);
-        }
+        listeners.remove(selectionListener);
     }
 
     private void fireSelectionEvent(SelectionEvent selectionEvent) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTree.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTree.java
@@ -23,12 +23,14 @@ import com.willwinder.ugs.nbp.designer.entities.EntityGroup;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import net.miginfocom.swing.MigLayout;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.JTree;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
+import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
-import java.awt.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,30 +38,30 @@ import java.util.List;
 /**
  * @author Joacim Breiler
  */
-public class EntitiesTree extends JPanel implements TreeSelectionListener, SelectionListener {
+public class EntitiesTree extends JTree implements TreeSelectionListener, SelectionListener {
 
     private transient Controller controller;
-    private final JTree tree;
 
-    public EntitiesTree(Controller controller) {
-        setLayout(new BorderLayout());
-        tree = new JTree();
-        tree.setEditable(true);
-        tree.setRootVisible(false);
-        tree.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        tree.setCellRenderer(new EntityCellRenderer(tree));
-        tree.setModel(new EntityTreeModel(controller));
-        tree.addTreeSelectionListener(this);
-        tree.expandRow(0);
+    public EntitiesTree(Controller controller, TreeModel treeModel) {
+        super(treeModel);
 
-        setBackground(tree.getBackground());
-        add(tree, BorderLayout.CENTER);
+        setEditable(true);
+        setRootVisible(false);
+        setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+        setCellRenderer(new EntityCellRenderer(this));
+        addTreeSelectionListener(this);
+        expandRow(0);
         updateController(controller);
+        ((EntityTreeModel) getModel()).notifyTreeStructureChanged(controller.getDrawing().getRootEntity());
     }
 
     private void updateController(Controller controller) {
         this.controller = controller;
         controller.getSelectionManager().addSelectionListener(this);
+    }
+
+    public void release() {
+        controller.getSelectionManager().removeSelectionListener(this);
     }
 
     @Override
@@ -79,6 +81,6 @@ public class EntitiesTree extends JPanel implements TreeSelectionListener, Selec
         EntityGroup rootEntity = (EntityGroup) controller.getDrawing().getRootEntity();
         List<TreePath> treePathList = EntityTreeUtils.getSelectedPaths(controller, rootEntity, Collections.emptyList());
         TreePath[] treePaths = treePathList.toArray(new TreePath[0]);
-        tree.setSelectionPaths(treePaths);
+        setSelectionPaths(treePaths);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntityCellRenderer.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntityCellRenderer.java
@@ -49,13 +49,6 @@ public class EntityCellRenderer extends DefaultTreeCellRenderer {
         return this;
     }
 
-    @Override
-    public Dimension getPreferredSize() {
-        Dimension preferredSize = super.getPreferredSize();
-        preferredSize.width = tree.getWidth();
-        return preferredSize;
-    }
-
     private Object getUserObject(Object value) {
         if (value instanceof DefaultMutableTreeNode) {
             return ((DefaultMutableTreeNode) value).getUserObject();

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntityTreeModel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntityTreeModel.java
@@ -45,6 +45,11 @@ public class EntityTreeModel implements TreeModel, ControllerListener, DrawingLi
         controller.getDrawing().addListener(this);
     }
 
+    public void release() {
+        controller.removeListener(this);
+        controller.getDrawing().removeListener(this);
+    }
+
     @Override
     public Object getRoot() {
         return controller.getDrawing().getRootEntity();
@@ -93,11 +98,7 @@ public class EntityTreeModel implements TreeModel, ControllerListener, DrawingLi
 
     protected void fireTreeStructureChanged(Object object) {
         List<Entity> selection = controller.getSelectionManager().getSelection();
-        TreeModelEvent e = new TreeModelEvent(this,
-                new Object[]{object});
-        for (TreeModelListener tml : treeModelListeners) {
-            tml.treeStructureChanged(e);
-        }
+        notifyTreeStructureChanged(object);
 
         // Restore old selection
         List<Entity> existingEntities = controller.getDrawing().getEntities();
@@ -105,6 +106,14 @@ public class EntityTreeModel implements TreeModel, ControllerListener, DrawingLi
                 .filter(existingEntities::contains)
                 .collect(Collectors.toList());
         controller.getSelectionManager().setSelection(newSelection);
+    }
+
+    public void notifyTreeStructureChanged(Object object) {
+        TreeModelEvent e = new TreeModelEvent(this,
+                new Object[]{object});
+        for (TreeModelListener tml : treeModelListeners) {
+            tml.treeStructureChanged(e);
+        }
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/Controller.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/Controller.java
@@ -87,8 +87,7 @@ public class Controller {
     }
 
     private void notifyListeners(ControllerEventType event) {
-        new ArrayList<>(listeners)
-                .forEach(l -> l.onControllerEvent(event));
+        listeners.forEach(l -> l.onControllerEvent(event));
     }
 
     public Settings getSettings() {
@@ -117,5 +116,9 @@ public class Controller {
 
     public void setCursor(Cursor cursor) {
         drawing.setCursor(cursor);
+    }
+
+    public void release() {
+        notifyListeners(ControllerEventType.RELEASE);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/ControllerEventType.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/ControllerEventType.java
@@ -23,5 +23,6 @@ package com.willwinder.ugs.nbp.designer.logic;
  */
 public enum ControllerEventType {
     NEW_DRAWING,
-    TOOL_SELECTED
+    TOOL_SELECTED,
+    RELEASE
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
@@ -148,6 +148,7 @@ public class DesignerTopComponent extends TopComponent implements UndoManagerLis
     protected void componentClosed() {
         super.componentClosed();
         controller.getUndoManager().removeListener(this);
+        controller.release();
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
@@ -19,11 +19,16 @@
 package com.willwinder.ugs.nbp.designer.platform;
 
 import com.willwinder.ugs.nbp.designer.gui.tree.EntitiesTree;
+import com.willwinder.ugs.nbp.designer.gui.tree.EntityTreeModel;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerEventType;
+import com.willwinder.ugs.nbp.designer.logic.ControllerListener;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import net.miginfocom.swing.MigLayout;
 import org.openide.windows.TopComponent;
 
-import javax.swing.*;
+import javax.swing.JScrollPane;
+import java.awt.BorderLayout;
 
 /**
  * @author Joacim Breiler
@@ -33,24 +38,43 @@ import javax.swing.*;
         persistenceType = TopComponent.PERSISTENCE_NEVER
 )
 @TopComponent.Registration(mode = "bottom_left", openAtStartup = false)
-public class EntitiesTreeTopComponent extends TopComponent {
+public class EntitiesTreeTopComponent extends TopComponent implements ControllerListener {
     private static final long serialVersionUID = 432423498723987873L;
-    private transient final EntitiesTree entitesTree;
+    private transient EntitiesTree entitesTree;
+    private transient EntityTreeModel entitiesTreeModel;
 
     public EntitiesTreeTopComponent() {
         setMinimumSize(new java.awt.Dimension(50, 50));
         setPreferredSize(new java.awt.Dimension(200, 200));
         setLayout(new java.awt.BorderLayout());
         setDisplayName("Design objects");
+    }
 
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
-        entitesTree = new EntitiesTree(controller);
+    @Override
+    protected void componentClosed() {
+        entitesTree.release();
+        entitesTree = null;
+
+        entitiesTreeModel.release();
+        entitiesTreeModel = null;
     }
 
     @Override
     protected void componentOpened() {
         super.componentOpened();
+        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        controller.addListener(this);
+        entitiesTreeModel = new EntityTreeModel(controller);
+        entitesTree = new EntitiesTree(controller, entitiesTreeModel);
+
         removeAll();
-        add(new JScrollPane(entitesTree));
+        add(new JScrollPane(entitesTree, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED), BorderLayout.CENTER);
+    }
+
+    @Override
+    public void onControllerEvent(ControllerEventType event) {
+        if (event == ControllerEventType.RELEASE) {
+            close();
+        }
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
@@ -20,6 +20,8 @@ package com.willwinder.ugs.nbp.designer.platform;
 
 import com.willwinder.ugs.nbp.designer.gui.SelectionSettingsPanel;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerEventType;
+import com.willwinder.ugs.nbp.designer.logic.ControllerListener;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.netbeans.api.settings.ConvertAsProperties;
 import org.openide.windows.TopComponent;
@@ -32,7 +34,7 @@ import org.openide.windows.TopComponent;
         persistenceType = TopComponent.PERSISTENCE_NEVER
 )
 @TopComponent.Registration(mode = "top_left", openAtStartup = false)
-public class SettingsTopComponent extends TopComponent {
+public class SettingsTopComponent extends TopComponent implements ControllerListener {
     private static final long serialVersionUID = 324234398723987873L;
 
     private transient final SelectionSettingsPanel selectionSettingsPanel;
@@ -45,6 +47,7 @@ public class SettingsTopComponent extends TopComponent {
 
         Controller controller = CentralLookup.getDefault().lookup(Controller.class);
         selectionSettingsPanel = new SelectionSettingsPanel(controller);
+        controller.addListener(this);
     }
 
     @Override
@@ -52,5 +55,12 @@ public class SettingsTopComponent extends TopComponent {
         super.componentOpened();
         removeAll();
         add(selectionSettingsPanel);
+    }
+
+    @Override
+    public void onControllerEvent(ControllerEventType event) {
+        if (event == ControllerEventType.RELEASE) {
+            close();
+        }
     }
 }


### PR DESCRIPTION
Fixed problem with the entity tree not expanding its rows when starting the designer. Now also closes related top components when the designer is closed.