### PR TITLE
Mappable shortcuts in the designer

### DIFF
--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/AbstractRotateAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/AbstractRotateAction.java
@@ -29,7 +29,6 @@ import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UGSEvent;
 import com.willwinder.universalgcodesender.model.events.ControllerStateEvent;
-import com.willwinder.universalgcodesender.model.events.FileState;
 import com.willwinder.universalgcodesender.model.events.FileStateEvent;
 import com.willwinder.universalgcodesender.uielements.helpers.LoaderDialogHelper;
 import com.willwinder.universalgcodesender.utils.*;

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
@@ -1,17 +1,26 @@
 package com.willwinder.ugs.nbp.designer;
 
-import com.willwinder.ugs.nbp.designer.actions.SimpleUndoManager;
 import com.willwinder.ugs.nbp.designer.actions.UndoManager;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
-import com.willwinder.ugs.nbp.designer.gui.*;
+import com.willwinder.ugs.nbp.designer.gui.DrawingContainer;
+import com.willwinder.ugs.nbp.designer.gui.MainMenu;
+import com.willwinder.ugs.nbp.designer.gui.PopupMenuFactory;
+import com.willwinder.ugs.nbp.designer.gui.SelectionSettingsPanel;
+import com.willwinder.ugs.nbp.designer.gui.ToolBox;
 import com.willwinder.ugs.nbp.designer.gui.tree.EntitiesTree;
 import com.willwinder.ugs.nbp.designer.gui.tree.EntityTreeModel;
 import com.willwinder.ugs.nbp.designer.io.svg.SvgReader;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JFrame;
