### PR TITLE
Fix file encoding problems

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtils.java
@@ -34,8 +34,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -365,13 +367,13 @@ public class GcodeParserUtils {
      */
     public static void processAndExport(GcodeParser gcp, File input, IGcodeWriter output)
             throws IOException, GcodeParserException {
-        try(BufferedReader br = new BufferedReader(new FileReader(input))) {
+        try(BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(input), StandardCharsets.UTF_8.name()))) {
             if (processAndExportGcodeStream(gcp, br, output)) {
                 return;
             }
         }
 
-        try(BufferedReader br = new BufferedReader(new FileReader(input))) {
+        try(BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(input), StandardCharsets.UTF_8.name()))) {
             processAndExportText(gcp, br, output);
         }
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -43,8 +43,6 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.nio.charset.Charset;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -822,9 +820,6 @@ public class GUIBackend implements BackendAPI, ControllerListener, SettingChange
     private void initializeProcessedLines(boolean forceReprocess, File startFile, GcodeParser gcodeParser)
             throws Exception {
         if (startFile != null) {
-            try (FileReader fr = new FileReader(startFile)) {
-                Charset.forName(fr.getEncoding());
-            }
             logger.info("Start preprocessing");
             long start = System.currentTimeMillis();
             if (this.processedGcodeFile == null || forceReprocess) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroSettingsPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/macros/MacroSettingsPanel.java
@@ -44,9 +44,15 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -316,12 +322,14 @@ public class MacroSettingsPanel extends JPanel implements UGSEventListener {
                 try {
                     Collection<Macro> macros = backend.getSettings().getMacros();
 
-                    try (FileWriter fileWriter = new FileWriter(fileChooser.getSelectedFile())) {
+                    try (OutputStream fileOutputStream = new FileOutputStream(fileChooser.getSelectedFile())) {
+                        Writer writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
                         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                        fileWriter.write(gson.toJson(macros, Collection.class));
+                        writer.write(gson.toJson(macros, Collection.class));
+                        writer.flush();
                     }
                 } catch (Exception ex) {
-                    logger.log(Level.SEVERE, "Problem while browsing.", ex);
+                    logger.log(Level.SEVERE, "Problem while saving macros.", ex);
                     GUIHelpers.displayErrorDialog(ex.getMessage());
                 }
             }
@@ -333,9 +341,9 @@ public class MacroSettingsPanel extends JPanel implements UGSEventListener {
                 try {
                     File importFile = fileChooser.getSelectedFile();
 
-                    try (FileReader reader = new FileReader(importFile)) {
+                    try (InputStream reader = new FileInputStream(importFile)) {
                         Type type = new TypeToken<ArrayList<Macro>>(){}.getType();
-                        List<Macro> macros = new Gson().fromJson(reader, type);
+                        List<Macro> macros = new Gson().fromJson(new InputStreamReader(reader, StandardCharsets.UTF_8), type);
                         this.macros.addAll(macros);
 
                         // Update the window.

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeFileWriter.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeFileWriter.java
@@ -4,14 +4,15 @@ import com.willwinder.universalgcodesender.types.GcodeCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 public class GcodeFileWriter implements IGcodeWriter {
     private final File file;
     private final PrintWriter fileWriter;
 
-    public GcodeFileWriter(File f) throws FileNotFoundException {
+    public GcodeFileWriter(File f) throws FileNotFoundException, UnsupportedEncodingException {
         file = f;
-        fileWriter = new PrintWriter(f);
+        fileWriter = new PrintWriter(f, StandardCharsets.UTF_8.name());
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamReader.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamReader.java
@@ -23,9 +23,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Reads a 'GcodeStream' file containing command processing information, actual
@@ -58,7 +60,7 @@ public class GcodeStreamReader extends GcodeStream implements IGcodeStreamReader
     }
 
     public GcodeStreamReader(File f) throws NotGcodeStreamFile, FileNotFoundException {
-        this(new BufferedReader(new FileReader(f)));
+        this(new BufferedReader(new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8)));
     }
     
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamWriter.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/GcodeStreamWriter.java
@@ -1,13 +1,5 @@
 /*
- * GcodeStreamReader.java
- *
- * Reads a 'GcodeStream' file containing command processing information, actual
- * command to send and other metadata like total number of commands.
- *
- * Created on Jan 7, 2016
- */
-/*
-    Copyright 2016-2017 Will Winder
+    Copyright 2016-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -33,9 +25,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
- * Writes a "GcodeStream" file in a machine readable format.
+ * Writes a "GcodeStream" file in a machine readable format containing command processing
+ * information, actual command to send and other metadata like total number of commands.
+ *
  * @author wwinder
  */
 public class GcodeStreamWriter extends GcodeStream implements IGcodeWriter {
@@ -47,10 +43,14 @@ public class GcodeStreamWriter extends GcodeStream implements IGcodeWriter {
 
     public GcodeStreamWriter(File f) throws FileNotFoundException {
         file = f;
-        fileWriter = new PrintWriter(f);
-        // 50 bytes at the beginning of the file to store metadata
-        fileWriter.append(metadataReservedSize);
-        fileWriter.append("\n");
+        try {
+            fileWriter = new PrintWriter(f, StandardCharsets.UTF_8.name());
+            // 50 bytes at the beginning of the file to store metadata
+            fileWriter.append(metadataReservedSize);
+            fileWriter.append("\n");
+        } catch (UnsupportedEncodingException e) {
+            throw new FileNotFoundException("Could not use UTF-8 to output gcode stream file");
+        }
     }
 
     private String getString(String str) {
@@ -89,7 +89,7 @@ public class GcodeStreamWriter extends GcodeStream implements IGcodeWriter {
     }
 
     public void addLine(String original, String processed, String comment, int commandNumber) {
-        if (    (original != null && original.trim().contains("\n")) || 
+        if ((original != null && original.trim().contains("\n")) ||
                 (processed != null && processed.trim().contains("\n")) ||
                 (comment != null && comment.trim().contains("\n"))) {
             throw new IllegalArgumentException("Cannot include newlines in gcode stream.");

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/SettingsFactory.java
@@ -24,6 +24,7 @@ import com.willwinder.universalgcodesender.i18n.Localization;
 import org.apache.commons.io.FileUtils;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -52,18 +53,14 @@ public class SettingsFactory {
             if (!settingsFile.exists()) {
                 settings = new Settings();
             } else {
-                try {
-                    //logger.log(Level.INFO, "{0}: {1}", new Object[]{Localization.getString("settings.log.location"), settingsFile});
+                try (InputStream fileInputStream = new FileInputStream(settingsFile)){
                     logger.log(Level.INFO, "Log location: {0}", settingsFile.getAbsolutePath());
                     logger.info("Loading settings.");
-                    settings = new Gson().fromJson(new FileReader(settingsFile), Settings.class);
+                    settings = new Gson().fromJson(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8), Settings.class);
                     if (settings != null) {
                         settings.finalizeInitialization();
                     }
-                    // Localized setting not available here.
-                    //logger.info(Localization.getString("settings.log.loading"));
-                } catch (FileNotFoundException ex) {
-                    //logger.warning(Localization.getString("settings.log.error"));
+                } catch (IOException ex) {
                     logger.log(Level.SEVERE, "Can't load settings, using defaults.", ex);
                 }
             }
@@ -80,12 +77,12 @@ public class SettingsFactory {
         try {
             // Save json file.
             File jsonFile = getSettingsFile();
-            try (FileWriter fileWriter = new FileWriter(jsonFile)) {
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(jsonFile), StandardCharsets.UTF_8)) {
                 Gson gson = new GsonBuilder()
                         .setPrettyPrinting()
                         .serializeSpecialFloatingPointValues()
                         .create();
-                fileWriter.write(gson.toJson(settings, Settings.class));
+                writer.write(gson.toJson(settings, Settings.class));
             }
          } catch (Exception e) {
             logger.log(Level.SEVERE, Localization.getString("settings.log.saveerror"), e);

--- a/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendPreprocessorTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendPreprocessorTest.java
@@ -26,6 +26,7 @@ import com.willwinder.universalgcodesender.gcode.util.GcodeParserException;
 import com.willwinder.universalgcodesender.utils.GcodeStreamReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -117,7 +118,7 @@ public class GUIBackendPreprocessorTest {
 
         // Create GcodeStream input file by putting it through the preprocessor.
         List<String> lines = Arrays.asList("line one", "line two");
-        Files.write(outputFile, lines, Charset.defaultCharset(), StandardOpenOption.WRITE);
+        Files.write(outputFile, lines, StandardCharsets.UTF_8, StandardOpenOption.WRITE);
         try (IGcodeWriter gcw = new GcodeStreamWriter(inputFile.toFile())) {
             backend.preprocessAndExportToFile(gcp, outputFile.toFile(), gcw);
         }

--- a/ugs-core/test/com/willwinder/universalgcodesender/utils/GcodeStreamTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/utils/GcodeStreamTest.java
@@ -21,6 +21,7 @@ package com.willwinder.universalgcodesender.utils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
@@ -60,7 +61,7 @@ public class GcodeStreamTest {
     @Test(expected=GcodeStreamReader.NotGcodeStreamFile.class)
     public void testNotGcodeStream() throws FileNotFoundException, IOException, GcodeStreamReader.NotGcodeStreamFile {
         File f = new File(tempDir,"gcodeFile");
-        try (PrintWriter writer = new PrintWriter(f)) {
+        try (PrintWriter writer = new PrintWriter(f, StandardCharsets.UTF_8.name())) {
             writer.println("invalid format");
         }
        
@@ -120,7 +121,8 @@ public class GcodeStreamTest {
             }
         }
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(f))) {
+        try (InputStream fileInputStream = new FileInputStream(f)) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8));
             int i = 0;
             while (reader.ready()) {
                 String c = "";

--- a/ugs-platform/DowelModule/src/main/java/com/willwinder/ugs/platform/dowel/DowelTopComponent.java
+++ b/ugs-platform/DowelModule/src/main/java/com/willwinder/ugs/platform/dowel/DowelTopComponent.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2017-2018 Will Winder
+    Copyright 2017-2022 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -44,8 +44,8 @@ import org.openide.windows.TopComponent;
 import java.awt.*;
 import java.io.PrintWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -215,7 +215,7 @@ public final class DowelTopComponent extends TopComponent {
 
   private void generateAndLoadGcode(File file) {
     try {
-      try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
+      try (PrintWriter writer = new PrintWriter(file, StandardCharsets.UTF_8.name())) {
         generator.generate(writer);
       }
       backend.setGcodeFile(file);

--- a/ugs-platform/GcodeTools/src/main/java/com/willwinder/ugp/tools/GcodeTilerTopComponent.java
+++ b/ugs-platform/GcodeTools/src/main/java/com/willwinder/ugp/tools/GcodeTilerTopComponent.java
@@ -49,10 +49,10 @@ import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -186,7 +186,7 @@ public final class GcodeTilerTopComponent extends TopComponent {
   private void generateAndLoadGcode(File file) {
     try {
       if (this.outputFile == null) {
-        try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
+        try (PrintWriter writer = new PrintWriter(file, StandardCharsets.UTF_8.name())) {
           double padding = SwingHelpers.getDouble(this.padding);
           double stepX = padding + GcodeTilerTopComponent.xWidth;
           double stepY = padding + GcodeTilerTopComponent.yWidth;
@@ -267,7 +267,7 @@ public final class GcodeTilerTopComponent extends TopComponent {
         try (
             FileInputStream fstream = new FileInputStream(file);
             DataInputStream dis = new DataInputStream(fstream);
-            BufferedReader fileStream = new BufferedReader(new InputStreamReader(dis))) {
+            BufferedReader fileStream = new BufferedReader(new InputStreamReader(dis, StandardCharsets.UTF_8))) {
           String line;
           while ((line = fileStream.readLine()) != null) {
             applyTranslation(line, parser, output);


### PR DESCRIPTION
Now assumes that gcode files are in UTF-8.
Settings, macros and other files written by UGS will now be in UTF-8.

Possible fix for #2078 and #2011