### PR TITLE
Add actions for selecting previous and next entity in the designer

### DIFF
--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SelectNextAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SelectNextAction.java
@@ -1,0 +1,73 @@
+/*
+    Copyright 2023 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.actions;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+
+import java.awt.event.ActionEvent;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Joacim Breiler
+ */
+@ActionID(
+        id = "com.willwinder.ugs.nbp.designer.actions.SelectNextAction",
+        category = LocalizingService.CATEGORY_DESIGNER)
+@ActionRegistration(
+        displayName = "Select next",
+        lazy = false)
+@ActionReferences({
+        @ActionReference(
+                path = "Shortcuts",
+                name = "SD-N")
+})
+public class SelectNextAction extends AbstractDesignAction {
+
+    public SelectNextAction() {
+        putValue("menuText", "Select next");
+        putValue(NAME, "Select next");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        Controller controller = ControllerFactory.getController();
+        List<Entity> entities = controller.getDrawing().getEntities();
+        if (!entities.isEmpty()) {
+            int currentIndex = controller.getSelectionManager()
+                    .getSelection()
+                    .stream()
+                    .findFirst()
+                    .map(entities::indexOf)
+                    .orElse(0);
+
+            if (currentIndex < entities.size() - 1) {
+                currentIndex++;
+            }
+            controller.getSelectionManager().setSelection(Collections.singletonList(entities.get(currentIndex)));
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SelectPreviousAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/SelectPreviousAction.java
@@ -1,0 +1,74 @@
+/*
+    Copyright 2023 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.actions;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+
+import java.awt.event.ActionEvent;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Joacim Breiler
+ */
+@ActionID(
+        id = "com.willwinder.ugs.nbp.designer.actions.SelectPreviousAction",
+        category = LocalizingService.CATEGORY_DESIGNER)
+@ActionRegistration(
+        displayName = "Select previous",
+        lazy = false
+)
+@ActionReferences({
+        @ActionReference(
+                path = "Shortcuts",
+                name = "SD-P")
+})
+public class SelectPreviousAction extends AbstractDesignAction {
+
+    public SelectPreviousAction() {
+        putValue("menuText", "Select previous");
+        putValue(NAME, "Select previous");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        Controller controller = ControllerFactory.getController();
+        List<Entity> entities = controller.getDrawing().getEntities();
+        if (!entities.isEmpty()) {
+            int currentIndex = controller.getSelectionManager()
+                    .getSelection()
+                    .stream()
+                    .findFirst()
+                    .map(entities::indexOf)
+                    .orElse(0);
+
+            if (currentIndex > 0) {
+                currentIndex--;
+            }
+            controller.getSelectionManager().setSelection(Collections.singletonList(entities.get(currentIndex)));
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/MainMenu.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/MainMenu.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Will Winder
+    Copyright 2021-2023 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -32,6 +32,8 @@ import com.willwinder.ugs.nbp.designer.actions.QuitAction;
 import com.willwinder.ugs.nbp.designer.actions.RedoAction;
 import com.willwinder.ugs.nbp.designer.actions.SaveAction;
 import com.willwinder.ugs.nbp.designer.actions.SelectAllAction;
+import com.willwinder.ugs.nbp.designer.actions.SelectNextAction;
+import com.willwinder.ugs.nbp.designer.actions.SelectPreviousAction;
 import com.willwinder.ugs.nbp.designer.actions.UndoAction;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
 import org.openide.util.Utilities;
@@ -69,6 +71,8 @@ public class MainMenu extends JMenuBar {
         JMenuItem flipVertical = new JMenuItem(new FlipVerticallyAction());
 
         JMenuItem all = new JMenuItem(new SelectAllAction());
+        JMenuItem previous = new JMenuItem(new SelectPreviousAction());
+        JMenuItem next = new JMenuItem(new SelectNextAction());
         JMenuItem clear = new JMenuItem(new ClearSelectionAction());
         JMenuItem delete = new JMenuItem(new DeleteAction());
 
@@ -80,7 +84,9 @@ public class MainMenu extends JMenuBar {
         quit.setAccelerator(Utilities.stringToKey("D-Q"));
         export.setAccelerator(Utilities.stringToKey("D-E"));
         clear.setAccelerator(Utilities.stringToKey("O-C"));
+        previous.setAccelerator(Utilities.stringToKey("SD-P"));
         all.setAccelerator(Utilities.stringToKey("D-A"));
+        next.setAccelerator(Utilities.stringToKey("SD-N"));
         delete.setAccelerator(Utilities.stringToKey("BACK_SPACE"));
         copy.setAccelerator(Utilities.stringToKey("D-C"));
         paste.setAccelerator(Utilities.stringToKey("D-V"));
@@ -106,6 +112,8 @@ public class MainMenu extends JMenuBar {
         editMenu.add(flipVertical);
         editMenu.add(new JSeparator());
         editMenu.add(all);
+        editMenu.add(previous);
+        editMenu.add(next);
         editMenu.add(clear);
         editMenu.add(delete);
 


### PR DESCRIPTION
Add actions for selecting previous and next entity in the designer which can be assigned a keymap or assigned to a gamepad.

![2023-01-16 12-26-07 2023-01-16 12_27_25](https://user-images.githubusercontent.com/8962024/212667782-86f1e6c3-7c83-454d-a807-a1d336c0335f.gif)
