### PR TITLE
Fixed macro shortcuts

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/types/Macro.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/types/Macro.java
@@ -5,11 +5,13 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
+import java.util.UUID;
 
 /**
  * Created by Phil on 9/6/2015.
  */
 public class Macro implements Serializable {
+    private String uuid = UUID.randomUUID().toString();
     private String name;
     private String description;
     private String gcode;
@@ -17,10 +19,15 @@ public class Macro implements Serializable {
     public Macro() {
     }
 
-    public Macro(String name, String description, String gcode) {
+    public Macro(String uuid, String name, String description, String gcode) {
+        this.uuid = uuid;
         this.name = name;
         this.description = description;
         this.gcode = gcode;
+    }
+
+    public String getUuid() {
+        return uuid;
     }
 
     public String getName() {
@@ -63,6 +70,7 @@ public class Macro implements Serializable {
     @Override
     public String toString() {
         return "Macro{" +
+                "uuid='" + uuid + '\'' +
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
                 ", gcode='" + gcode + '\'' +

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroSettingsPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroSettingsPanel.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -303,7 +304,7 @@ public class MacroSettingsPanel extends JPanel implements UGSEventListener {
 
         this.addButton.addActionListener(l -> {
             String macroName = findUniqueMacroName(macros.size());
-            macros.add(new Macro(macroName, null, ""));
+            macros.add(new Macro(UUID.randomUUID().toString(), macroName, null, ""));
             doLayout();
         });
 
@@ -352,7 +353,7 @@ public class MacroSettingsPanel extends JPanel implements UGSEventListener {
     }
 
     private String findUniqueMacroName(int index) {
-        final String macroName = "Macro #" + index;
+        final String macroName = "Macro #" + (index + 1);
         if (macros.stream().noneMatch(m ->
                 {
                     if (m.getName() != null) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/Settings.java
@@ -122,7 +122,7 @@ public class Settings {
         logger.fine("Initializing...");
 
         // Initialize macros with a default macro
-        macros.put(1, new Macro(null, null, "G91 X0 Y0;"));
+        macros.put(1, new Macro(UUID.randomUUID().toString(), "Go to XY zero", null, "G90 X0 Y0;"));
     }
 
     /**
@@ -130,23 +130,23 @@ public class Settings {
      */
     public void finalizeInitialization() {
         if (customGcode1 != null) {
-            updateMacro(1, null, null, customGcode1);
+            updateMacro("customGcode1", 1, null, null, customGcode1);
             customGcode1 = null;
         }
         if (customGcode2 != null) {
-            updateMacro(2, null, null, customGcode2);
+            updateMacro("customGcode2",2, null, null, customGcode2);
             customGcode2 = null;
         }
         if (customGcode3 != null) {
-            updateMacro(3, null, null, customGcode3);
+            updateMacro("customGcode3",3, null, null, customGcode3);
             customGcode3 = null;
         }
         if (customGcode4 != null) {
-            updateMacro(4, null, null, customGcode4);
+            updateMacro("customGcode4", 4, null, null, customGcode4);
             customGcode4 = null;
         }
         if (customGcode5 != null) {
-            updateMacro(5, null, null, customGcode5);
+            updateMacro("customGcode5", 5, null, null, customGcode5);
             customGcode5 = null;
         }
     }
@@ -323,7 +323,7 @@ public class Settings {
     public WindowSettings getMainWindowSettings() {
         return this.mainWindowSettings;
     }
-    
+
     public void setMainWindowSettings(WindowSettings ws) {
         this.mainWindowSettings = ws;
         changed();
@@ -332,7 +332,7 @@ public class Settings {
     public WindowSettings getVisualizerWindowSettings() {
         return this.visualizerWindowSettings;
     }
-    
+
     public void setVisualizerWindowSettings(WindowSettings vw) {
         this.visualizerWindowSettings = vw;
         changed();
@@ -364,7 +364,7 @@ public class Settings {
         this.statusUpdateRate = statusUpdateRate;
         changed();
     }
-        
+
     public Units getPreferredUnits() {
         return (preferredUnits == null) ? Units.MM : preferredUnits;
     }
@@ -414,14 +414,14 @@ public class Settings {
         return Collections.unmodifiableList(new ArrayList<>(macros.values()));
     }
 
-    public void updateMacro(Integer index, String name, String description, String gcode) {
+    public void updateMacro(String uuid, Integer index, String name, String description, String gcode) {
         if (gcode == null) {
             macros.remove(index);
         } else {
             if (name == null) {
                 name = index.toString();
             }
-            macros.put(index, new Macro(name, description, gcode));
+            macros.put(index, new Macro(uuid, name, description, gcode));
         }
         changed();
     }
@@ -434,7 +434,7 @@ public class Settings {
 
         return this.language;
     }
-    
+
     public void setLanguage (String language) {
         this.language = language;
         changed();

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
@@ -140,11 +140,11 @@ public class SettingsFactory {
                 out.setSingleStepMode(Boolean.valueOf(properties.getProperty("singleStepMode", FALSE)));
                 out.setStatusUpdatesEnabled(Boolean.valueOf(properties.getProperty("statusUpdatesEnabled", "true")));
                 out.setStatusUpdateRate(Integer.valueOf(properties.getProperty("statusUpdateRate", "200")));
-                out.updateMacro(1, null, null, properties.getProperty("customGcode1", "G0 X0 Y0;"));
-                out.updateMacro(2, null, null, properties.getProperty("customGcode2", "G0 G91 X10;G0 G91 Y10;"));
-                out.updateMacro(3, null, null, properties.getProperty("customGcode3", ""));
-                out.updateMacro(4, null, null, properties.getProperty("customGcode4", ""));
-                out.updateMacro(5, null, null, properties.getProperty("customGcode5", ""));
+                out.updateMacro("customGcode1", 1, null, null, properties.getProperty("customGcode1", "G0 X0 Y0;"));
+                out.updateMacro("customGcode2", 2, null, null, properties.getProperty("customGcode2", "G0 G91 X10;G0 G91 Y10;"));
+                out.updateMacro("customGcode3", 3, null, null, properties.getProperty("customGcode3", ""));
+                out.updateMacro("customGcode4", 4, null, null, properties.getProperty("customGcode4", ""));
+                out.updateMacro("customGcode5", 5, null, null, properties.getProperty("customGcode5", ""));
                 out.setLanguage(properties.getProperty("language", "en_US"));
                 saveSettings(out);
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/ThreadHelper.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/ThreadHelper.java
@@ -20,6 +20,7 @@ package com.willwinder.universalgcodesender.utils;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -40,8 +41,8 @@ public class ThreadHelper {
 
     private static final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(THREAD_POOL_SIZE);
 
-    static public void invokeLater(Runnable r) {
-        scheduledExecutor.submit(r);
+    static public Future<?> invokeLater(Runnable r) {
+        return scheduledExecutor.submit(r);
     }
 
     /**

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/Bundle.properties
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/Bundle.properties
@@ -3,3 +3,5 @@ OpenIDE-Module-Name=UGS Surface Scanner
 OpenIDE-Module-Short-Description=Surface scanning and gcode updater
 OpenIDE-Module-Long-Description=Utility for scanning the surface of a material, generating a 3D representation of that material, and adjusting gcode to contour along with the surface of that material.
 OpenIDE-Module-Display-Category=UGS Plugin
+AdvancedOption_DisplayName_AutoLeveler=Auto Leveler
+AdvancedOption_Keywords_AutoLeveler=autoleveler, surface scanner

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroAction.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroAction.java
@@ -6,12 +6,14 @@ import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.UGSEvent;
 import com.willwinder.universalgcodesender.model.events.ControllerStateEvent;
+import com.willwinder.universalgcodesender.model.events.SettingChangedEvent;
 import com.willwinder.universalgcodesender.types.Macro;
 import com.willwinder.universalgcodesender.utils.GUIHelpers;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.util.Exceptions;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.AbstractAction;
+import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.io.Serializable;
 
@@ -28,6 +30,7 @@ public class MacroAction extends AbstractAction implements Serializable {
     public MacroAction(Macro macro) {
         this.macro = macro;
         this.backend = getBackend();
+        updateMacroName();
     }
 
     private BackendAPI getBackend() {
@@ -40,8 +43,19 @@ public class MacroAction extends AbstractAction implements Serializable {
 
     private void onEvent(UGSEvent event) {
         if (event instanceof ControllerStateEvent) {
-           setEnabled(isEnabled());
+            setEnabled(isEnabled());
+        } else if (event instanceof SettingChangedEvent && macro != null) {
+            backend.getSettings().getMacros().stream().filter(m -> StringUtils.equalsIgnoreCase(m.getUuid(), macro.getUuid())).findFirst().ifPresent(m -> {
+                macro = m;
+                updateMacroName();
+            });
         }
+    }
+
+    private void updateMacroName() {
+        String name = macro.getName();
+        putValue(NAME, name);
+        putValue("menuText", name);
     }
 
     @Override

--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacroService.java
@@ -80,7 +80,7 @@ public final class MacroService {
                         text = macro.getNameAndDescription();
                     }
 
-                    ars.registerAction(MacroAction.class.getCanonicalName() + "." + macro.getName(), text, actionCategory, null, menuPath, index, localized, new MacroAction(macro));
+                    ars.registerAction(MacroAction.class.getCanonicalName() + "." + macro.getUuid(), text, actionCategory, null, menuPath, index, localized, new MacroAction(macro));
                 } catch (IOException e) {
                     logger.log(Level.WARNING, "Couldn't register macro action: \"" + macro.getName() + "\"", e);
                 }
@@ -89,6 +89,4 @@ public final class MacroService {
             logger.log(Level.WARNING, "Couldn't register macro actions", e);
         }
     }
-
-
 }


### PR DESCRIPTION
Added a UUID to macros in order to identify them uniquely. Previously the name was used to register the macro action which is then stored with that file name. The name may contain illegal characters for the file system which would break any macro shortcut. 

The name of the macro action was not updated which is now also fixed.

Fixes #1901 
Fixes #1862
Fixes #1827