### PR TITLE
FluidNC usability fixes

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -34,6 +34,7 @@ import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.types.GrblFeedbackMessage;
 import com.willwinder.universalgcodesender.types.GrblSettingMessage;
+import com.willwinder.universalgcodesender.utils.ControllerUtils;
 import com.willwinder.universalgcodesender.utils.GrblLookups;
 import org.apache.commons.lang3.StringUtils;
 
@@ -378,33 +379,7 @@ public class GrblController extends AbstractController {
             return super.getCommunicatorState();
         }
 
-        ControllerState state = this.controllerStatus == null ? ControllerState.DISCONNECTED : this.controllerStatus.getState();
-        switch(state) {
-            case JOG:
-            case RUN:
-                return CommunicatorState.COMM_SENDING;
-            case HOLD:
-            case DOOR:
-                return CommunicatorState.COMM_SENDING_PAUSED;
-            case IDLE:
-                if (isStreaming()){
-                    return CommunicatorState.COMM_SENDING_PAUSED;
-                } else {
-                    return CommunicatorState.COMM_IDLE;
-                }
-            case ALARM:
-                return CommunicatorState.COMM_IDLE;
-            case CHECK:
-                if (isStreaming() && comm.isPaused()) {
-                    return CommunicatorState.COMM_SENDING_PAUSED;
-                } else if (isStreaming() && !comm.isPaused()) {
-                    return CommunicatorState.COMM_SENDING;
-                } else {
-                    return COMM_CHECK;
-                }
-            default:
-                return CommunicatorState.COMM_IDLE;
-        }
+        return ControllerUtils.getCommunicatorState(controllerStatus.getState(), this, comm);
     }
 
     /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/SmoothieController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/SmoothieController.java
@@ -30,6 +30,7 @@ import com.willwinder.universalgcodesender.listeners.ControllerStatusBuilder;
 import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.*;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
