### PR TITLE
New design and gcode actions

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
@@ -45,6 +45,13 @@ public interface BackendAPI extends BackendAPIReadOnly {
     void setGcodeFile(File file) throws Exception;
 
     /**
+     * Resets the backend and unloads the currently loaded gcode file
+     *
+     * @throws Exception
+     */
+    void unsetGcodeFile() throws Exception;
+
+    /**
      * Reloads the currently loaded gcode file. This will retain the current parser and its processors.
      *
      * @throws Exception

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -323,7 +323,7 @@ public class GUIBackend implements BackendAPI {
 
     @Override
     public ControllerState getControllerState() {
-        return controller != null ? controller.getControllerStatus().getState() : ControllerState.DISCONNECTED;
+        return controller != null && controller.getControllerStatus() != null ? controller.getControllerStatus().getState() : ControllerState.DISCONNECTED;
     }
 
     @Override
@@ -358,6 +358,18 @@ public class GUIBackend implements BackendAPI {
         initGcodeParser();
         this.gcodeFile = file;
         processGcodeFile();
+    }
+
+    @Override
+    public void unsetGcodeFile() throws Exception {
+        if (gcodeStream != null) {
+            gcodeStream.close();
+        }
+
+        eventDispatcher.sendUGSEvent(new FileStateEvent(FileState.FILE_UNLOADED, null));
+        initGcodeParser();
+        this.gcodeFile = null;
+        this.processedGcodeFile = null;
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/events/FileState.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/events/FileState.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Will Winder
+    Copyright 2021-2023 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -22,5 +22,6 @@ public enum FileState {
     OPENING_FILE,
     FILE_LOADING,
     FILE_LOADED,
+    FILE_UNLOADED,
     FILE_STREAM_COMPLETE
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/toolbars/SendStatusLine.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/toolbars/SendStatusLine.java
@@ -30,6 +30,7 @@ import java.awt.event.ActionListener;
 
 import static com.willwinder.universalgcodesender.model.events.FileState.FILE_LOADED;
 import static com.willwinder.universalgcodesender.model.events.FileState.FILE_STREAM_COMPLETE;
+import static com.willwinder.universalgcodesender.model.events.FileState.FILE_UNLOADED;
 
 /**
  * A component which should be embedded in a status bar.
@@ -123,7 +124,7 @@ public class SendStatusLine extends JLabel implements UGSEventListener {
         // Display the number of rows when a file is loaded.
         if (evt instanceof FileStateEvent) {
             FileStateEvent fileStateEvent = (FileStateEvent) evt;
-            if (fileStateEvent.getFileState() == FILE_LOADED) {
+            if (fileStateEvent.getFileState() == FILE_LOADED || fileStateEvent.getFileState() == FILE_UNLOADED) {
                 setRows();
             } else if (fileStateEvent.getFileState() == FILE_STREAM_COMPLETE) {
                 endSend();

--- a/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/model/GUIBackendTest.java
@@ -486,6 +486,33 @@ public class GUIBackendTest {
         assertNotNull(instance.getProcessedGcodeFile());
     }
 
+    @Test
+    public void unsetGcodeFileShouldUnloadFile() throws Exception {
+        // Given
+        instance.connect(FIRMWARE, PORT, BAUD_RATE);
+
+        File tempFile = File.createTempFile("ugs-", ".gcode");
+        FileUtils.writeStringToFile(tempFile, "G0 X0 Y0\n", StandardCharsets.UTF_8);
+        instance.setGcodeFile(tempFile);
+
+        // When
+        instance.unsetGcodeFile();
+
+        // Then
+        List<UGSEvent> events = eventArgumentCaptor.getAllValues();
+        assertEquals(5, events.size());
+        assertEquals(FileState.OPENING_FILE, ((FileStateEvent) events.get(0)).getFileState());
+        assertEquals(FileState.FILE_LOADING, ((FileStateEvent) events.get(1)).getFileState());
+        assertEquals(SettingChangedEvent.class, events.get(2).getClass());
+        assertEquals(FileState.FILE_LOADED, ((FileStateEvent) events.get(3)).getFileState());
+        assertEquals(FileState.FILE_UNLOADED, ((FileStateEvent) events.get(4)).getFileState());
+
+        assertNull(instance.getProcessedGcodeFile());
+        assertNull(instance.getGcodeFile());
+        assertEquals(0, instance.getNumRemainingRows());
+        assertEquals(0, instance.getNumRows());
+    }
+
     @Test(expected = IOException.class)
     public void getGcodeFileThatDoesNotExistShouldThrowException() throws Exception {
         // Given

--- a/ugs-platform/ugs-platform-gcode-editor/pom.xml
+++ b/ugs-platform/ugs-platform-gcode-editor/pom.xml
@@ -16,6 +16,7 @@
                 <groupId>org.apache.netbeans.utilities</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
                 <configuration>
+                    <verifyRuntime>warn</verifyRuntime>
                     <publicPackages>
                     </publicPackages>
                 </configuration>

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/EditorUtils.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/EditorUtils.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Will Winder
+    Copyright 2021-2023 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -29,10 +29,36 @@ import java.io.File;
  * @author Joacim Breiler
  */
 public class EditorUtils {
-    public static void openFile(FileObject pf) {
+
+    private EditorUtils() {
+        // Can not be instanced
+    }
+
+    /**
+     * Loads the file into the backend
+     *
+     * @param fileObject the file object to load
+     */
+    public static void openFile(FileObject fileObject) {
         BackendAPI backend = CentralLookup.getDefault().lookup(BackendAPI.class);
         try {
-            backend.setGcodeFile(new File((pf.getPath())));
+            backend.setGcodeFile(new File((fileObject.getPath())));
+        } catch (Exception e) {
+            ErrorManager.getDefault().notify(ErrorManager.WARNING, e);
+        }
+    }
+
+    /**
+     * Unloads the gcode in the backend if all editor panes are closed
+     */
+    public static void unloadFile() {
+        if (com.willwinder.ugs.nbp.lib.EditorUtils.getOpenEditors().size() > 1) {
+            return;
+        }
+
+        try {
+            BackendAPI backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+            backend.unsetGcodeFile();
         } catch (Exception e) {
             ErrorManager.getDefault().notify(ErrorManager.WARNING, e);
         }

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
@@ -105,6 +105,7 @@ public class SourceMultiviewElement extends MultiViewEditorElement implements UG
             GcodeHighlightsLayerFactory.release(getEditorPane().getDocument());
         }
         editorListener.reset();
+        EditorUtils.unloadFile();
         super.componentClosed();
     }
 

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/NewGcodeAction.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/actions/NewGcodeAction.java
@@ -1,0 +1,127 @@
+/*
+    Copyright 2021 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.editor.actions;
+
+import com.willwinder.ugs.nbp.core.actions.OpenAction;
+import com.willwinder.ugs.nbp.lib.EditorUtils;
+import com.willwinder.ugs.nbp.lib.services.LocalizingService;
+import com.willwinder.universalgcodesender.uielements.components.GcodeFileTypeFilter;
+import com.willwinder.universalgcodesender.utils.GUIHelpers;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+import org.openide.cookies.OpenCookie;
+import org.openide.filesystems.FileChooserBuilder;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataObject;
+import org.openide.util.ImageUtilities;
+
+import javax.swing.AbstractAction;
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@ActionID(
+        category = LocalizingService.OpenCategory,
+        id = "com.willwinder.ugs.nbp.editor.actions.NewGcodeAction")
+@ActionRegistration(
+        iconBase = "icons/new.svg",
+        displayName = "New gcode",
+        lazy = false)
+@ActionReferences({
+        @ActionReference(
+                path = LocalizingService.OpenWindowPath,
+                position = 8),
+        @ActionReference(
+                path = "Toolbars/File",
+                position = 8)
+})
+public final class NewGcodeAction extends AbstractAction {
+
+    public static final String SMALL_ICON_PATH = "icons/new.svg";
+    public static final String LARGE_ICON_PATH = "icons/new24.svg";
+
+    public NewGcodeAction() {
+        putValue("iconBase", SMALL_ICON_PATH);
+        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
+        putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
+        putValue("menuText", "New gcode file");
+        putValue(NAME, "New gcode file");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (!EditorUtils.closeOpenEditors()) {
+            return;
+        }
+
+        try {
+            File file = chooseFile();
+            if (!file.createNewFile()) {
+                throw new IOException("Could not create temporary file " + file);
+            }
+            writeExampleToFile(file);
+            FileObject fileObject = FileUtil.toFileObject(file);
+            DataObject.find(fileObject).getLookup().lookup(OpenCookie.class).open();
+        } catch (IOException ex) {
+            GUIHelpers.displayErrorDialog("Could not create temporary file");
+        }
+    }
+
+    private File chooseFile() throws IOException {
+        FileChooserBuilder fcb = new FileChooserBuilder(OpenAction.class);
+        fcb.setTitle("Create Gcode file");
+        fcb.setFileFilter(new GcodeFileTypeFilter());
+        JFileChooser fileChooser = fcb.createFileChooser();
+        fileChooser.setFileHidingEnabled(true);
+
+        if (fileChooser.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) {
+            throw new IOException();
+        }
+
+        // Removing the old file
+        File file = new File(StringUtils.appendIfMissing(fileChooser.getSelectedFile().getAbsolutePath(), ".gcode"));
+        if (file.exists()) {
+            if (JOptionPane.showConfirmDialog(null, "Are you sure you want to overwrite the file " + file.getName(), "Overwrite existing file", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+                file.delete();
+            } else {
+                throw new IOException();
+            }
+        }
+        return file;
+    }
+
+    private void writeExampleToFile(File file) throws IOException {
+        try (InputStream exampleStream = getClass().getResourceAsStream("/com/willwinder/ugs/nbp/editor/example.gcode")) {
+            if (exampleStream == null) {
+                return;
+            }
+            FileUtils.write(file, IOUtils.toString(exampleStream, StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/example.gcode
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/com/willwinder/ugs/nbp/editor/example.gcode
@@ -1,0 +1,22 @@
+G21 ; millimeters
+G90 ; absolute coordinate
+G17 ; XY plane
+G94 ; units per minute feed rate mode
+M3 S1000 ; Turning on spindle
+
+; Go to safety height
+G0 Z5
+
+; Go to zero location
+G0 X0 Y0
+G0 Z0
+
+; Create rectangle
+G1 X0 Y0 F1000
+G1 Y10
+G1 X10
+G1 Y0
+G1 X0
+
+; Turning off spindle
+M5

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/icons/new.svg
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/icons/new.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg960"
+   sodipodi:docname="new.svg"
+   width="16"
+   height="16"
+   inkscape:version="1.2.2 (b0a8486, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs964" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1436"
+     inkscape:window-height="1051"
+     id="namedview962"
+     showgrid="false"
+     height="16px"
+     inkscape:zoom="7.16"
+     inkscape:cx="47.695531"
+     inkscape:cy="9.5670391"
+     inkscape:window-x="61"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg960"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="M 13.856485,3.061902 11.235266,0.44053896 C 10.954087,0.15934388 10.572932,0 10.176156,0 H 3.7996251 C 2.971707,0.00312439 2.3,0.6748682 2.3,1.5028315 V 14.500293 C 2.3,15.328256 2.971707,16 3.7996251,16 H 12.797376 C 13.625293,16 14.297,15.328256 14.297,14.500293 V 4.1241945 C 14.297,3.727397 14.137664,3.3430971 13.856485,3.061902 Z M 12.675531,4.0023433 H 10.298 V 1.6246827 Z M 3.7996251,14.500293 V 1.5028315 h 4.9987498 v 3.2493654 c 0,0.4155441 0.3342921,0.7498536 0.7498131,0.7498536 h 3.249188 v 8.9982425 z"
+     id="path958"
+     style="fill:#353a40;fill-opacity:1;stroke-width:0.0312431"
+     sodipodi:nodetypes="ssscssssssscccccccssccc" />
+  <g
+     aria-label="G0"
+     id="text5885"
+     style="font-size:12.8724px;line-height:1.25;font-family:'Courier New';-inkscape-font-specification:'Courier New';fill:#353a40;stroke-width:0.32181"
+     transform="matrix(0.49997917,0,0,0.5,0.3000833,0)">
+    <path
+       d="m 14.920801,22.709926 q -1.087366,0.798239 -2.407289,0.798239 -1.728472,0 -2.6209921,-1.169075 Q 9,21.163729 9,18.907288 q 0,-2.181017 0.8610931,-3.39409 0.8673789,-1.213073 2.6524189,-1.213073 0.641105,0 1.269641,0.163419 0.628535,0.163419 1.011941,0.43369 l -0.339409,0.81081 q -0.886234,-0.502828 -1.942173,-0.502828 -1.219359,0 -1.822752,0.89252 -0.597109,0.89252 -0.597109,2.809552 0,3.695787 2.419861,3.695787 0.911376,0 1.376492,-0.383407 v -2.187302 h -1.59648 v -0.89252 h 2.627277 z"
+       style="font-weight:bold;font-family:monospace;-inkscape-font-specification:'monospace Bold'"
+       id="path5937" />
+    <path
+       d="m 19.773093,14.300125 q 1.407918,0 2.162161,1.213073 0.760527,1.206788 0.760527,3.39409 0,2.118163 -0.735386,3.362663 -0.735386,1.238214 -2.187302,1.238214 -1.401634,0 -2.162161,-1.206787 -0.760528,-1.206788 -0.760528,-3.39409 0,-2.124449 0.735386,-3.362663 0.741672,-1.2445 2.187303,-1.2445 z m 0,8.30295 q 0.930232,0 1.376492,-0.879949 0.452545,-0.886235 0.452545,-2.815838 0,-1.935888 -0.452545,-2.809552 -0.44626,-0.879949 -1.376492,-0.879949 -0.917662,0 -1.370207,0.898805 -0.452545,0.898805 -0.452545,2.790696 0,1.917032 0.44626,2.809552 0.452545,0.886235 1.376492,0.886235 z m -0.02514,-4.63859 q 0.395977,0 0.666248,0.276556 0.276555,0.27027 0.276555,0.666247 0,0.408548 -0.276555,0.703959 -0.276556,0.289127 -0.666248,0.289127 -0.383406,0 -0.659962,-0.289127 -0.27027,-0.295411 -0.27027,-0.703959 0,-0.402263 0.263985,-0.672533 0.27027,-0.27027 0.666247,-0.27027 z"
+       style="font-weight:bold;font-family:monospace;-inkscape-font-specification:'monospace Bold'"
+       id="path5939" />
+  </g>
+</svg>

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/icons/new24.svg
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/icons/new24.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg960"
+   sodipodi:docname="new24.svg"
+   width="24"
+   height="24"
+   inkscape:version="1.2.2 (b0a8486, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs964" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1436"
+     inkscape:window-height="1051"
+     id="namedview962"
+     showgrid="false"
+     height="16px"
+     inkscape:zoom="7.16"
+     inkscape:cx="47.695531"
+     inkscape:cy="9.5670391"
+     inkscape:window-x="61"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg960"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="M 20.435209,4.592853 16.503271,0.66080844 C 16.08149,0.23901582 15.509743,0 14.914562,0 H 5.3495 C 4.1075884,0.00468659 3.1,1.0123023 3.1,2.2542473 V 21.750439 C 3.1,22.992384 4.1075884,24 5.3495,24 h 13.497 c 1.241911,0 2.2495,-1.007616 2.2495,-2.249561 V 6.1862918 c 0,-0.5951963 -0.23901,-1.1716461 -0.660791,-1.5934388 z M 18.663728,6.0035149 H 15.097333 V 2.437024 Z M 5.3495,21.750439 V 2.2542473 h 7.498333 v 4.874048 c 0,0.6233162 0.501452,1.1247805 1.12475,1.1247805 H 18.8465 V 21.750439 Z"
+     id="path958"
+     style="fill:#353a40;fill-opacity:1;stroke-width:0.0468652"
+     sodipodi:nodetypes="ssscssssssscccccccssccc" />
+  <g
+     aria-label="G0"
+     id="text5885"
+     style="font-size:12.8724px;line-height:1.25;font-family:'Courier New';-inkscape-font-specification:'Courier New';fill:#353a40;stroke-width:0.32181"
+     transform="matrix(0.74998958,0,0,0.75,0.10004168,0)">
+    <path
+       d="m 14.920801,22.709926 q -1.087366,0.798239 -2.407289,0.798239 -1.728472,0 -2.6209921,-1.169075 Q 9,21.163729 9,18.907288 q 0,-2.181017 0.8610931,-3.39409 0.8673789,-1.213073 2.6524189,-1.213073 0.641105,0 1.269641,0.163419 0.628535,0.163419 1.011941,0.43369 l -0.339409,0.81081 q -0.886234,-0.502828 -1.942173,-0.502828 -1.219359,0 -1.822752,0.89252 -0.597109,0.89252 -0.597109,2.809552 0,3.695787 2.419861,3.695787 0.911376,0 1.376492,-0.383407 v -2.187302 h -1.59648 v -0.89252 h 2.627277 z"
+       style="font-weight:bold;font-family:monospace;-inkscape-font-specification:'monospace Bold'"
+       id="path5937" />
+    <path
+       d="m 19.773093,14.300125 q 1.407918,0 2.162161,1.213073 0.760527,1.206788 0.760527,3.39409 0,2.118163 -0.735386,3.362663 -0.735386,1.238214 -2.187302,1.238214 -1.401634,0 -2.162161,-1.206787 -0.760528,-1.206788 -0.760528,-3.39409 0,-2.124449 0.735386,-3.362663 0.741672,-1.2445 2.187303,-1.2445 z m 0,8.30295 q 0.930232,0 1.376492,-0.879949 0.452545,-0.886235 0.452545,-2.815838 0,-1.935888 -0.452545,-2.809552 -0.44626,-0.879949 -1.376492,-0.879949 -0.917662,0 -1.370207,0.898805 -0.452545,0.898805 -0.452545,2.790696 0,1.917032 0.44626,2.809552 0.452545,0.886235 1.376492,0.886235 z m -0.02514,-4.63859 q 0.395977,0 0.666248,0.276556 0.276555,0.27027 0.276555,0.666247 0,0.408548 -0.276555,0.703959 -0.276556,0.289127 -0.666248,0.289127 -0.383406,0 -0.659962,-0.289127 -0.27027,-0.295411 -0.27027,-0.703959 0,-0.402263 0.263985,-0.672533 0.27027,-0.27027 0.666247,-0.27027 z"
+       style="font-weight:bold;font-family:monospace;-inkscape-font-specification:'monospace Bold'"
+       id="path5939" />
+  </g>
+</svg>

--- a/ugs-platform/ugs-platform-gcode-editor/src/main/resources/icons/new32.svg
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/resources/icons/new32.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg960"
+   sodipodi:docname="new32.svg"
+   width="32"
+   height="32"
+   inkscape:version="1.2.2 (b0a8486, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs964" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1436"
+     inkscape:window-height="1051"
+     id="namedview962"
+     showgrid="false"
+     height="16px"
+     inkscape:zoom="7.16"
+     inkscape:cx="47.695531"
+     inkscape:cy="9.5670391"
+     inkscape:window-x="61"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg960"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="M 27.113934,6.123804 21.871276,0.88107792 C 21.308893,0.31868776 20.546553,0 19.752968,0 H 6.9993749 C 5.3434699,0.00624879 4,1.3497364 4,3.0056631 V 29.000585 C 4,30.656512 5.3434699,32 6.9993749,32 H 24.995626 C 26.651529,32 27.995,30.656512 27.995,29.000585 V 8.2483891 C 27.995,7.454794 27.676316,6.6861943 27.113934,6.123804 Z M 24.751925,8.0046865 H 19.996667 V 3.2493653 Z M 6.9993749,29.000585 V 3.0056631 h 9.9979161 v 6.4987306 c 0,0.8310883 0.668612,1.4997073 1.499687,1.4997073 h 6.498648 v 17.996484 z"
+     id="path958"
+     style="fill:#353a40;fill-opacity:1;stroke-width:0.0624873"
+     sodipodi:nodetypes="ssscssssssscccccccssccc" />
+  <g
+     aria-label="G0"
+     id="text5885"
+     style="font-size:12.8724px;line-height:1.25;font-family:'Courier New';-inkscape-font-specification:'Courier New';fill:#353a40;stroke-width:0.32181">
+    <path
+       d="m 14.920801,22.709926 q -1.087366,0.798239 -2.407289,0.798239 -1.728472,0 -2.6209921,-1.169075 Q 9,21.163729 9,18.907288 q 0,-2.181017 0.8610931,-3.39409 0.8673789,-1.213073 2.6524189,-1.213073 0.641105,0 1.269641,0.163419 0.628535,0.163419 1.011941,0.43369 l -0.339409,0.81081 q -0.886234,-0.502828 -1.942173,-0.502828 -1.219359,0 -1.822752,0.89252 -0.597109,0.89252 -0.597109,2.809552 0,3.695787 2.419861,3.695787 0.911376,0 1.376492,-0.383407 v -2.187302 h -1.59648 v -0.89252 h 2.627277 z"
+       style="font-weight:bold;font-family:monospace;-inkscape-font-specification:'monospace Bold'"
+       id="path5937" />
+    <path
+       d="m 19.773093,14.300125 q 1.407918,0 2.162161,1.213073 0.760527,1.206788 0.760527,3.39409 0,2.118163 -0.735386,3.362663 -0.735386,1.238214 -2.187302,1.238214 -1.401634,0 -2.162161,-1.206787 -0.760528,-1.206788 -0.760528,-3.39409 0,-2.124449 0.735386,-3.362663 0.741672,-1.2445 2.187303,-1.2445 z m 0,8.30295 q 0.930232,0 1.376492,-0.879949 0.452545,-0.886235 0.452545,-2.815838 0,-1.935888 -0.452545,-2.809552 -0.44626,-0.879949 -1.376492,-0.879949 -0.917662,0 -1.370207,0.898805 -0.452545,0.898805 -0.452545,2.790696 0,1.917032 0.44626,2.809552 0.452545,0.886235 1.376492,0.886235 z m -0.02514,-4.63859 q 0.395977,0 0.666248,0.276556 0.276555,0.27027 0.276555,0.666247 0,0.408548 -0.276555,0.703959 -0.276556,0.289127 -0.666248,0.289127 -0.383406,0 -0.659962,-0.289127 -0.27027,-0.295411 -0.27027,-0.703959 0,-0.402263 0.263985,-0.672533 0.27027,-0.27027 0.666247,-0.27027 z"
+       style="font-weight:bold;font-family:monospace;-inkscape-font-specification:'monospace Bold'"
+       id="path5939" />
+  </g>
+</svg>

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
@@ -130,6 +130,11 @@ public class DesignerTopComponent extends TopComponent implements UndoManagerLis
         super.componentClosed();
         controller.getUndoManager().removeListener(this);
         controller.release();
+        try {
+            backend.unsetGcodeFile();
+        } catch (Exception e) {
+            // Never mind
+        }
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/NewDesignAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/NewDesignAction.java
@@ -57,7 +57,7 @@ import static com.willwinder.ugs.nbp.designer.platform.UgsDataObject.ATTRIBUTE_T
 public final class NewDesignAction extends AbstractAction {
 
     public static final String SMALL_ICON_PATH = "img/new.svg";
-    public static final String LARGE_ICON_PATH = "img/new32.svg";
+    public static final String LARGE_ICON_PATH = "img/new24.svg";
 
     public NewDesignAction() {
         putValue("iconBase", SMALL_ICON_PATH);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/NewDesignAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/NewDesignAction.java
@@ -18,27 +18,26 @@
  */
 package com.willwinder.ugs.nbp.designer.platform;
 
-import com.willwinder.ugs.nbp.designer.actions.OpenAction;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.nbp.lib.EditorUtils;
 import com.willwinder.ugs.nbp.lib.services.LocalizingService;
-import com.willwinder.universalgcodesender.model.BackendAPI;
-import org.apache.commons.lang3.StringUtils;
+import com.willwinder.universalgcodesender.utils.GUIHelpers;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
 import org.openide.cookies.OpenCookie;
-import org.openide.filesystems.FileChooserBuilder;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+
+import static com.willwinder.ugs.nbp.designer.platform.UgsDataObject.ATTRIBUTE_TEMPORARY;
 
 @ActionID(
         category = LocalizingService.OpenCategory,
@@ -53,20 +52,14 @@ import java.io.IOException;
                 position = 9),
         @ActionReference(
                 path = "Toolbars/File",
-                position = 9),
-        @ActionReference(
-                path = "Shortcuts",
-                name = "M-O")
+                position = 9)
 })
 public final class NewDesignAction extends AbstractAction {
 
     public static final String SMALL_ICON_PATH = "img/new.svg";
     public static final String LARGE_ICON_PATH = "img/new32.svg";
-    private final transient BackendAPI backend;
 
     public NewDesignAction() {
-        this.backend = CentralLookup.getDefault().lookup(BackendAPI.class);
-
         putValue("iconBase", SMALL_ICON_PATH);
         putValue(SMALL_ICON, ImageUtilities.loadImageIcon(SMALL_ICON_PATH, false));
         putValue(LARGE_ICON_KEY, ImageUtilities.loadImageIcon(LARGE_ICON_PATH, false));
@@ -75,36 +68,18 @@ public final class NewDesignAction extends AbstractAction {
     }
 
     @Override
-    public boolean isEnabled() {
-        return backend != null;
-    }
-
-    @Override
     public void actionPerformed(ActionEvent e) {
         try {
-            FileChooserBuilder fcb = new FileChooserBuilder(OpenAction.class);
-            fcb.setFileFilter(OpenAction.DESIGN_FILE_FILTER);
-
-            JFileChooser fileChooser = fcb.createFileChooser();
-            fileChooser.setFileHidingEnabled(true);
-            if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
-                File file = new File(StringUtils.appendIfMissing(fileChooser.getSelectedFile().getAbsolutePath(), ".ugsd"));
-                FileObject dir = FileUtil.toFileObject(fileChooser.getSelectedFile().getParentFile());
-
-                // Removing the old file
-                if (file.exists()) {
-                    if(JOptionPane.showConfirmDialog(SwingUtilities.getRoot((Component)e.getSource()), "Are you sure you want to overwrite the file " + file.getName(), "Overwrite existing file", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
-                        file.delete();
-                    } else {
-                        return;
-                    }
-                }
-
-                FileObject fileObject = dir.createData(file.getName());
-                DataObject.find(fileObject).getLookup().lookup(OpenCookie.class).open();
+            EditorUtils.closeOpenEditors();
+            File file = new File(Files.createTempDirectory("ugsd").toFile().getAbsolutePath(), "unnamed.ugsd");
+            if (!file.createNewFile()) {
+                throw new IOException("Could not create temporary file " + file);
             }
+            FileObject fileObject = FileUtil.toFileObject(file);
+            fileObject.setAttribute(ATTRIBUTE_TEMPORARY, true);
+            DataObject.find(fileObject).getLookup().lookup(OpenCookie.class).open();
         } catch (IOException ex) {
-            ex.printStackTrace();
+            GUIHelpers.displayErrorDialog("Could not create temporary file");
         }
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsDataObject.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/UgsDataObject.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 public class UgsDataObject extends MultiDataObject {
 
     public static final String MIME_TYPE = "application/x-ugs";
+    public static final String ATTRIBUTE_TEMPORARY = "temporary-file";
 
     public UgsDataObject(FileObject pf, MultiFileLoader loader) throws IOException {
         super(pf, loader);
@@ -51,6 +52,11 @@ public class UgsDataObject extends MultiDataObject {
         cookies.add(new UgsCloseCookie(this));
         cookies.add(new UgsOpenSupport(getPrimaryEntry()));
         cookies.add(new UgsSaveAsCookie());
+
+        // If this is a temporary new file
+        if (pf.getAttribute(ATTRIBUTE_TEMPORARY) != null) {
+            setModified(true);
+        }
     }
 
     @Override

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/RendererInputHandler.java
@@ -125,6 +125,9 @@ public class RendererInputHandler implements
             animator.pause();
             FileStateEvent fileStateEvent = (FileStateEvent) cse;
             switch (fileStateEvent.getFileState()) {
+                case FILE_UNLOADED:
+                    setGcodeFile(null);
+                    break;
                 case FILE_LOADED:
                     setGcodeFile(fileStateEvent.getFile());
                     break;


### PR DESCRIPTION
Previously when creating a new design you needed to type the file name first. This has now been fixed so that you'll get a unnamed file that you need to name when you save.

There is now also an action for creating new gcode files.

When closing a gcode or design file, the gcode is cleared from the visualizer.

Fixes: #2140
Fixes: #2120
Fixes: #2057

