### PR TITLE
Do not use CentralLookup to look up the Controller-instance

### DIFF
--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -423,9 +423,8 @@ public class GrblUtilsTest {
         String status = "<Idle|MPos:1.1,2.2,3.3|WPos:4.4,5.5,6.6|WCO:7.7,8.8,9.9|Ov:1,2,3|F:12345.6|FS:12345.7,65432.1|Pn:XYZPDHRS|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
 
@@ -460,9 +459,8 @@ public class GrblUtilsTest {
         String status = "<Idle|MPos:1.1,2.2,3.3|WPos:4.4,5.5,6.6|Ov:1,2,3|F:12345.6|FS:12345.7,65432.1|Pn:XYZPDHRS|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(new Position(1.1, 2.2, 3.3, MM), controllerStatus.getMachineCoord());
         assertEquals(new Position(4.4, 5.5, 6.6, MM), controllerStatus.getWorkCoord());
@@ -474,9 +472,8 @@ public class GrblUtilsTest {
         String status = "<Idle|MPos:1.0,2.0,3.0|WCO:7.0,8.0,9.0|Ov:1,2,3|F:12345.6|FS:12345.7,65432.1|Pn:XYZPDHRS|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(new Position(1, 2, 3, MM), controllerStatus.getMachineCoord());
         assertEquals(new Position(-6, -6, -6, MM), controllerStatus.getWorkCoord());
@@ -502,9 +499,8 @@ public class GrblUtilsTest {
         String status = "<Idle|WPos:4.0,5.0,6.0|WCO:7.0,8.0,9.0|Ov:1,2,3|FS:12345.7,65432.1|F:12345.6|Pn:XYZPDHRS|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(Double.valueOf(12345.6), controllerStatus.getFeedSpeed());
         assertEquals(Double.valueOf(65432.1), controllerStatus.getSpindleSpeed());
@@ -515,9 +511,8 @@ public class GrblUtilsTest {
         String status = "<Idle|WPos:4.0,5.0,6.0|WCO:7.0,8.0,9.0|Ov:1,2,3|F:12345.6,1000.0>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(Double.valueOf(0), controllerStatus.getFeedSpeed());
     }
@@ -527,9 +522,8 @@ public class GrblUtilsTest {
         String status = "<Idle|WPos:4.0,5.0,6.0|WCO:7.0,8.0,9.0|Ov:1,2,3|F:12345.6,1000.0,2000.0>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(Double.valueOf(12345.6), controllerStatus.getFeedSpeed());
     }
@@ -539,9 +533,8 @@ public class GrblUtilsTest {
         String status = "<Idle|WPos:4.0,5.0,6.0|WCO:7.0,8.0,9.0|Ov:1,2,3|FS:12345.7,65432.1|F:12345.6|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertFalse(controllerStatus.getEnabledPins().CycleStart);
         assertFalse(controllerStatus.getEnabledPins().Door);
@@ -558,10 +551,24 @@ public class GrblUtilsTest {
         String status = "<Idle|WPos:4.0,5.0,6.0|WCO:7.0,8.0,9.0|Ov:1,2,3|FS:12345.7,65432.1|F:12345.6>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
+        assertFalse(controllerStatus.getAccessoryStates().Flood);
+        assertFalse(controllerStatus.getAccessoryStates().Mist);
+        assertFalse(controllerStatus.getAccessoryStates().SpindleCCW);
+        assertFalse(controllerStatus.getAccessoryStates().SpindleCW);
+    }
+
+    @Test
+    public void getStatusFromStatusStringShouldBeAbleToProcessEmptyAccessoryState() {
+        String status = "<Idle|A:>";
+        Capabilities version = new Capabilities();
+        version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
+
+        assertEquals(ControllerState.IDLE, controllerStatus.getState());
+        assertNotNull(controllerStatus.getAccessoryStates());
         assertFalse(controllerStatus.getAccessoryStates().Flood);
         assertFalse(controllerStatus.getAccessoryStates().Mist);
         assertFalse(controllerStatus.getAccessoryStates().SpindleCCW);
@@ -573,9 +580,8 @@ public class GrblUtilsTest {
         String status = "<Idle|MPos:1.1,2.2,3.3,4.4,5.5,6.6|WPos:7.7,8.8,9.9,10.10,11.11,12.12|WCO:13.13,14.14,15.15,16.16,17.17,18.18|Ov:1,2,3|F:12345.6|FS:12345.7,65432.1|Pn:XYZABCPDHRS|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
 
@@ -593,9 +599,8 @@ public class GrblUtilsTest {
         String status = "<Idle|MPos:1.1,2.2,3.3,4.4,5.5|WPos:7.7,8.8,9.9,10.10,11.11|WCO:13.13,14.14,15.15,16.16,17.17|Ov:1,2,3|F:12345.6|FS:12345.7,65432.1|Pn:XYZABPDHRS|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
 
@@ -612,9 +617,8 @@ public class GrblUtilsTest {
         String status = "<Idle|MPos:1.1,2.2,3.3,4.4|WPos:7.7,8.8,9.9,10.10|WCO:13.13,14.14,15.15,16.16|Ov:1,2,3|F:12345.6|FS:12345.7,65432.1|Pn:XYZAPDHRS|A:SFMC>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.V1_FORMAT);
-        UnitUtils.Units unit = MM;
 
-        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, unit);
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
 

--- a/ugs-platform/pom.xml
+++ b/ugs-platform/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
       <maven.build.timestamp.format>yyyy.MM.dd.HH.mm</maven.build.timestamp.format>
-      <netbeans.version>RELEASE150</netbeans.version>
+      <netbeans.version>RELEASE160</netbeans.version>
       <ugs.app.title>Universal Gcode Platform ${project.version}</ugs.app.title>
       <ugs.appbundle.name>Universal Gcode Platform</ugs.appbundle.name>
       <parsedVersion.majorVersion>2</parsedVersion.majorVersion>

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ExportGcodeAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ExportGcodeAction.java
@@ -21,7 +21,7 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.designer.io.DesignWriter;
 import com.willwinder.ugs.nbp.designer.io.gcode.GcodeDesignWriter;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.universalgcodesender.utils.SwingHelpers;
 import org.openide.util.ImageUtilities;
 
@@ -53,7 +53,7 @@ public class ExportGcodeAction extends AbstractDesignAction {
             if (!hasGcodeFileEnding) {
                 path = path + ".gcode";
             }
-            Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+            Controller controller = ControllerFactory.getController();
             DesignWriter designWriter = new GcodeDesignWriter();
             designWriter.write(new File(path), controller);
         }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/MoveAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/MoveAction.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class MoveAction implements DrawAction, UndoableAction {
 
     private final List<Entity> entityList;
-    private Point2D movement;
+    private final Point2D movement;
 
     /**
      * Creates a MoveAction that moves all Shapes in the given Selection in the

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/NewAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/NewAction.java
@@ -20,7 +20,7 @@ package com.willwinder.ugs.nbp.designer.actions;
 
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import org.openide.util.ImageUtilities;
 
 import java.awt.event.ActionEvent;
@@ -43,13 +43,13 @@ public class NewAction extends AbstractDesignAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        UndoManager undoManager = CentralLookup.getDefault().lookup(UndoManager.class);
+        UndoManager undoManager = ControllerFactory.getUndoManager();
         undoManager.clear();
 
-        SelectionManager selectionManager = CentralLookup.getDefault().lookup(SelectionManager.class);
+        SelectionManager selectionManager = ControllerFactory.getSelectionManager();
         selectionManager.clearSelection();
 
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        Controller controller = ControllerFactory.getController();
         controller.newDrawing();
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/OpenAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/OpenAction.java
@@ -24,8 +24,8 @@ import com.willwinder.ugs.nbp.designer.io.c2d.C2dReader;
 import com.willwinder.ugs.nbp.designer.io.svg.SvgReader;
 import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignReader;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.model.Design;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import org.openide.util.ImageUtilities;
 
@@ -61,13 +61,13 @@ public class OpenAction extends AbstractDesignAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        UndoManager undoManager = CentralLookup.getDefault().lookup(UndoManager.class);
+        UndoManager undoManager = ControllerFactory.getUndoManager();
         undoManager.clear();
 
-        SelectionManager selectionManager = CentralLookup.getDefault().lookup(SelectionManager.class);
+        SelectionManager selectionManager = ControllerFactory.getSelectionManager();
         selectionManager.clearSelection();
 
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        Controller controller = ControllerFactory.getController();
         fileChooser.showOpenDialog(null);
 
         ThreadHelper.invokeLater(() -> {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/RedoAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/RedoAction.java
@@ -18,7 +18,7 @@
  */
 package com.willwinder.ugs.nbp.designer.actions;
 
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import org.openide.util.ImageUtilities;
 
 import java.awt.event.ActionEvent;
@@ -33,7 +33,7 @@ public class RedoAction extends AbstractDesignAction implements UndoManagerListe
     private final transient UndoManager undoManager;
 
     public RedoAction() {
-        undoManager = CentralLookup.getDefault().lookup(UndoManager.class);
+        undoManager = ControllerFactory.getUndoManager();
         undoManager.addListener(this);
         setEnabled(undoManager.canRedo());
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/RotateAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/RotateAction.java
@@ -33,7 +33,7 @@ public class RotateAction implements DrawAction, UndoableAction {
 
     private final List<Entity> entityList;
     private final Point2D center;
-    private double rotation;
+    private final double rotation;
 
     /**
      * Creates a MoveAction that moves all Shapes in the given Selection in the

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolZoomAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolZoomAction.java
@@ -48,8 +48,8 @@ public class ToolZoomAction extends AbstractAction {
         putValue("iconBase", ICON_SMALL_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_SMALL_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(ICON_LARGE_PATH, false));
-        putValue("menuText", "Draw circle");
-        putValue(NAME, "Draw circle");
+        putValue("menuText", "Zoom");
+        putValue(NAME, "Zoom");
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/UndoAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/UndoAction.java
@@ -18,10 +18,9 @@
  */
 package com.willwinder.ugs.nbp.designer.actions;
 
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
 /**
@@ -33,7 +32,7 @@ public class UndoAction extends AbstractDesignAction implements UndoManagerListe
     private final transient UndoManager undoManager;
 
     public UndoAction() {
-        undoManager = CentralLookup.getDefault().lookup(UndoManager.class);
+        undoManager = ControllerFactory.getUndoManager();
         undoManager.addListener(this);
         setEnabled(undoManager.canUndo());
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/MoveControl.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/MoveControl.java
@@ -29,7 +29,7 @@ import com.willwinder.ugs.nbp.designer.gui.Colors;
 import com.willwinder.ugs.nbp.designer.gui.Drawing;
 import com.willwinder.ugs.nbp.designer.gui.MouseEntityEvent;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
@@ -148,7 +148,7 @@ public class MoveControl extends AbstractControl {
     }
 
     private void addUndoAction(Point2D deltaMovement, Entity target) {
-        UndoManager undoManager = CentralLookup.getDefault().lookup(UndoManager.class);
+        UndoManager undoManager = ControllerFactory.getUndoManager();
         if (undoManager != null) {
             List<Entity> entityList = new ArrayList<>();
             if (target instanceof SelectionManager) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/ResizeControl.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/ResizeControl.java
@@ -30,8 +30,8 @@ import com.willwinder.ugs.nbp.designer.gui.Colors;
 import com.willwinder.ugs.nbp.designer.gui.Drawing;
 import com.willwinder.ugs.nbp.designer.gui.MouseEntityEvent;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.model.Size;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 
 import java.awt.Cursor;
 import java.awt.Graphics2D;
@@ -145,7 +145,7 @@ public class ResizeControl extends AbstractControl {
     }
 
     private void addUndoAction(Entity target, Location location, Size originalSize, Size newSize) {
-        UndoManager undoManager = CentralLookup.getDefault().lookup(UndoManager.class);
+        UndoManager undoManager = ControllerFactory.getUndoManager();
         if (undoManager != null) {
             List<Entity> entityList = new ArrayList<>();
             if (target instanceof SelectionManager) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/RotationControl.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/controls/RotationControl.java
@@ -28,7 +28,7 @@ import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.gui.Colors;
 import com.willwinder.ugs.nbp.designer.gui.Drawing;
 import com.willwinder.ugs.nbp.designer.gui.MouseEntityEvent;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import org.openide.util.ImageUtilities;
 
 import java.awt.Cursor;
@@ -163,7 +163,7 @@ public class RotationControl extends AbstractControl {
                 target.rotate(center, deltaAngle);
                 startPosition = mousePosition;
             } else if (mouseShapeEvent.getType() == EventType.MOUSE_RELEASED) {
-                double totalRotation = (startRotation + target.getRotation());
+                double totalRotation = (target.getRotation() - startRotation);
                 addUndoAction(center, totalRotation, target);
             } else if (mouseShapeEvent.getType() == EventType.MOUSE_IN) {
                 isHovered = true;
@@ -174,7 +174,7 @@ public class RotationControl extends AbstractControl {
     }
 
     private void addUndoAction(Point2D center, double rotation, Entity target) {
-        UndoManager undoManager = CentralLookup.getDefault().lookup(UndoManager.class);
+        UndoManager undoManager = ControllerFactory.getUndoManager();
         if (undoManager != null) {
             List<Entity> entityList = new ArrayList<>();
             if (target instanceof SelectionManager) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/AbstractCuttable.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/AbstractCuttable.java
@@ -22,7 +22,7 @@ import com.willwinder.ugs.nbp.designer.entities.AbstractEntity;
 import com.willwinder.ugs.nbp.designer.gui.Colors;
 import com.willwinder.ugs.nbp.designer.gui.Drawing;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 
 import java.awt.*;
 import java.awt.geom.Line2D;
@@ -114,7 +114,7 @@ public abstract class AbstractCuttable extends AbstractEntity implements Cuttabl
     }
 
     private double getCutAlpha() {
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        Controller controller = ControllerFactory.getController();
         if (getTargetDepth() == 0) {
             return 1d;
         }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTree.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntitiesTree.java
@@ -39,23 +39,19 @@ import java.util.List;
  */
 public class EntitiesTree extends JTree implements TreeSelectionListener, SelectionListener {
 
-    private transient Controller controller;
+    private final transient Controller controller;
 
     public EntitiesTree(Controller controller, TreeModel treeModel) {
         super(treeModel);
-
         setEditable(true);
         setRootVisible(false);
         setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        setCellRenderer(new EntityCellRenderer(this));
+        setCellRenderer(new EntityCellRenderer());
         addTreeSelectionListener(this);
         expandRow(0);
-        updateController(controller);
         ((EntityTreeModel) getModel()).notifyTreeStructureChanged(controller.getDrawing().getRootEntity());
         addMouseListener(new EntitiesTreePopupListener());
-    }
 
-    private void updateController(Controller controller) {
         this.controller = controller;
         controller.getSelectionManager().addSelectionListener(this);
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntityCellRenderer.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/tree/EntityCellRenderer.java
@@ -8,17 +8,12 @@ import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.UnitUtils;
 
-import javax.swing.*;
+import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
-import java.awt.*;
+import java.awt.Component;
 
 public class EntityCellRenderer extends DefaultTreeCellRenderer {
-    private final JTree tree;
-
-    public EntityCellRenderer(JTree tree) {
-        this.tree = tree;
-    }
 
     @Override
     public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/EntitiesTreeTopComponent.java
@@ -22,8 +22,8 @@ import com.willwinder.ugs.nbp.designer.gui.tree.EntitiesTree;
 import com.willwinder.ugs.nbp.designer.gui.tree.EntityTreeModel;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.designer.logic.ControllerEventType;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.ControllerListener;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.windows.TopComponent;
 
 import javax.swing.JScrollPane;
@@ -61,7 +61,7 @@ public class EntitiesTreeTopComponent extends TopComponent implements Controller
     @Override
     protected void componentOpened() {
         super.componentOpened();
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        Controller controller = ControllerFactory.getController();
         controller.addListener(this);
         entitiesTreeModel = new EntityTreeModel(controller);
         entitesTree = new EntitiesTree(controller, entitiesTreeModel);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/PlatformUtils.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/PlatformUtils.java
@@ -1,12 +1,18 @@
 package com.willwinder.ugs.nbp.designer.platform;
 
+import com.google.common.io.Files;
 import com.willwinder.ugs.nbp.designer.actions.CopyAction;
 import com.willwinder.ugs.nbp.designer.actions.DeleteAction;
 import com.willwinder.ugs.nbp.designer.actions.PasteAction;
 import com.willwinder.ugs.nbp.designer.actions.RedoAction;
 import com.willwinder.ugs.nbp.designer.actions.SelectAllAction;
 import com.willwinder.ugs.nbp.designer.actions.UndoAction;
+import com.willwinder.ugs.nbp.designer.io.DesignWriter;
+import com.willwinder.ugs.nbp.designer.io.gcode.GcodeDesignWriter;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.model.BackendAPI;
 import org.openide.util.Utilities;
 import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
@@ -16,22 +22,30 @@ import javax.swing.ActionMap;
 import javax.swing.InputMap;
 import javax.swing.JComponent;
 import javax.swing.text.DefaultEditorKit;
+import java.io.File;
 
 public class PlatformUtils {
     public static final String UNDO_KEY = "undo";
     public static final String REDO_KEY = "redo";
     public static final String DELETE_KEY = "delete";
 
+    private static final DeleteAction DELETE_ACTION = new DeleteAction();
+    private static final SelectAllAction SELECT_ALL_ACTION = new SelectAllAction();
+    private static final CopyAction COPY_ACTION = new CopyAction();
+    private static final PasteAction PASTE_ACTION = new PasteAction();
+    private static final UndoAction UNDO_ACTION = new UndoAction();
+    private static final RedoAction REDO_ACTION = new RedoAction();
+
     private PlatformUtils() {
     }
 
     public static void registerActions(ActionMap actionMap, TopComponent component) {
-        actionMap.put(DELETE_KEY, new DeleteAction());
-        actionMap.put(DefaultEditorKit.selectAllAction, new SelectAllAction());
-        actionMap.put(DefaultEditorKit.copyAction, new CopyAction());
-        actionMap.put(DefaultEditorKit.pasteAction, new PasteAction());
-        actionMap.put(UNDO_KEY, new UndoAction());
-        actionMap.put(REDO_KEY, new RedoAction());
+        actionMap.put(DELETE_KEY, DELETE_ACTION);
+        actionMap.put(DefaultEditorKit.selectAllAction, SELECT_ALL_ACTION);
+        actionMap.put(DefaultEditorKit.copyAction, COPY_ACTION);
+        actionMap.put(DefaultEditorKit.pasteAction, PASTE_ACTION);
+        actionMap.put(UNDO_KEY, UNDO_ACTION);
+        actionMap.put(REDO_KEY, REDO_ACTION);
 
         // Need to make special input maps as this normally is handled by the texteditor
         InputMap inputMap = component.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
@@ -41,6 +55,17 @@ public class PlatformUtils {
         inputMap.put(Utilities.stringToKey("D-A"), DefaultEditorKit.selectAllAction);
         inputMap.put(Utilities.stringToKey("D-Z"), UNDO_KEY);
         inputMap.put(Utilities.stringToKey("SD-Z"), REDO_KEY);
+    }
+
+    public static void exportAndLoadGcode(String name) {
+        try {
+            DesignWriter designWriter = new GcodeDesignWriter();
+            File file = new File(Files.createTempDir(), name + ".gcode");
+            designWriter.write(file, ControllerFactory.getController());
+            CentralLookup.getDefault().lookup(BackendAPI.class).setGcodeFile(file);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not generate gcode");
+        }
     }
 
     public static SettingsTopComponent openSettings(Controller controller) {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsTopComponent.java
@@ -21,8 +21,8 @@ package com.willwinder.ugs.nbp.designer.platform;
 import com.willwinder.ugs.nbp.designer.gui.SelectionSettingsPanel;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import com.willwinder.ugs.nbp.designer.logic.ControllerEventType;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.designer.logic.ControllerListener;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import org.openide.windows.TopComponent;
 
 /**
@@ -51,7 +51,7 @@ public class SettingsTopComponent extends TopComponent implements ControllerList
         selectionSettingsPanel.release();
         selectionSettingsPanel = null;
 
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        Controller controller = ControllerFactory.getController();
         controller.removeListener(this);
     }
 
@@ -59,7 +59,7 @@ public class SettingsTopComponent extends TopComponent implements ControllerList
     protected void componentOpened() {
         super.componentOpened();
         removeAll();
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
+        Controller controller = ControllerFactory.getController();
         selectionSettingsPanel = new SelectionSettingsPanel(controller);
         add(selectionSettingsPanel);
         controller.addListener(this);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsOpenSupport.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsOpenSupport.java
@@ -19,6 +19,7 @@ public class UgsOpenSupport implements OpenCookie, EditorCookie {
             DesignerTopComponent designerTopComponent = new DesignerTopComponent(dobj);
             designerTopComponent.open();
             designerTopComponent.requestActive();
+            PlatformUtils.exportAndLoadGcode(entry.getDataObject().getName());
         }
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsSaveCookie.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsSaveCookie.java
@@ -18,16 +18,21 @@
  */
 package com.willwinder.ugs.nbp.designer.platform;
 
+import com.google.common.io.Files;
+import com.willwinder.ugs.nbp.designer.io.DesignWriter;
+import com.willwinder.ugs.nbp.designer.io.gcode.GcodeDesignWriter;
 import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignWriter;
-import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.model.BackendAPI;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.openide.cookies.SaveCookie;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.Icon;
+import java.awt.Component;
+import java.awt.Graphics;
 import java.io.File;
 
 /**
@@ -43,13 +48,13 @@ public class UgsSaveCookie implements Icon, SaveCookie {
 
     @Override
     public void save() {
-        Controller controller = CentralLookup.getDefault().lookup(Controller.class);
-        if (controller == null) {
-            throw new IllegalStateException("Couldn't find an instance of the drawing controller");
-        }
+        saveDesign();
+        PlatformUtils.exportAndLoadGcode(dataObject.getName());
+    }
 
+    private void saveDesign() {
         UgsDesignWriter writer = new UgsDesignWriter();
-        writer.write(new File(dataObject.getPrimaryFile().getPath()), controller);
+        writer.write(new File(dataObject.getPrimaryFile().getPath()), ControllerFactory.getController());
         dataObject.setModified(false);
     }
 


### PR DESCRIPTION
This caused it to create duplicates of the service somehow. Created its own singleton instead. Also now loads a new gcode model when the design is saved instead of when the design is updated.