+import com.willwinder.universalgcodesender.utils.ControllerUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import static com.willwinder.universalgcodesender.model.CommunicatorState.*;
@@ -274,32 +275,7 @@ public class SmoothieController extends AbstractController {
 
     @Override
     public CommunicatorState getCommunicatorState() {
-        ControllerState state = controllerStatus.getState();
-        switch(state) {
-            case JOG:
-            case RUN:
-                return COMM_SENDING;
-            case HOLD:
-            case DOOR:
-                return COMM_SENDING_PAUSED;
-            case IDLE:
-                if (isStreaming()){
-                    return COMM_SENDING_PAUSED;
-                } else {
-                    return COMM_IDLE;
-                }
-            case CHECK:
-                if (isStreaming() && comm.isPaused()) {
-                    return COMM_SENDING_PAUSED;
-                } else if (isStreaming() && !comm.isPaused()) {
-                    return COMM_SENDING;
-                } else {
-                    return COMM_CHECK;
-                }
-            case ALARM:
-            default:
-                return COMM_IDLE;
-        }
+        return ControllerUtils.getCommunicatorState(controllerStatus.getState(), this, comm);
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -34,6 +34,7 @@ import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.*;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.types.TinyGGcodeCommand;
+import com.willwinder.universalgcodesender.utils.ControllerUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,8 +43,6 @@ import java.util.logging.Logger;
 
 import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
 import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_SENDING;
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_SENDING_PAUSED;
 
 /**
  * TinyG Control layer, coordinates all aspects of control.
@@ -430,32 +429,7 @@ public class TinyGController extends AbstractController {
     }
 
     protected CommunicatorState getControlState(ControllerState controllerState) {
-        switch (controllerState) {
-            case JOG:
-            case RUN:
-                return COMM_SENDING;
-            case HOLD:
-            case DOOR:
-                return COMM_SENDING_PAUSED;
-            case IDLE:
-                if (isStreaming()) {
-                    return COMM_SENDING_PAUSED;
-                } else {
-                    return COMM_IDLE;
-                }
-            case ALARM:
-                return COMM_IDLE;
-            case CHECK:
-                if (isStreaming() && comm.isPaused()) {
-                    return COMM_SENDING_PAUSED;
-                } else if (isStreaming() && !comm.isPaused()) {
-                    return COMM_SENDING;
-                } else {
-                    return COMM_CHECK;
-                }
-            default:
-                return COMM_IDLE;
-        }
+        return ControllerUtils.getCommunicatorState(controllerState, this, comm);
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/CommandTextArea.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/CommandTextArea.java
@@ -18,6 +18,7 @@
  */
 package com.willwinder.universalgcodesender.uielements.components;
 
+import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.UGSEvent;
@@ -77,10 +78,12 @@ public class CommandTextArea extends JTextField implements KeyEventDispatcher, U
     @Override
     public void UGSEvent(UGSEvent evt) {
         if (evt instanceof ControllerStateEvent) {
-            if (!backend.isIdle() && isEnabled()) {
+            ControllerState state = backend.getControllerState();
+            boolean isIdle = (state == ControllerState.IDLE || state == ControllerState.ALARM || state == ControllerState.CHECK);
+            if (!isIdle && isEnabled()) {
                 regainFocus = hasFocus();
                 setEnabled(false);
-            } else if (backend.isIdle() && !isEnabled()) {
+            } else if (isIdle && !isEnabled()) {
                 setEnabled(true);
                 if (regainFocus) {
                     regainFocus = false;

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCControllerTest.java
@@ -27,10 +27,11 @@ import static org.mockito.Mockito.when;
 public class FluidNCControllerTest {
 
     private IController target;
+    private ICommunicator communicator;
 
     @Before
     public void setUp() {
-        ICommunicator communicator = mock(ICommunicator.class);
+        communicator = mock(ICommunicator.class);
         target = spy(new FluidNCController(communicator));
     }
 
@@ -67,6 +68,50 @@ public class FluidNCControllerTest {
         List<GcodeCommand> commands = commandArgumentCaptor.getAllValues();
         assertEquals("G90 G0 X0 Y0", commands.get(0).getCommandString());
         assertEquals("G90 G0 Z0", commands.get(1).getCommandString());
+    }
+
+    @Test
+    public void restoreParserModalStateShouldRestoreUnitsToMM() {
+        target.updateParserModalState(new GcodeCommand("G21"));
+
+        ArgumentCaptor<GcodeCommand> commandArgumentCaptor = ArgumentCaptor.forClass(GcodeCommand.class);
+        doNothing().when(communicator).queueCommand(commandArgumentCaptor.capture());
+        target.restoreParserModalState();
+
+        assertEquals("G21", commandArgumentCaptor.getValue().getCommandString());
+    }
+
+    @Test
+    public void restoreParserModalStateShouldRestoreUnitsToInches() {
+        target.updateParserModalState(new GcodeCommand("G20"));
+
+        ArgumentCaptor<GcodeCommand> commandArgumentCaptor = ArgumentCaptor.forClass(GcodeCommand.class);
+        doNothing().when(communicator).queueCommand(commandArgumentCaptor.capture());
+        target.restoreParserModalState();
+
+        assertEquals("G20", commandArgumentCaptor.getValue().getCommandString());
+    }
+
+    @Test
+    public void restoreParserModalStateShouldRestoreAbsoluteMode() {
+        target.updateParserModalState(new GcodeCommand("G90"));
+
+        ArgumentCaptor<GcodeCommand> commandArgumentCaptor = ArgumentCaptor.forClass(GcodeCommand.class);
+        doNothing().when(communicator).queueCommand(commandArgumentCaptor.capture());
+        target.restoreParserModalState();
+
+        assertEquals("G90", commandArgumentCaptor.getValue().getCommandString());
+    }
+
+    @Test
+    public void restoreParserModalStateShouldRestoreRelativeMode() {
+        target.updateParserModalState(new GcodeCommand("G91"));
+
+        ArgumentCaptor<GcodeCommand> commandArgumentCaptor = ArgumentCaptor.forClass(GcodeCommand.class);
+        doNothing().when(communicator).queueCommand(commandArgumentCaptor.capture());
+        target.restoreParserModalState();
+
+        assertEquals("G91", commandArgumentCaptor.getValue().getCommandString());
     }
 
     private void mockControllerStatus(Position workPosition) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCUtilsTest.java
@@ -1,15 +1,25 @@
 package com.willwinder.universalgcodesender.firmware.fluidnc;
 
 import com.willwinder.universalgcodesender.Capabilities;
+import com.willwinder.universalgcodesender.IController;
 import com.willwinder.universalgcodesender.firmware.IFirmwareSettings;
+import com.willwinder.universalgcodesender.firmware.fluidnc.commands.GetFirmwareVersionCommand;
+import com.willwinder.universalgcodesender.firmware.fluidnc.commands.GetStatusCommand;
+import com.willwinder.universalgcodesender.services.MessageService;
+import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.SemanticVersion;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 import static com.willwinder.universalgcodesender.CapabilitiesConstants.FILE_SYSTEM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FluidNCUtilsTest {
 
@@ -58,5 +68,135 @@ public class FluidNCUtilsTest {
 
         FluidNCUtils.addCapabilities(capabilities, new SemanticVersion(3, 5, 2), firmwareSettings);
         assertTrue(capabilities.hasCapability(FILE_SYSTEM));
+    }
+
+    @Test
+    public void queryFirmwareVersionShouldReturnTheFirmwareVersion() throws Exception {
+        IController controller = mock(IController.class);
+        MessageService messageService = mock(MessageService.class);
+
+        // Simulate response from controller on any sent gcode commands
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("[VER:3.6 FluidNC v3.6.6:]");
+            command.appendResponse("ok");
+            return null;
+        }).when(controller).sendCommandImmediately(any());
+
+        GetFirmwareVersionCommand firmwareVersionCommand = FluidNCUtils.queryFirmwareVersion(controller, messageService);
+        SemanticVersion semanticVersion = firmwareVersionCommand.getVersion();
+        assertEquals(semanticVersion.getMajor(), 3);
+        assertEquals(semanticVersion.getMinor(), 6);
+        assertEquals(semanticVersion.getPatch(), 6);
+        assertEquals("FluidNC", firmwareVersionCommand.getFirmware());
+    }
+
+    @Test
+    public void queryFirmwareVersionShouldThrowErrorIfVersionToLow() throws Exception {
+        IController controller = mock(IController.class);
+        MessageService messageService = mock(MessageService.class);
+
+        // Simulate response from controller on any sent gcode commands
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("[VER:3.6 FluidNC v3.2.9:]");
+            command.appendResponse("ok");
+            return null;
+        }).when(controller).sendCommandImmediately(any());
+
+        assertThrows(IllegalStateException.class, () -> FluidNCUtils.queryFirmwareVersion(controller, messageService));
+    }
+
+    @Test
+    public void queryFirmwareVersionShouldThrowErrorIfNotFluidNC() throws Exception {
+        IController controller = mock(IController.class);
+        MessageService messageService = mock(MessageService.class);
+
+        // Simulate response from controller on any sent gcode commands
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("[VER:3.6 SomethingElse v3.6.6:]");
+            command.appendResponse("ok");
+            return null;
+        }).when(controller).sendCommandImmediately(any());
+
+        assertThrows(IllegalStateException.class, () -> FluidNCUtils.queryFirmwareVersion(controller, messageService));
+    }
+
+    @Test
+    public void isControllerResponsiveWhenControllerRespondsAsIdle() throws Exception {
+        IController controller = mock(IController.class);
+        when(controller.isCommOpen()).thenReturn(true);
+        MessageService messageService = mock(MessageService.class);
+
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("<Idle>");
+            return null;
+        }).when(controller).sendCommandImmediately(any(GetStatusCommand.class));
+
+        assertTrue(FluidNCUtils.isControllerResponsive(controller, messageService));
+    }
+
+    @Test
+    public void isControllerResponsiveWhenControllerHold() throws Exception {
+        IController controller = mock(IController.class);
+        when(controller.isCommOpen()).thenReturn(true);
+        MessageService messageService = mock(MessageService.class);
+
+        // Respond with status hold
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("<Hold>");
+            return null;
+        }).when(controller).sendCommandImmediately(any(GetStatusCommand.class));
+
+        // Responds with ok on empty system command
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("ok");
+            return null;
+        }).when(controller).sendCommandImmediately(ArgumentMatchers.argThat(command -> command.getCommandString().equals("")));
+
+        assertTrue(FluidNCUtils.isControllerResponsive(controller, messageService));
+    }
+
+    @Test
+    public void isControllerResponsiveWhenControllerInAlarm() throws Exception {
+        IController controller = mock(IController.class);
+        when(controller.isCommOpen()).thenReturn(true);
+        MessageService messageService = mock(MessageService.class);
+
+        // Respond with status hold
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("<Alarm>");
+            return null;
+        }).when(controller).sendCommandImmediately(any(GetStatusCommand.class));
+
+        // Responds with ok on empty system command
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("ok");
+            return null;
+        }).when(controller).sendCommandImmediately(ArgumentMatchers.argThat(command -> command.getCommandString().equals("")));
+
+        assertTrue(FluidNCUtils.isControllerResponsive(controller, messageService));
+    }
+
+    @Test
+    public void isControllerResponsiveWhenControllerInAlarmAndNotResponsive() throws Exception {
+        IController controller = mock(IController.class);
+        when(controller.isCommOpen()).thenReturn(true);
+        MessageService messageService = mock(MessageService.class);
+
+        // Respond with status hold
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("<Alarm>");
+            return null;
+        }).when(controller).sendCommandImmediately(any(GetStatusCommand.class));
+
+        assertFalse(FluidNCUtils.isControllerResponsive(controller, messageService));
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/utils/ControllerUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/utils/ControllerUtilsTest.java
@@ -19,6 +19,9 @@
 package com.willwinder.universalgcodesender.utils;
 
 import com.willwinder.universalgcodesender.IController;