+import javax.swing.JMenuBar;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.WindowConstants;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
 
 /**
  * A test implementation of the gcode designer tool that works in stand alone mode
@@ -21,26 +30,28 @@ import java.awt.*;
 public class DesignerMain extends JFrame {
 
     private static final long serialVersionUID = 0;
+    public static final String PROPERTY_IS_STANDALONE = "ugs.designer.standalone";
+    public static final String PROPERTY_USE_SCREEN_MENU = "apple.laf.useScreenMenuBar";
 
     /**
      * Constructs a new graphical user interface for the program and shows it.
      */
     public DesignerMain() {
-        System.setProperty("apple.laf.useScreenMenuBar", "true");
-
+        System.setProperty(PROPERTY_USE_SCREEN_MENU, "true");
+        System.setProperty(PROPERTY_IS_STANDALONE, "true");
 
         setTitle("UGS Designer");
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         setPreferredSize(new Dimension(1024, 768));
 
-        UndoManager undoManager = new SimpleUndoManager();
+        Controller controller = ControllerFactory.getController();
+        CentralLookup.getDefault().add(controller);
+
+        UndoManager undoManager = ControllerFactory.getUndoManager();
         CentralLookup.getDefault().add(undoManager);
 
-        SelectionManager selectionManager = new SelectionManager();
+        SelectionManager selectionManager = ControllerFactory.getSelectionManager();
         CentralLookup.getDefault().add(selectionManager);
-
-        Controller controller = new Controller(selectionManager, undoManager);
-        CentralLookup.getDefault().add(controller);
 
         DrawingContainer drawingContainer = new DrawingContainer(controller);
         selectionManager.addSelectionListener(e -> drawingContainer.repaint());
@@ -64,13 +75,13 @@ public class DesignerMain extends JFrame {
         setVisible(true);
 
         loadExample(controller);
-        controller.getDrawing().setComponentPopupMenu(new PopupMenuFactory().createPopupMenu(controller));
+        controller.getDrawing().setComponentPopupMenu(new PopupMenuFactory().createPopupMenu());
         controller.getDrawing().repaint();
     }
 
     private JSplitPane createRightPanel(Controller controller) {
         EntityTreeModel entityTreeModel = new EntityTreeModel(controller);
-        JSplitPane toolsSplit = new JSplitPane( JSplitPane.VERTICAL_SPLIT, new JScrollPane(new EntitiesTree(controller, entityTreeModel)), new SelectionSettingsPanel(controller));
+        JSplitPane toolsSplit = new JSplitPane(JSplitPane.VERTICAL_SPLIT, new JScrollPane(new EntitiesTree(controller, entityTreeModel)), new SelectionSettingsPanel(controller));
         toolsSplit.setResizeWeight(0.9);
         return toolsSplit;
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/DesignerMain.java
@@ -75,7 +75,7 @@ public class DesignerMain extends JFrame {
         setVisible(true);
 
         loadExample(controller);
-        controller.getDrawing().setComponentPopupMenu(new PopupMenuFactory().createPopupMenu());
+        controller.getDrawing().setComponentPopupMenu(PopupMenuFactory.createPopupMenu());
         controller.getDrawing().repaint();
     }
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/Utils.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/Utils.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import java.awt.geom.Point2D;
 import java.text.ParseException;
 
+import static com.willwinder.ugs.nbp.designer.DesignerMain.PROPERTY_IS_STANDALONE;
+
 /**
  * @author Joacim Breiler
  */
@@ -112,5 +114,15 @@ public class Utils {
             power = 1;
         }
         return Math.round(value * power) / power;
+    }
+
+    /**
+     * Returns if the application is stand alone. This is a work around for
+     * the netbeans platform that uses DataObjects to open files.
+     *
+     * @return true if we are running in our own main
+     */
+    public static boolean isStandalone() {
+        return Boolean.parseBoolean(System.getProperty(PROPERTY_IS_STANDALONE));
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/AbstractDesignAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/AbstractDesignAction.java
@@ -1,0 +1,72 @@
+/*
+    Copyright 2023 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.actions;
+
+import com.willwinder.ugs.nbp.designer.Utils;
+import com.willwinder.ugs.nbp.designer.platform.UgsDataObject;
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.listeners.UGSEventListener;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import com.willwinder.universalgcodesender.model.UGSEvent;
+import com.willwinder.universalgcodesender.model.events.ControllerStateEvent;
+import org.openide.util.Lookup;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
+import org.openide.util.Utilities;
+
+import javax.swing.AbstractAction;
+
+/**
+ * An abstract action class for design actions. This will listen if a connected machine is idle or
+ * that a file has been loaded
+ *
+ * @author Joacim Breiler
+ */
+public abstract class AbstractDesignAction extends AbstractAction implements LookupListener, UGSEventListener {
+    private final transient BackendAPI backendAPI;
+    private final transient Lookup context;
+
+    protected AbstractDesignAction() {
+        this(Utilities.actionsGlobalContext());
+    }
+
+    protected AbstractDesignAction(Lookup context) {
+        super();
+        this.context = context;
+        backendAPI = CentralLookup.getDefault().lookup(BackendAPI.class);
+        backendAPI.addUGSEventListener(this);
+
+        Lookup.Result<UgsDataObject> lookupResult = context.lookupResult(UgsDataObject.class);
+        lookupResult.addLookupListener(this);
+    }
+
+    @Override
+    public void resultChanged(LookupEvent ev) {
+        boolean isIdleOrDisconnected = (backendAPI.isConnected() && backendAPI.isIdle()) || !backendAPI.isConnected();
+        boolean isFileLoaded = Utils.isStandalone() || (!context.lookupAll(UgsDataObject.class).isEmpty());
+        setEnabled(isIdleOrDisconnected && isFileLoaded);
+    }
+
+    @Override
+    public void UGSEvent(UGSEvent event) {
+        if (event instanceof ControllerStateEvent) {
+            resultChanged(null);
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/AddAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/AddAction.java
@@ -21,7 +21,6 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.designer.entities.Entity;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,7 +32,7 @@ import java.util.List;
  *
  * @author Joacim Breiler
  */
-public class AddAction extends AbstractAction implements DrawAction, UndoableAction {
+public class AddAction extends AbstractDesignAction implements DrawAction, UndoableAction {
 
     private final transient Controller controller;
     private final transient List<Entity> entities;

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/BreakApartAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/BreakApartAction.java
@@ -26,14 +26,17 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.io.gcode.toolpaths.ToolPathUtils;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import org.locationtech.jts.awt.ShapeWriter;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.geom.Area;
 import java.util.ArrayList;
@@ -47,19 +50,26 @@ import java.util.stream.Collectors;
  *
  * @author Joacim Breiler
  */
-public class BreakApartAction extends AbstractAction implements SelectionListener {
-    private static final String SMALL_ICON_PATH = "img/break.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "BreakApartAction")
+@ActionRegistration(
+        iconBase = BreakApartAction.SMALL_ICON_PATH,
+        displayName = "Break apart",
+        lazy = false)
+public class BreakApartAction extends AbstractDesignAction implements SelectionListener {
+    public static final String SMALL_ICON_PATH = "img/break.svg";
     private static final String LARGE_ICON_PATH = "img/break24.svg";
     private final transient Controller controller;
 
-    public BreakApartAction(Controller controller) {
+    public BreakApartAction() {
         putValue("menuText", "Break apart");
         putValue(NAME, "Break apart");
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);
         onSelectionEvent(new SelectionEvent());

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ClearSelectionAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ClearSelectionAction.java
@@ -22,6 +22,10 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
 import javax.swing.*;
@@ -30,6 +34,13 @@ import java.awt.event.ActionEvent;
 /**
  * @author Joacim Breiler
  */
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ClearSelectionAction")
+@ActionRegistration(
+        iconBase = ClearSelectionAction.SMALL_ICON_PATH,
+        displayName = "Clear selection",
+        lazy = false)
 public class ClearSelectionAction extends AbstractAction implements SelectionListener {
 
     public static final String SMALL_ICON_PATH = "img/clear-selection.svg";
@@ -37,14 +48,14 @@ public class ClearSelectionAction extends AbstractAction implements SelectionLis
 
     private final transient SelectionManager selectionManager;
 
-    public ClearSelectionAction(Controller controller) {
+    public ClearSelectionAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Clear selection");
         putValue(NAME, "Clear selection");
 
-        selectionManager = controller.getSelectionManager();
+        selectionManager = ControllerFactory.getSelectionManager();
         selectionManager.addSelectionListener(this);
         setEnabled(!selectionManager.getSelection().isEmpty());
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/CopyAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/CopyAction.java
@@ -5,6 +5,7 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignWriter;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
@@ -24,15 +25,15 @@ import java.awt.event.ActionEvent;
                 path = "Shortcuts",
                 name = "D-C")
 })
-public class CopyAction extends AbstractAction implements SelectionListener {
+public class CopyAction extends AbstractDesignAction implements SelectionListener {
 
     private final transient Controller controller;
 
-    public CopyAction(Controller controller) {
+    public CopyAction() {
         putValue("menuText", "Copy");
         putValue(NAME, "Copy");
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
 
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/DeleteAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/DeleteAction.java
@@ -24,6 +24,7 @@ import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
@@ -48,7 +49,7 @@ import java.util.List;
                 path = "Shortcuts",
                 name = "BACK_SPACE")
 })
-public class DeleteAction extends AbstractAction implements SelectionListener {
+public class DeleteAction extends AbstractDesignAction implements SelectionListener {
 
     private static final String SMALL_ICON_PATH = "img/delete.svg";
     private static final String LARGE_ICON_PATH = "img/delete24.svg";
@@ -58,14 +59,14 @@ public class DeleteAction extends AbstractAction implements SelectionListener {
      * Creates an DeleteAction that removes all shapes in the given Selection
      * from the given Drawing.
      */
-    public DeleteAction(Controller controller) {
+    public DeleteAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Delete");
         putValue(NAME, "Delete");
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
 
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ExportGcodeAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ExportGcodeAction.java
@@ -25,7 +25,6 @@ import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.universalgcodesender.utils.SwingHelpers;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.util.Optional;
@@ -33,7 +32,7 @@ import java.util.Optional;
 /**
  * @author Joacim Breiler
  */
-public class ExportGcodeAction extends AbstractAction {
+public class ExportGcodeAction extends AbstractDesignAction {
     public static final String SMALL_ICON_PATH = "img/export.svg";
     public static final String LARGE_ICON_PATH = "img/export24.svg";
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ExportPngAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ExportPngAction.java
@@ -22,7 +22,6 @@ import com.willwinder.ugs.nbp.designer.io.png.PngWriter;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -32,7 +31,7 @@ import java.io.File;
 /**
  * @author Joacim Breiler
  */
-public class ExportPngAction extends AbstractAction {
+public class ExportPngAction extends AbstractDesignAction {
 
     private static final String SMALL_ICON_PATH = "img/export.svg";
     private static final String LARGE_ICON_PATH = "img/export24.svg";

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/FlipHorizontallyAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/FlipHorizontallyAction.java
@@ -7,20 +7,30 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.gui.Drawing;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.util.List;
 
-public class FlipHorizontallyAction extends AbstractAction implements SelectionListener {
-    private static final String SMALL_ICON_PATH = "img/flip-horizontal.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "FlipHorizontallyAction")
+@ActionRegistration(
+        iconBase = FlipHorizontallyAction.SMALL_ICON_PATH,
+        displayName = "Flip horizontally",
+        lazy = false)
+public class FlipHorizontallyAction extends AbstractDesignAction implements SelectionListener {
+    public static final String SMALL_ICON_PATH = "img/flip-horizontal.svg";
     private static final String LARGE_ICON_PATH = "img/flip-horizontal24.svg";
     private final transient Controller controller;
 
-    public FlipHorizontallyAction(Controller controller) {
+    public FlipHorizontallyAction() {
         putValue("menuText", "Flip horizontally");
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
@@ -28,7 +38,7 @@ public class FlipHorizontallyAction extends AbstractAction implements SelectionL
 
         putValue(NAME, "Flip horizontally");
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
 
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/FlipVerticallyAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/FlipVerticallyAction.java
@@ -7,27 +7,37 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.gui.Drawing;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.util.List;
 
-public class FlipVerticallyAction extends AbstractAction implements SelectionListener {
-    private static final String SMALL_ICON_PATH = "img/flip-vertical.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "FlipVerticallyAction")
+@ActionRegistration(
+        iconBase = FlipVerticallyAction.SMALL_ICON_PATH,
+        displayName = "Flip vertically",
+        lazy = false)
+public class FlipVerticallyAction extends AbstractDesignAction implements SelectionListener {
+    public static final String SMALL_ICON_PATH = "img/flip-vertical.svg";
     private static final String LARGE_ICON_PATH = "img/flip-vertical24.svg";
     private final transient Controller controller;
 
-    public FlipVerticallyAction(Controller controller) {
+    public FlipVerticallyAction() {
         putValue("menuText", "Flip vertically");
         putValue(NAME, "Flip vertically");
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
 
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/IntersectionAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/IntersectionAction.java
@@ -25,9 +25,12 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.geom.Area;
 import java.util.List;
@@ -38,19 +41,26 @@ import java.util.List;
  *
  * @author Joacim Breiler
  */
-public class IntersectionAction extends AbstractAction implements SelectionListener {
-    private static final String SMALL_ICON_PATH = "img/intersection.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "IntersectionAction")
+@ActionRegistration(
+        iconBase = IntersectionAction.SMALL_ICON_PATH,
+        displayName = "Intersection",
+        lazy = false)
+public class IntersectionAction extends AbstractDesignAction implements SelectionListener {
+    public static final String SMALL_ICON_PATH = "img/intersection.svg";
     private static final String LARGE_ICON_PATH = "img/intersection24.svg";
     private final transient Controller controller;
 
-    public IntersectionAction(Controller controller) {
+    public IntersectionAction() {
         putValue("menuText", "Intersection");
         putValue(NAME, "Intersection");
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);
         setEnabled(selectionManager.getSelection().size() == 2);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/MultiplyAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/MultiplyAction.java
@@ -23,10 +23,13 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.gui.MultiplyDialog;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 
 /**
@@ -35,19 +38,26 @@ import java.awt.event.ActionEvent;
  *
  * @author Joacim Breiler
  */
-public class MultiplyAction extends AbstractAction implements SelectionListener {
-    private static final String SMALL_ICON_PATH = "img/multiply.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "MultiplyAction")
+@ActionRegistration(
+        iconBase = MultiplyAction.SMALL_ICON_PATH,
+        displayName = "Multiply",
+        lazy = false)
+public class MultiplyAction extends AbstractDesignAction implements SelectionListener {
+    public static final String SMALL_ICON_PATH = "img/multiply.svg";
     private static final String LARGE_ICON_PATH = "img/multiply24.svg";
     private final transient Controller controller;
 
-    public MultiplyAction(Controller controller) {
+    public MultiplyAction() {
         putValue("menuText", "Multiply");
         putValue(NAME, "Multiply");
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
 
-        this.controller = controller;
+        controller = ControllerFactory.getController();
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);
         setEnabled(!selectionManager.isEmpty());

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/NewAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/NewAction.java
@@ -18,18 +18,17 @@
  */
 package com.willwinder.ugs.nbp.designer.actions;
 
-import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
+import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class NewAction extends AbstractAction {
+public class NewAction extends AbstractDesignAction {
 
     public static final String SMALL_ICON_PATH = "img/new.svg";
     public static final String LARGE_ICON_PATH = "img/new24.svg";

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/OpenAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/OpenAction.java
@@ -29,17 +29,17 @@ import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
+import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.util.Optional;
 
-public class OpenAction extends AbstractAction {
+public class OpenAction extends AbstractDesignAction {
+    public static final FileFilter DESIGN_FILE_FILTER = new FileNameExtensionFilter("UGS Design (ugsd)", "ugsd");
     private static final String ICON_SMALL_PATH = "img/open.svg";
     private static final String ICON_LARGE_PATH = "img/open24.svg";
-    public static final FileFilter DESIGN_FILE_FILTER = new FileNameExtensionFilter("UGS Design (ugsd)", "ugsd");
     private static final FileFilter SVG_FILE_FILTER = new FileNameExtensionFilter("Scalable Vector Graphics (svg)", "svg");
     private static final FileFilter C2D_FILE_FILTER = new FileNameExtensionFilter("Carbide Create (c2d)", "c2d");
     private final JFileChooser fileChooser;

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/PasteAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/PasteAction.java
@@ -4,12 +4,12 @@ import com.google.gson.JsonSyntaxException;
 import com.willwinder.ugs.nbp.designer.entities.Entity;
 import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignReader;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -27,15 +27,15 @@ import java.util.logging.Logger;
                 path = "Shortcuts",
                 name = "D-V")
 })
-public class PasteAction extends AbstractAction {
+public class PasteAction extends AbstractDesignAction {
 
     private static final Logger LOGGER = Logger.getLogger(PasteAction.class.getSimpleName());
     private final transient Controller controller;
 
-    public PasteAction(Controller controller) {
+    public PasteAction() {
         putValue("menuText", "Paste");
         putValue(NAME, "Paste");
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/QuitAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/QuitAction.java
@@ -20,13 +20,12 @@ package com.willwinder.ugs.nbp.designer.actions;
 
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class QuitAction extends AbstractAction {
+public class QuitAction extends AbstractDesignAction {
     private static final String ICON_SMALL_PATH = "img/exit.svg";
     private static final String ICON_LARGE_PATH = "img/exit24.svg";
 
@@ -37,7 +36,7 @@ public class QuitAction extends AbstractAction {
         putValue("menuText", "Quit");
         putValue(NAME, "Quit");
     }
-    
+
     @Override
     public void actionPerformed(ActionEvent e) {
         System.exit(0);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/RedoAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/RedoAction.java
@@ -21,13 +21,12 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class RedoAction extends AbstractAction implements UndoManagerListener {
+public class RedoAction extends AbstractDesignAction implements UndoManagerListener {
     public static final String SMALL_ICON_PATH = "img/redo.svg";
     public static final String LARGE_ICON_PATH = "img/redo24.svg";
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SaveAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SaveAction.java
@@ -18,19 +18,18 @@
  */
 package com.willwinder.ugs.nbp.designer.actions;
 
-import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignWriter;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
+import javax.swing.JFileChooser;
 import java.awt.event.ActionEvent;
 import java.io.File;
 
 /**
  * @author Joacim Breiler
  */
-public class SaveAction extends AbstractAction {
+public class SaveAction extends AbstractDesignAction {
     private static final String ICON_SMALL_PATH = "img/save.svg";
     private static final String ICON_LARGE_PATH = "img/save24.svg";
     private final transient Controller controller;
@@ -58,10 +57,7 @@ public class SaveAction extends AbstractAction {
 
         File f = fileDialog.getSelectedFile();
         if (f != null) {
-            ThreadHelper.invokeLater(() -> {
-                UgsDesignWriter writer = new UgsDesignWriter();
-                writer.write(f, controller);
-            });
+            ThreadHelper.invokeLater(() -> controller.saveFile(f));
         }
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SelectAllAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SelectAllAction.java
@@ -18,17 +18,17 @@
  */
 package com.willwinder.ugs.nbp.designer.actions;
 
+import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.gui.DrawingEvent;
 import com.willwinder.ugs.nbp.designer.gui.DrawingListener;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
-import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 
 /**
@@ -42,21 +42,21 @@ import java.awt.event.ActionEvent;
                 path = "Shortcuts",
                 name = "D-A")
 })
-public class SelectAllAction extends AbstractAction implements DrawingListener {
+public class SelectAllAction extends AbstractDesignAction implements DrawingListener {
 
     public static final String SMALL_ICON_PATH = "img/select-all.svg";
     public static final String LARGE_ICON_PATH = "img/select-all24.svg";
 
     private final transient Controller controller;
 
-    public SelectAllAction(Controller controller) {
+    public SelectAllAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Select all");
         putValue(NAME, "Select all");
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
 
         setEnabled(!this.controller.getDrawing().getEntities().isEmpty());
         this.controller.getDrawing().addListener(this);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SubtractAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SubtractAction.java
@@ -26,9 +26,12 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.geom.Area;
 import java.util.List;
@@ -39,19 +42,26 @@ import java.util.List;
  *
  * @author Joacim Breiler
  */
-public class SubtractAction extends AbstractAction implements SelectionListener {
-    private static final String SMALL_ICON_PATH = "img/subtract.svg";
-    private static final String LARGE_ICON_PATH = "img/subtract24.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "SubtractAction")
+@ActionRegistration(
+        iconBase = SubtractAction.SMALL_ICON_PATH,
+        displayName = "Subtract",
+        lazy = false)
+public class SubtractAction extends AbstractDesignAction implements SelectionListener {
+    public static final String SMALL_ICON_PATH = "img/subtract.svg";
+    public static final String LARGE_ICON_PATH = "img/subtract24.svg";
     private final transient Controller controller;
 
-    public SubtractAction(Controller controller) {
+    public SubtractAction() {
         putValue("menuText", "Subtract");
         putValue(NAME, "Subtract");
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);
         setEnabled(selectionManager.getSelection().size() >= 2);
@@ -85,7 +95,7 @@ public class SubtractAction extends AbstractAction implements SelectionListener 
             for (int i = 1; i < entities.size(); i++) {
                 Entity entity = entities.get(i);
                 if (entity instanceof Group) {
-                   ((Group) entity).getAllChildren().forEach(groupEntity -> area.subtract(new Area(groupEntity.getShape())));
+                    ((Group) entity).getAllChildren().forEach(groupEntity -> area.subtract(new Area(groupEntity.getShape())));
                 } else {
                     area.subtract(new Area(entity.getShape()));
                 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolClipartAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolClipartAction.java
@@ -21,30 +21,38 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.designer.gui.clipart.Clipart;
 import com.willwinder.ugs.nbp.designer.gui.clipart.InsertClipartDialog;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.util.Optional;
 
 /**
  * @author Joacim Breiler
  */
-public final class ToolClipartAction extends AbstractAction {
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolClipartAction")
+@ActionRegistration(
+        iconBase = ToolClipartAction.SMALL_ICON_PATH,
+        displayName = "Insert clipart",
+        lazy = false)
+public final class ToolClipartAction extends AbstractDesignAction {
 
     public static final String SMALL_ICON_PATH = "img/clipart.svg";
     public static final String LARGE_ICON_PATH = "img/clipart24.svg";
-    private final transient Controller controller;
 
-    public ToolClipartAction(Controller controller) {
+    public ToolClipartAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Insert clipart");
         putValue(NAME, "Insert clipart");
-        this.controller = controller;
     }
 
     @Override
@@ -52,7 +60,7 @@ public final class ToolClipartAction extends AbstractAction {
         InsertClipartDialog dialog = new InsertClipartDialog();
         ThreadHelper.invokeLater(() -> {
             Optional<Clipart> optionalClipart = dialog.showDialog();
-
+            Controller controller = ControllerFactory.getController();
             if (optionalClipart.isPresent()) {
                 AddAction addAction = new AddAction(controller, optionalClipart.get().getCuttable());
                 addAction.actionPerformed(e);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawCircleAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawCircleAction.java
@@ -19,31 +19,40 @@
 package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class ToolDrawCircleAction extends AbstractAction {
-    private static final String ICON_SMALL_PATH = "img/circle.svg";
-    private static final String ICON_LARGE_PATH = "img/circle24.svg";
-    private final transient Controller controller;
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolDrawCircleAction")
+@ActionRegistration(
+        iconBase = ToolDrawCircleAction.ICON_SMALL_PATH,
+        displayName = "Draw circle",
+        lazy = false)
+public class ToolDrawCircleAction extends AbstractDesignAction {
+    public static final String ICON_SMALL_PATH = "img/circle.svg";
+    public static final String ICON_LARGE_PATH = "img/circle24.svg";
 
-    public ToolDrawCircleAction(Controller controller) {
+    public ToolDrawCircleAction() {
         putValue("iconBase", ICON_SMALL_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_SMALL_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(ICON_LARGE_PATH, false));
         putValue("menuText", "Draw circle");
         putValue(NAME, "Draw circle");
-        this.controller = controller;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        Controller controller = ControllerFactory.getController();
         controller.setTool(Tool.CIRCLE);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawPointAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawPointAction.java
@@ -19,31 +19,40 @@
 package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class ToolDrawPointAction extends AbstractAction {
-    private static final String SMALL_ICON_PATH = "img/point.png";
-    private static final String LARGE_ICON_PATH = "img/point24.png";
-    private final transient Controller controller;
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolDrawPointAction")
+@ActionRegistration(
+        iconBase = ToolDrawPointAction.SMALL_ICON_PATH,
+        displayName = "Draw point",
+        lazy = false)
+public class ToolDrawPointAction extends AbstractDesignAction {
+    public static final String SMALL_ICON_PATH = "img/point.png";
+    public static final String LARGE_ICON_PATH = "img/point24.png";
 
-    public ToolDrawPointAction(Controller controller) {
+    public ToolDrawPointAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Draw point");
         putValue(NAME, "Draw point");
-        this.controller = controller;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        Controller controller = ControllerFactory.getController();
         controller.setTool(Tool.POINT);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawRectangleAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawRectangleAction.java
@@ -19,31 +19,40 @@
 package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class ToolDrawRectangleAction extends AbstractAction {
-    private static final String SMALL_ICON_PATH = "img/rectangle.png";
-    private static final String LARGE_ICON_PATH = "img/rectangle24.png";
-    private final transient Controller controller;
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolDrawRectangleAction")
+@ActionRegistration(
+        iconBase = ToolDrawRectangleAction.SMALL_ICON_PATH,
+        displayName = "Draw Rectangle",
+        lazy = false)
+public class ToolDrawRectangleAction extends AbstractDesignAction {
+    public static final String SMALL_ICON_PATH = "img/rectangle.png";
+    public static final String LARGE_ICON_PATH = "img/rectangle24.png";
 
-    public ToolDrawRectangleAction(Controller controller) {
+    public ToolDrawRectangleAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Draw rectangle");
         putValue(NAME, "Draw rectangle");
-        this.controller = controller;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        Controller controller = ControllerFactory.getController();
         controller.setTool(Tool.RECTANGLE);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawTextAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolDrawTextAction.java
@@ -19,31 +19,40 @@
 package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class ToolDrawTextAction extends AbstractAction {
-    private static final String SMALL_ICON_PATH = "img/text.png";
-    private static final String LARGE_ICON_PATH = "img/text24.png";
-    private final transient Controller controller;
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolDrawTextAction")
+@ActionRegistration(
+        iconBase = ToolDrawTextAction.SMALL_ICON_PATH,
+        displayName = "Draw text",
+        lazy = false)
+public class ToolDrawTextAction extends AbstractDesignAction {
+    public static final String SMALL_ICON_PATH = "img/text.png";
+    public static final String LARGE_ICON_PATH = "img/text24.png";
 
-    public ToolDrawTextAction(Controller controller) {
+    public ToolDrawTextAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Draw text");
         putValue(NAME, "Draw text");
-        this.controller = controller;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        Controller controller = ControllerFactory.getController();
         controller.setTool(Tool.TEXT);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolImportAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolImportAction.java
@@ -21,16 +21,19 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.designer.io.c2d.C2dReader;
 import com.willwinder.ugs.nbp.designer.io.dxf.DxfReader;
 import com.willwinder.ugs.nbp.designer.io.svg.SvgReader;
-import com.willwinder.ugs.nbp.designer.model.Design;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.designer.model.Design;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import org.apache.commons.lang3.StringUtils;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.event.ActionEvent;
@@ -40,19 +43,26 @@ import java.util.Optional;
 /**
  * @author Joacim Breiler
  */
-public final class ToolImportAction extends AbstractAction {
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolImportAction")
+@ActionRegistration(
+        iconBase = ToolImportAction.SMALL_ICON_PATH,
+        displayName = "Import",
+        lazy = false)
+public final class ToolImportAction extends AbstractDesignAction {
 
     public static final String SMALL_ICON_PATH = "img/import.svg";
     public static final String LARGE_ICON_PATH = "img/import24.svg";
     private final transient Controller controller;
 
-    public ToolImportAction(Controller controller) {
+    public ToolImportAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Import");
         putValue(NAME, "Import");
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolSelectAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolSelectAction.java
@@ -19,27 +19,37 @@
 package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
  * @author Joacim Breiler
  */
-public class ToolSelectAction extends AbstractAction {
-    private static final String SMALL_ICON_PATH = "img/pointer.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolSelectAction")
+@ActionRegistration(
+        iconBase = ToolSelectAction.SMALL_ICON_PATH,
+        displayName = "Select",
+        lazy = false)
+public class ToolSelectAction extends AbstractDesignAction {
+    public static final String SMALL_ICON_PATH = "img/pointer.svg";
     private static final String LARGE_ICON_PATH = "img/pointer24.svg";
     private final transient Controller controller;
 
-    public ToolSelectAction(Controller controller) {
+    public ToolSelectAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Select");
         putValue(NAME, "Select");
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolZoomAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolZoomAction.java
@@ -19,7 +19,11 @@
 package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.awt.StatusDisplayer;
 import org.openide.util.ImageUtilities;
 
@@ -29,23 +33,28 @@ import java.awt.event.ActionEvent;
 /**
  * @author Joacim Breiler
  */
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "ToolZoomAction")
+@ActionRegistration(
+        iconBase = ToolZoomAction.ICON_SMALL_PATH,
+        displayName = "Zoom",
+        lazy = false)
 public class ToolZoomAction extends AbstractAction {
-    private static final String ICON_SMALL_PATH = "img/zoom.svg";
+    public static final String ICON_SMALL_PATH = "img/zoom.svg";
     private static final String ICON_LARGE_PATH = "img/zoom24.svg";
-    private final transient Controller controller;
 
-    public ToolZoomAction(Controller controller) {
+    public ToolZoomAction() {
         putValue("iconBase", ICON_SMALL_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_SMALL_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(ICON_LARGE_PATH, false));
         putValue("menuText", "Draw circle");
         putValue(NAME, "Draw circle");
-        this.controller = controller;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         StatusDisplayer.getDefault().setStatusText("Click to Zoom in, SHIFT + Click to Zoom out");
-        controller.setTool(Tool.ZOOM);
+        ControllerFactory.getController().setTool(Tool.ZOOM);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/TraceImageAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/TraceImageAction.java
@@ -21,30 +21,40 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.designer.entities.Entity;
 import com.willwinder.ugs.nbp.designer.gui.imagetracer.ImageTracerDialog;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.Tool;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.util.List;
 
 /**
  * @author Joacim Breiler
  */
-public class TraceImageAction extends AbstractAction {
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "TraceImageAction")
+@ActionRegistration(
+        iconBase = TraceImageAction.SMALL_ICON_PATH,
+        displayName = "Trace image",
+        lazy = false)
+public class TraceImageAction extends AbstractDesignAction {
 
     public static final String SMALL_ICON_PATH = "img/trace.svg";
     public static final String LARGE_ICON_PATH = "img/trace24.svg";
     private final transient Controller controller;
 
-    public TraceImageAction(Controller controller) {
+    public TraceImageAction() {
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
         putValue("menuText", "Trace image");
         putValue(NAME, "Trace Image");
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/UndoAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/UndoAction.java
@@ -27,7 +27,7 @@ import java.awt.event.ActionEvent;
 /**
  * @author Joacim Breiler
  */
-public class UndoAction extends AbstractAction implements UndoManagerListener {
+public class UndoAction extends AbstractDesignAction implements UndoManagerListener {
     public static final String SMALL_ICON_PATH = "img/undo.svg";
     public static final String LARGE_ICON_PATH = "img/undo24.svg";
     private final transient UndoManager undoManager;

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/UnionAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/UnionAction.java
@@ -25,9 +25,12 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 import java.awt.geom.Area;
 import java.util.List;
@@ -38,19 +41,26 @@ import java.util.List;
  *
  * @author Joacim Breiler
  */
-public class UnionAction extends AbstractAction implements SelectionListener {
-    private static final String SMALL_ICON_PATH = "img/union.svg";
-    private static final String LARGE_ICON_PATH = "img/union24.svg";
+@ActionID(
+        category = LocalizingService.CATEGORY_DESIGNER,
+        id = "UnionAction")
+@ActionRegistration(
+        iconBase = UnionAction.SMALL_ICON_PATH,
+        displayName = "Union",
+        lazy = false)
+public class UnionAction extends AbstractDesignAction implements SelectionListener {
+    public static final String SMALL_ICON_PATH = "img/union.svg";
+    public static final String LARGE_ICON_PATH = "img/union24.svg";
     private final transient Controller controller;
 
-    public UnionAction(Controller controller) {
+    public UnionAction() {
         putValue("menuText", "Union");
         putValue(NAME, "Union");
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
 
-        this.controller = controller;
+        this.controller = ControllerFactory.getController();
         SelectionManager selectionManager = controller.getSelectionManager();
         selectionManager.addSelectionListener(this);
         setEnabled(selectionManager.getSelection().size() >= 2);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/MainMenu.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/MainMenu.java
@@ -18,11 +18,28 @@
  */
 package com.willwinder.ugs.nbp.designer.gui;
 
-import com.willwinder.ugs.nbp.designer.actions.*;
+import com.willwinder.ugs.nbp.designer.actions.ClearSelectionAction;
+import com.willwinder.ugs.nbp.designer.actions.CopyAction;
+import com.willwinder.ugs.nbp.designer.actions.DeleteAction;
+import com.willwinder.ugs.nbp.designer.actions.ExportGcodeAction;
+import com.willwinder.ugs.nbp.designer.actions.ExportPngAction;
+import com.willwinder.ugs.nbp.designer.actions.FlipHorizontallyAction;
+import com.willwinder.ugs.nbp.designer.actions.FlipVerticallyAction;
+import com.willwinder.ugs.nbp.designer.actions.NewAction;
+import com.willwinder.ugs.nbp.designer.actions.OpenAction;
+import com.willwinder.ugs.nbp.designer.actions.PasteAction;
+import com.willwinder.ugs.nbp.designer.actions.QuitAction;
+import com.willwinder.ugs.nbp.designer.actions.RedoAction;
+import com.willwinder.ugs.nbp.designer.actions.SaveAction;
+import com.willwinder.ugs.nbp.designer.actions.SelectAllAction;
+import com.willwinder.ugs.nbp.designer.actions.UndoAction;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import org.openide.util.Utilities;
 
-import javax.swing.*;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JSeparator;
 
 /**
  * Represents a main menu for a DrawGUI
@@ -35,7 +52,6 @@ public class MainMenu extends JMenuBar {
     private static final long serialVersionUID = 0;
 
     public MainMenu(Controller controller) {
-
         JMenuItem newdrawing = new JMenuItem(new NewAction());
         JMenuItem open = new JMenuItem(new OpenAction());
         JMenuItem save = new JMenuItem(new SaveAction(controller));
@@ -43,18 +59,18 @@ public class MainMenu extends JMenuBar {
         JMenuItem exportGcode = new JMenuItem(new ExportGcodeAction());
         JMenuItem quit = new JMenuItem(new QuitAction());
 
-        JMenuItem undo = new JMenuItem(controller.getAction(UndoAction.class));
-        JMenuItem redo = new JMenuItem(controller.getAction(RedoAction.class));
+        JMenuItem undo = new JMenuItem(new UndoAction());
+        JMenuItem redo = new JMenuItem(new RedoAction());
 
-        JMenuItem copy = new JMenuItem(controller.getAction(CopyAction.class));
-        JMenuItem paste = new JMenuItem(controller.getAction(PasteAction.class));
+        JMenuItem copy = new JMenuItem(new CopyAction());
+        JMenuItem paste = new JMenuItem(new PasteAction());
 
-        JMenuItem flipHorizontal = new JMenuItem(controller.getAction(FlipHorizontallyAction.class));
-        JMenuItem flipVertical = new JMenuItem(controller.getAction(FlipVerticallyAction.class));
+        JMenuItem flipHorizontal = new JMenuItem(new FlipHorizontallyAction());
+        JMenuItem flipVertical = new JMenuItem(new FlipVerticallyAction());
 
-        JMenuItem all = new JMenuItem(controller.getAction(SelectAllAction.class));
-        JMenuItem clear = new JMenuItem(controller.getAction(ClearSelectionAction.class));
-        JMenuItem delete = new JMenuItem(controller.getAction(DeleteAction.class));
+        JMenuItem all = new JMenuItem(new SelectAllAction());
+        JMenuItem clear = new JMenuItem(new ClearSelectionAction());
+        JMenuItem delete = new JMenuItem(new DeleteAction());
 
         open.setAccelerator(Utilities.stringToKey("D-O"));
         save.setAccelerator(Utilities.stringToKey("D-S"));

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/PopupMenuFactory.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/PopupMenuFactory.java
@@ -1,32 +1,42 @@
 package com.willwinder.ugs.nbp.designer.gui;
 
-import com.willwinder.ugs.nbp.designer.actions.*;
-import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.actions.BreakApartAction;
+import com.willwinder.ugs.nbp.designer.actions.ClearSelectionAction;
+import com.willwinder.ugs.nbp.designer.actions.CopyAction;
+import com.willwinder.ugs.nbp.designer.actions.DeleteAction;
+import com.willwinder.ugs.nbp.designer.actions.FlipHorizontallyAction;
+import com.willwinder.ugs.nbp.designer.actions.FlipVerticallyAction;
+import com.willwinder.ugs.nbp.designer.actions.IntersectionAction;
+import com.willwinder.ugs.nbp.designer.actions.JogMachineToCenterAction;
+import com.willwinder.ugs.nbp.designer.actions.PasteAction;
+import com.willwinder.ugs.nbp.designer.actions.SelectAllAction;
+import com.willwinder.ugs.nbp.designer.actions.SubtractAction;
+import com.willwinder.ugs.nbp.designer.actions.UnionAction;
 
-import javax.swing.*;
+import javax.swing.JPopupMenu;
 
 /**
  * @author Joacim Breiler
  */
 public class PopupMenuFactory {
-    public JPopupMenu createPopupMenu(Controller controller) {
+    public JPopupMenu createPopupMenu() {
         JPopupMenu popupMenu = new JPopupMenu();
-        popupMenu.add(controller.getAction(SelectAllAction.class));
-        popupMenu.add(controller.getAction(ClearSelectionAction.class));
-        popupMenu.add(controller.getAction(DeleteAction.class));
+        popupMenu.add(new SelectAllAction());
+        popupMenu.add(new ClearSelectionAction());
+        popupMenu.add(new DeleteAction());
         popupMenu.addSeparator();
-        popupMenu.add(controller.getAction(CopyAction.class));
-        popupMenu.add(controller.getAction(PasteAction.class));
+        popupMenu.add(new CopyAction());
+        popupMenu.add(new PasteAction());
         popupMenu.addSeparator();
-        popupMenu.add(controller.getAction(UnionAction.class));
-        popupMenu.add(controller.getAction(SubtractAction.class));
-        popupMenu.add(controller.getAction(IntersectionAction.class));
-        popupMenu.add(controller.getAction(BreakApartAction.class));
+        popupMenu.add(new UnionAction());
+        popupMenu.add(new SubtractAction());
+        popupMenu.add(new IntersectionAction());
+        popupMenu.add(new BreakApartAction());
         popupMenu.addSeparator();
-        popupMenu.add(controller.getAction(FlipHorizontallyAction.class));
-        popupMenu.add(controller.getAction(FlipVerticallyAction.class));
+        popupMenu.add(new FlipHorizontallyAction());
+        popupMenu.add(new FlipVerticallyAction());
         popupMenu.addSeparator();
-        popupMenu.add(controller.getAction(JogMachineToCenterAction.class));
+        popupMenu.add(new JogMachineToCenterAction());
         return popupMenu;
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/PopupMenuFactory.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/PopupMenuFactory.java
@@ -1,3 +1,21 @@
+/*
+    Copyright 2023 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.willwinder.ugs.nbp.designer.gui;
 
 import com.willwinder.ugs.nbp.designer.actions.BreakApartAction;
@@ -19,8 +37,19 @@ import javax.swing.JPopupMenu;
  * @author Joacim Breiler
  */
 public class PopupMenuFactory {
-    public JPopupMenu createPopupMenu() {
-        JPopupMenu popupMenu = new JPopupMenu();
+
+    private static JPopupMenu popupMenu;
+
+    private PopupMenuFactory() {
+        // Should not be instanced
+    }
+
+    public static JPopupMenu createPopupMenu() {
+        if (popupMenu != null) {
+            return popupMenu;
+        }
+
+        popupMenu = new JPopupMenu();
         popupMenu.add(new SelectAllAction());
         popupMenu.add(new ClearSelectionAction());
         popupMenu.add(new DeleteAction());

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/SelectionSettingsPanel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/SelectionSettingsPanel.java
@@ -27,7 +27,6 @@ import com.willwinder.ugs.nbp.designer.entities.EntityListener;
 import com.willwinder.ugs.nbp.designer.entities.EventType;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.CutType;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.Cuttable;
-import com.willwinder.ugs.nbp.designer.entities.cuttable.Point;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.Text;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionEvent;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionListener;
@@ -238,7 +237,6 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
     @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
-        requestFocus();
         Arrays.stream(getComponents()).forEach(component -> component.setEnabled(enabled));
         if (!enabled) {
             setFieldValue(targetDepthSpinner, 0d);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
@@ -19,11 +19,28 @@
 package com.willwinder.ugs.nbp.designer.gui;
 
 import com.willwinder.ugs.nbp.core.ui.ToolBar;
-import com.willwinder.ugs.nbp.designer.actions.*;
+import com.willwinder.ugs.nbp.designer.actions.BreakApartAction;
+import com.willwinder.ugs.nbp.designer.actions.FlipHorizontallyAction;
+import com.willwinder.ugs.nbp.designer.actions.FlipVerticallyAction;
+import com.willwinder.ugs.nbp.designer.actions.IntersectionAction;
+import com.willwinder.ugs.nbp.designer.actions.MultiplyAction;
+import com.willwinder.ugs.nbp.designer.actions.SubtractAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolClipartAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolDrawCircleAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolDrawPointAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolDrawRectangleAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolDrawTextAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolImportAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolSelectAction;
+import com.willwinder.ugs.nbp.designer.actions.ToolZoomAction;
+import com.willwinder.ugs.nbp.designer.actions.TraceImageAction;
+import com.willwinder.ugs.nbp.designer.actions.UnionAction;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.designer.logic.ControllerEventType;
 
-import javax.swing.*;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JToggleButton;
 
 /**
  * @author Joacim Breiler
@@ -33,47 +50,47 @@ public class ToolBox extends ToolBar {
     public ToolBox(Controller controller) {
         setFloatable(false);
 
-        JToggleButton select = new JToggleButton(new ToolSelectAction(controller));
+        JToggleButton select = new JToggleButton(new ToolSelectAction());
         select.setSelected(true);
         select.setText("");
         select.setToolTipText("Select and move shapes");
         add(select);
 
-        JToggleButton point = new JToggleButton(new ToolDrawPointAction(controller));
+        JToggleButton point = new JToggleButton(new ToolDrawPointAction());
         point.setText("");
         point.setToolTipText("Draw points");
         add(point);
 
-        JToggleButton rectangle = new JToggleButton(new ToolDrawRectangleAction(controller));
+        JToggleButton rectangle = new JToggleButton(new ToolDrawRectangleAction());
         rectangle.setText("");
         rectangle.setToolTipText("Draw squares and rectangles");
         add(rectangle);
 
-        JToggleButton circle = new JToggleButton(new ToolDrawCircleAction(controller));
+        JToggleButton circle = new JToggleButton(new ToolDrawCircleAction());
         circle.setText("");
         circle.setToolTipText("Draw circles and ellipses");
         add(circle);
 
-        JToggleButton text = new JToggleButton(new ToolDrawTextAction(controller));
+        JToggleButton text = new JToggleButton(new ToolDrawTextAction());
         text.setText("");
         text.setToolTipText("Write text");
         add(text);
 
-        JButton importButton = new JButton(new ToolImportAction(controller));
+        JButton importButton = new JButton(new ToolImportAction());
         importButton.setText("");
         importButton.setToolTipText("Imports a drawing");
         importButton.setContentAreaFilled(false);
         importButton.setBorderPainted(false);
         add(importButton);
 
-        JButton insertButton = new JButton(new ToolClipartAction(controller));
+        JButton insertButton = new JButton(new ToolClipartAction());
         insertButton.setText("");
         insertButton.setToolTipText("Inserts a clipart");
         insertButton.setContentAreaFilled(false);
         insertButton.setBorderPainted(false);
         add(insertButton);
 
-        insertButton = new JButton(new TraceImageAction(controller));
+        insertButton = new JButton(new TraceImageAction());
         insertButton.setText("");
         insertButton.setToolTipText("Traces a bitmap image");
         insertButton.setContentAreaFilled(false);
@@ -82,13 +99,13 @@ public class ToolBox extends ToolBar {
 
         addSeparator();
 
-        JButton flipHorizontal = new JButton(new FlipHorizontallyAction(controller));
+        JButton flipHorizontal = new JButton(new FlipHorizontallyAction());
         flipHorizontal.setText("");
         flipHorizontal.setToolTipText("Flips horizontally");
         flipHorizontal.setBorderPainted(false);
         add(flipHorizontal);
 
-        JButton flipVertical = new JButton(new FlipVerticallyAction(controller));
+        JButton flipVertical = new JButton(new FlipVerticallyAction());
         flipVertical.setText("");
         flipVertical.setToolTipText("Flips vertically");
         flipVertical.setBorderPainted(false);
@@ -96,25 +113,25 @@ public class ToolBox extends ToolBar {
 
         addSeparator();
 
-        JButton union = new JButton(new UnionAction(controller));
+        JButton union = new JButton(new UnionAction());
         union.setText("");
         union.setToolTipText("Unions two or more entities with each other");
         union.setBorderPainted(false);
         add(union);
 
-        JButton subtract = new JButton(new SubtractAction(controller));
+        JButton subtract = new JButton(new SubtractAction());
         subtract.setText("");
         subtract.setToolTipText("Subtracts one entity with another");
         subtract.setBorderPainted(false);
         add(subtract);
 
-        JButton intersection = new JButton(new IntersectionAction(controller));
+        JButton intersection = new JButton(new IntersectionAction());
         intersection.setText("");
         intersection.setToolTipText("Makes an intersection between two entities");
         intersection.setBorderPainted(false);
         add(intersection);
 
-        JButton breakApart = new JButton(new BreakApartAction(controller));
+        JButton breakApart = new JButton(new BreakApartAction());
         breakApart.setText("");
         breakApart.setToolTipText("Breaks apart multiple entities");
         breakApart.setBorderPainted(false);
@@ -122,7 +139,7 @@ public class ToolBox extends ToolBar {
 
         addSeparator();
 
-        JButton multiply = new JButton(new MultiplyAction(controller));
+        JButton multiply = new JButton(new MultiplyAction());
         multiply.setText("");
         multiply.setToolTipText("Multiplies the selection");
         multiply.setBorderPainted(false);
@@ -130,7 +147,7 @@ public class ToolBox extends ToolBar {
 
         addSeparator();
 
-        JToggleButton zoom = new JToggleButton(new ToolZoomAction(controller));
+        JToggleButton zoom = new JToggleButton(new ToolZoomAction());
         zoom.setText("");
         zoom.setToolTipText("Controls zoom");
         zoom.setBorderPainted(false);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolBox.java
@@ -187,6 +187,7 @@ public class ToolBox extends ToolBar {
                     case ZOOM:
                         zoom.setSelected(true);
                         break;
+                    default:
                 }
                 repaint();
             }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTree.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTree.java
@@ -52,6 +52,7 @@ public class EntitiesTree extends JTree implements TreeSelectionListener, Select
         expandRow(0);
         updateController(controller);
         ((EntityTreeModel) getModel()).notifyTreeStructureChanged(controller.getDrawing().getRootEntity());
+        addMouseListener(new EntitiesTreePopupListener());
     }
 
     private void updateController(Controller controller) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTreePopupListener.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTreePopupListener.java
@@ -1,0 +1,51 @@
+/*
+    Copyright 2023 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.gui.tree;
+
+import com.willwinder.ugs.nbp.designer.gui.PopupMenuFactory;
+
+import javax.swing.JComponent;
+import javax.swing.JPopupMenu;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/**
+ * @author Joacim Breiler
+ */
+public class EntitiesTreePopupListener extends MouseAdapter {
+    private final JPopupMenu popupMenu;
+
+    public EntitiesTreePopupListener() {
+        popupMenu = PopupMenuFactory.createPopupMenu();
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+        if (e.isPopupTrigger()) {
+            popupMenu.show((JComponent) e.getSource(), e.getX(), e.getY());
+        }
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        if (e.isPopupTrigger()) {
+            popupMenu.show((JComponent) e.getSource(), e.getX(), e.getY());
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/Controller.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/Controller.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Will Winder
+    Copyright 2021-2023 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -20,32 +20,18 @@ package com.willwinder.ugs.nbp.designer.logic;
 
 import com.google.common.collect.Sets;
 import com.willwinder.ugs.nbp.designer.actions.AddAction;
-import com.willwinder.ugs.nbp.designer.actions.BreakApartAction;
-import com.willwinder.ugs.nbp.designer.actions.ClearSelectionAction;
-import com.willwinder.ugs.nbp.designer.actions.CopyAction;
-import com.willwinder.ugs.nbp.designer.actions.DeleteAction;
-import com.willwinder.ugs.nbp.designer.actions.FlipHorizontallyAction;
-import com.willwinder.ugs.nbp.designer.actions.FlipVerticallyAction;
-import com.willwinder.ugs.nbp.designer.actions.IntersectionAction;
-import com.willwinder.ugs.nbp.designer.actions.JogMachineToCenterAction;
-import com.willwinder.ugs.nbp.designer.actions.PasteAction;
-import com.willwinder.ugs.nbp.designer.actions.RedoAction;
-import com.willwinder.ugs.nbp.designer.actions.SelectAllAction;
-import com.willwinder.ugs.nbp.designer.actions.SubtractAction;
-import com.willwinder.ugs.nbp.designer.actions.UndoAction;
 import com.willwinder.ugs.nbp.designer.actions.UndoManager;
-import com.willwinder.ugs.nbp.designer.actions.UnionAction;
 import com.willwinder.ugs.nbp.designer.entities.Entity;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.gui.Drawing;
+import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignReader;
+import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignWriter;
 import com.willwinder.ugs.nbp.designer.model.Design;
 import com.willwinder.ugs.nbp.designer.model.Settings;
 
-import javax.swing.Action;
 import java.awt.Cursor;
-import java.util.HashMap;
+import java.io.File;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -57,7 +43,6 @@ public class Controller {
     private final Settings settings = new Settings();
     private final Set<ControllerListener> listeners = Sets.newConcurrentHashSet();
     private final UndoManager undoManager;
-    private final Map<Class<? extends Action>, Action> actionMap = new HashMap<>();
     private final Drawing drawing;
     private Tool tool;
 
@@ -67,25 +52,7 @@ public class Controller {
         this.drawing = new Drawing(this);
         this.undoManager.addListener(this.drawing::repaint);
 
-        registerActions();
         setTool(Tool.SELECT);
-    }
-
-    private void registerActions() {
-        actionMap.put(DeleteAction.class, new DeleteAction(this));
-        actionMap.put(SelectAllAction.class, new SelectAllAction(this));
-        actionMap.put(ClearSelectionAction.class, new ClearSelectionAction(this));
-        actionMap.put(CopyAction.class, new CopyAction(this));
-        actionMap.put(PasteAction.class, new PasteAction(this));
-        actionMap.put(UndoAction.class, new UndoAction());
-        actionMap.put(RedoAction.class, new RedoAction());
-        actionMap.put(UnionAction.class, new UnionAction(this));
-        actionMap.put(SubtractAction.class, new SubtractAction(this));
-        actionMap.put(IntersectionAction.class, new IntersectionAction(this));
-        actionMap.put(BreakApartAction.class, new BreakApartAction(this));
-        actionMap.put(FlipHorizontallyAction.class, new FlipHorizontallyAction(this));
-        actionMap.put(FlipVerticallyAction.class, new FlipVerticallyAction(this));
-        actionMap.put(JogMachineToCenterAction.class, new JogMachineToCenterAction(this));
     }
 
     public void addEntity(Entity s) {
@@ -158,10 +125,13 @@ public class Controller {
         notifyListeners(ControllerEventType.RELEASE);
     }
 
-    public Action getAction(Class<? extends Action> actionClass) {
-        if (!actionMap.containsKey(actionClass)) {
-            throw new RuntimeException("Could not find action with the name " + actionClass.getName());
-        }
-        return actionMap.get(actionClass);
+    public void loadFile(File file) {
+        UgsDesignReader reader = new UgsDesignReader();
+        setDesign(reader.read(file).orElse(new Design()));
+    }
+
+    public void saveFile(File file) {
+        UgsDesignWriter writer = new UgsDesignWriter();
+        writer.write(file, this);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/ControllerFactory.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/logic/ControllerFactory.java
@@ -1,0 +1,52 @@
+/*
+    Copyright 2023 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.logic;
+
+import com.willwinder.ugs.nbp.designer.actions.SimpleUndoManager;
+import com.willwinder.ugs.nbp.designer.actions.UndoManager;
+import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
+
+/**
+ * Creates and keeps a singleton instance of the design controller.
+ *
+ * @author Joacim Breiler
+ */
+public class ControllerFactory {
+    private static Controller controller;
+
+    private ControllerFactory() {
+        // Can not be instanced
+    }
+
+    public static Controller getController() {
+        if (controller == null) {
+            controller = new Controller(new SelectionManager(), new SimpleUndoManager());
+        }
+
+        return controller;
+    }
+
+    public static UndoManager getUndoManager() {
+        return getController().getUndoManager();
+    }
+
+    public static SelectionManager getSelectionManager() {
+        return getController().getSelectionManager();
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
@@ -78,7 +78,7 @@ public class DesignerTopComponent extends TopComponent implements UndoManagerLis
 
         undoManagerAdapter = new UndoManagerAdapter(controller.getUndoManager());
         controller.getSelectionManager().addSelectionListener(this);
-        controller.getDrawing().setComponentPopupMenu(new PopupMenuFactory().createPopupMenu());
+        controller.getDrawing().setComponentPopupMenu(PopupMenuFactory.createPopupMenu());
         setActivatedNodes(new DataNode[]{new DataNode(dataObject, Children.LEAF, dataObject.getLookup())});
         dataObject.addPropertyChangeListener(evt -> updateFilename());
         loadDesign(dataObject);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
@@ -27,7 +27,6 @@ import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.windows.TopComponent;
 
 import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
 import java.awt.BorderLayout;
 
 /**
@@ -68,7 +67,7 @@ public class EntitiesTreeTopComponent extends TopComponent implements Controller
         entitesTree = new EntitiesTree(controller, entitiesTreeModel);
 
         removeAll();
-        add(new JScrollPane(entitesTree, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED), BorderLayout.CENTER);
+        add(new JScrollPane(entitesTree), BorderLayout.CENTER);
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/PlatformUtils.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/PlatformUtils.java
@@ -25,15 +25,15 @@ public class PlatformUtils {
     private PlatformUtils() {
     }
 
-    public static void registerActions(ActionMap actionMap, Controller controller, TopComponent component) {
-        actionMap.put(DELETE_KEY, controller.getAction(DeleteAction.class));
-        actionMap.put(DefaultEditorKit.selectAllAction, controller.getAction(SelectAllAction.class));
-        actionMap.put(DefaultEditorKit.copyAction, controller.getAction(CopyAction.class));
-        actionMap.put(DefaultEditorKit.pasteAction, controller.getAction(PasteAction.class));
-        actionMap.put(UNDO_KEY, controller.getAction(UndoAction.class));
-        actionMap.put(REDO_KEY, controller.getAction(RedoAction.class));
+    public static void registerActions(ActionMap actionMap, TopComponent component) {
+        actionMap.put(DELETE_KEY, new DeleteAction());
+        actionMap.put(DefaultEditorKit.selectAllAction, new SelectAllAction());
+        actionMap.put(DefaultEditorKit.copyAction, new CopyAction());
+        actionMap.put(DefaultEditorKit.pasteAction, new PasteAction());
+        actionMap.put(UNDO_KEY, new UndoAction());
+        actionMap.put(REDO_KEY, new RedoAction());
 
-        // Need to make special input maps as this normally is handled by the a texteditor
+        // Need to make special input maps as this normally is handled by the texteditor
         InputMap inputMap = component.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
         inputMap.put(Utilities.stringToKey("BACK_SPACE"), DELETE_KEY);
         inputMap.put(Utilities.stringToKey("D-C"), DefaultEditorKit.copyAction);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/Startup.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/Startup.java
@@ -20,6 +20,11 @@ package com.willwinder.ugs.nbp.designer.platform;
 
 import com.willwinder.ugs.nbp.core.services.FileFilterService;
 import com.willwinder.ugs.nbp.designer.actions.OpenAction;
+import com.willwinder.ugs.nbp.designer.actions.SimpleUndoManager;
+import com.willwinder.ugs.nbp.designer.actions.UndoManager;
+import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.modules.OnStart;
 import org.openide.util.Lookup;
 
@@ -31,6 +36,15 @@ public class Startup implements Runnable {
 
     @Override
     public void run() {
+        UndoManager undoManager = new SimpleUndoManager();
+        CentralLookup.getDefault().add(undoManager);
+
+        // Register a controller
+        Controller controller = ControllerFactory.getController();
+        CentralLookup.getDefault().add(controller);
+        CentralLookup.getDefault().add(controller.getUndoManager());
+        CentralLookup.getDefault().add(controller.getSelectionManager());
+
         // Registers the file types that can be opened in UGSs
         FileFilterService fileFilterService = Lookup.getDefault().lookup(FileFilterService.class);
         fileFilterService.registerFileFilter(OpenAction.DESIGN_FILE_FILTER);

--- a/ugs-platform/ugs-platform-ugslib/src/main/java/com/willwinder/ugs/nbp/lib/services/LocalizingService.java
+++ b/ugs-platform/ugs-platform-ugslib/src/main/java/com/willwinder/ugs/nbp/lib/services/LocalizingService.java
@@ -51,6 +51,7 @@ public class LocalizingService {
     public static final String CATEGORY_FILE = "File";
     public static final String CATEGORY_VISUALIZER = "Visualizer";
     public static final String CATEGORY_EDIT = "Edit";
+    public static final String CATEGORY_DESIGNER = "Designer";
 
     // Initialize backend (locale setting) before we load localized strings.
     public static final String lang = CentralLookup.getDefault().lookup(BackendAPI.class).getSettings().getLanguage();


### PR DESCRIPTION
Made most actions in the designer mappable with keyboard shortcuts:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/8962024/211904338-cd48a85c-be74-4aeb-bc81-04ea774489b0.png">

They will also be available as gamepad shortcuts:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/8962024/211904516-15fe6aab-5691-420f-ad38-d7208a2e72eb.png">

The actions will now also be disabled when the machine is moving.

The entities list can now be navigated using the keyboard and now also have the popup menu:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/8962024/211904736-c13cf002-cbae-436a-8c03-c69c7904c814.png">
