### PR TITLE
fix(sec): upgrade jetty-server to 9.4.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <changelist>-SNAPSHOT</changelist>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.17.v20190418</jetty.version>
+    <jetty.version>9.4.41</jetty.version>
     <jersey.version>2.29.1</jersey.version>
     <gluegen.version>2.3.2</gluegen.version>
     <jogl.version>2.3.2</jogl.version>


### PR DESCRIPTION
Upgrade jetty-server from 9.4.17.v20190418 to 9.4.41 for vulnerability fix:
- [CVE-2020-27218](https://www.oscs1024.com/hd/MPS-2020-17594)
- [CVE-2020-27223](https://www.oscs1024.com/hd/MPS-2021-2571)
- [CVE-2021-34428](https://www.oscs1024.com/hd/MPS-2021-8884)