+import com.willwinder.universalgcodesender.communicator.ICommunicator;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
+import com.willwinder.universalgcodesender.model.CommunicatorState;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import org.junit.Test;
 
@@ -151,5 +154,28 @@ public class ControllerUtilsTest {
 
         ControllerUtils.sendAndWaitForCompletionWithRetry(supplier, controller, 200, 10, integer -> {});
         verify(controller, times(0)).sendCommandImmediately(any());
+    }
+
+    @Test
+    public void getCommunicatorStateShouldReturnPausedWhenControllerIdleAndStreaming() {
+        IController controller = mock(IController.class);
+        when(controller.isStreaming()).thenReturn(true);
+        ICommunicator communicator = mock(ICommunicator.class);
+
+        CommunicatorState communicatorState = ControllerUtils.getCommunicatorState(ControllerState.IDLE, controller, communicator);
+
+        assertEquals(CommunicatorState.COMM_SENDING_PAUSED, communicatorState);
+    }
+
+    @Test
+    public void getCommunicatorStateShouldReturnPausedWhenControllerCheckAndStreaming() {
+        IController controller = mock(IController.class);
+        when(controller.isStreaming()).thenReturn(true);
+        ICommunicator communicator = mock(ICommunicator.class);
+        when(communicator.isPaused()).thenReturn(true);
+
+        CommunicatorState communicatorState = ControllerUtils.getCommunicatorState(ControllerState.CHECK, controller, communicator);
+
+        assertEquals(CommunicatorState.COMM_SENDING_PAUSED, communicatorState);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-console/src/main/java/com/willwinder/ugs/nbp/console/ConsolePanel.java
+++ b/ugs-platform/ugs-platform-plugin-console/src/main/java/com/willwinder/ugs/nbp/console/ConsolePanel.java
@@ -69,7 +69,6 @@ public class ConsolePanel extends JPanel implements MessageListener {
         // After the IO has been loaded, get the text component and disable some properties
         JTextComponent textView = consoleProvider.getTextComponent();
         textView.setEditable(false);
-        textView.setFocusable(false);
 
         this.backend = backend;
         backend.addMessageListener(this);

--- a/ugs-platform/ugs-platform-plugin-filebrowser/src/main/java/com/willwinder/ugs/nbp/filebrowser/actions/OpenFileBrowserAction.java
+++ b/ugs-platform/ugs-platform-plugin-filebrowser/src/main/java/com/willwinder/ugs/nbp/filebrowser/actions/OpenFileBrowserAction.java
@@ -72,8 +72,9 @@ public final class OpenFileBrowserAction extends AbstractAction implements UGSEv
 
     @Override
     public boolean isEnabled() {
+        ControllerState state = backend.getControllerState();
         return backend.isConnected() &&
-                backend.getController().getControllerStatus().getState() == ControllerState.IDLE &&
+                (state == ControllerState.IDLE || state == ControllerState.ALARM) &&
                 backend.getController().getCapabilities().hasCapability(CapabilitiesConstants.FILE_SYSTEM);
     }
 


### PR DESCRIPTION
Made a couple of usability changes to the FluidNC implementation:
* When stopping a running GCode program it will no longer fully reset the controller
* When initializing and it starts in Alarm or Hold state it will now do a quick check if it is finite and requires a reset
* Made the command text area active on alarms to be able to reconfigure the controller
* Made the console window focusable again to be able to copy text
* Made the file browser openable on alarm state