### PR TITLE
LineSplitter doesn't properly deal with relative coordinate mode (G91)

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -277,11 +277,11 @@ public class GcodePreprocessorUtils {
             }
             if (!Double.isNaN(end.y)) {
                 sb.append("Y");
-                sb.append(df.format(end.y-start.x));
+                sb.append(df.format(end.y-start.y));
             }
             if (!Double.isNaN(end.z)) {
                 sb.append("Z");
-                sb.append(df.format(end.z-start.x));
+                sb.append(df.format(end.z-start.z));
             }
         }
         

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/processors/LineSplitter.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/processors/LineSplitter.java
@@ -84,8 +84,12 @@ public class LineSplitter implements CommandProcessor {
 
         GcodeMeta command = Iterables.getLast(commands);
 
-        if (command == null || command.point == null) {
-            throw new GcodeParserException("Internal parser error: missing data.");
+        if (command == null) {
+            throw new GcodeParserException("Internal parser error: missing data. " + commandString);
+        }
+        if (command.point == null) {
+            // No point data associated with this command (Maybe just setting feed rate), leave it as-is
+            return Collections.singletonList(commandString);
         }
 
         // line length

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/processors/LineSplitterTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/processors/LineSplitterTest.java
@@ -19,6 +19,7 @@
 package com.willwinder.universalgcodesender.gcode.processors;
 
 import com.willwinder.universalgcodesender.gcode.GcodeState;
+import com.willwinder.universalgcodesender.gcode.util.Code;
 import com.willwinder.universalgcodesender.model.Position;
 import static com.willwinder.universalgcodesender.model.UnitUtils.Units.MM;
 import java.util.Arrays;
@@ -48,7 +49,19 @@ public class LineSplitterTest {
         List<String> result = instance.processCommand(command, state);
         assertEquals(expected, result);
     }
-    
+
+    private static void splitterHarnessRelativeMode(
+            double splitterLength, Position start, String command, List<String> expected) throws Exception {
+        LineSplitter instance = new LineSplitter(splitterLength);
+
+        GcodeState state = new GcodeState();
+        state.currentPoint = start;
+        state.inAbsoluteMode = false;
+
+        List<String> result = instance.processCommand(command, state);
+        assertEquals(expected, result);
+    }
+
     /**
      * Lines being split across each X/Y/Z axis.
      */
@@ -66,6 +79,25 @@ public class LineSplitterTest {
 
         expected = Arrays.asList("G1X0Y0Z0", "G1X0Y0Z1");
         splitterHarness(1, new Position(0, 0, -1, MM), "G1Z1", expected);
+    }
+
+    /**
+     * Lines being split across each X/Y/Z axis.
+     */
+    @Test
+    public void testSingleAxisRelative() throws Exception {
+        System.out.println("splitSingleAxis");
+
+        List<String> expected;
+
+        expected = Arrays.asList("G1X1Y0Z0", "G1X1Y0Z0");
+        splitterHarnessRelativeMode(1, new Position(-1, 0, 0, MM), "G1X2", expected);
+
+        expected = Arrays.asList("G1X0Y1Z0", "G1X0Y1Z0");
+        splitterHarnessRelativeMode(1, new Position(0, -1, 0, MM), "G1Y2", expected);
+
+        expected = Arrays.asList("G1X0Y0Z1", "G1X0Y0Z1");
+        splitterHarnessRelativeMode(1, new Position(0, 0, -1, MM), "G1Z2", expected);
     }
 
     /**
@@ -180,4 +212,5 @@ public class LineSplitterTest {
         List<String> expected = Arrays.asList("G1X0.3333Y0Z0", "G1X0.6667Y0Z0", "G1X1Y0Z0");
         splitterHarness(maxSegmentLength, new Position(0, 0, 0, MM), command, expected);
     }
+
 }


### PR DESCRIPTION
GcodePreprocessor was using x start axis for Y & Z
LineSplitter would incorrectly error out on a feed rate only command