### PR TITLE
fixes a possible bug in JSerialCommConnection.java that, due to re-us…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <miglayout.version>3.7.4</miglayout.version>
     <guava.version>28.1-jre</guava.version>
     <jssc.version>2.8.0</jssc.version>
-    <jserialcomm.version>2.6.2</jserialcomm.version>
+    <jserialcomm.version>2.9.2</jserialcomm.version>
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-io.version>2.11.0</commons-io.version>
     <commons-csv.version>1.9.0</commons-csv.version>


### PR DESCRIPTION
…e of a common buffer, could result in rx data being lost during overlapping serial event calls

updates jSerialComm to v2.9.2 (has many bug fixes since v2.6.2)

I've only tested this on MacOS.  This PR should be validated against other OS's, as well as trying to reproduce known MacOS jSerialComm hangs to see if the issue is really fixed. (I had a difficult time reliably reproducing the hangs).