### PR TITLE
Fix parsing of alarm state in legacy grbl status format

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/Capabilities.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/Capabilities.java
@@ -20,8 +20,8 @@ package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.model.Axis;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Stores all capabilities supported by the implementation of the {@link IController}.
@@ -33,7 +33,7 @@ public class Capabilities {
     /**
      * The capabilities available for the current hardware
      */
-    private Set<String> capabilities = new HashSet<>();
+    private final Set<String> capabilities = ConcurrentHashMap.newKeySet();
 
     /**
      * Merge capabilities from another Capabilities object into a new one.

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -340,7 +340,7 @@ public class GrblUtils {
      * @return the parsed controller status
      */
     private static ControllerStatus getStatusFromStatusStringLegacy(String status, Capabilities version, Units reportingUnits) {
-        String stateString = StringUtils.defaultString(getStateFromStatusString(status, version), "unknown");
+        String stateString = StringUtils.defaultString(getStateFromStatusString(status), "unknown");
         ControllerState state = getControllerStateFromStateString(stateString);
         return new ControllerStatus(
                 state,
@@ -488,21 +488,14 @@ public class GrblUtils {
     /**
      * Parse state out of position string.
      */
-    final static String STATUS_STATE_REGEX = "(?<=<)[a-zA-z]*(?=[,])";
+    final static String STATUS_STATE_REGEX = "(?<=<)[a-zA-z]*(?=[,>])";
     final static Pattern STATUS_STATE_PATTERN = Pattern.compile(STATUS_STATE_REGEX);
-    static protected String getStateFromStatusString(final String status, final Capabilities version) {
+    protected static String getStateFromStatusString(final String status) {
         String retValue = null;
-        
-        if (!version.hasCapability(GrblCapabilitiesConstants.REAL_TIME)) {
-            return null;
-        }
-        
-        // Search for a version.
         Matcher matcher = STATUS_STATE_PATTERN.matcher(status);
         if (matcher.find()) {
             retValue = matcher.group(0);
         }
-
         return retValue;
     }
 

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2020 Will Winder
+    Copyright 2013-2023 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -39,7 +39,6 @@ public class GrblUtilsTest {
      */
     @Test
     public void testIsGrblVersionString() {
-        System.out.println("isGrblVersionString");
         String response;
         Boolean expResult;
         Boolean result;
@@ -60,7 +59,6 @@ public class GrblUtilsTest {
      */
     @Test
     public void testGetVersionDouble() {
-        System.out.println("getVersionDouble");
         String response;
         double expResult;
         double result;
@@ -75,8 +73,6 @@ public class GrblUtilsTest {
         expResult = 0.9;
         result = GrblUtils.getVersionDouble(response);
         assertEquals(expResult, result, 0.0);
-
-
     }
 
     /**
@@ -84,7 +80,6 @@ public class GrblUtilsTest {
      */
     @Test
     public void testGetVersionLetter() {
-        System.out.println("getVersionLetter");
         String response = "Grbl 0.8c";
         Character expResult = 'c';
         Character result = GrblUtils.getVersionLetter(response);
@@ -93,7 +88,6 @@ public class GrblUtilsTest {
 
     @Test
     public void testGetHomingCommand() {
-        System.out.println("getHomingCommand");
         double version;
         Character letter;
         String result;
@@ -120,7 +114,6 @@ public class GrblUtilsTest {
 
     @Test
     public void testGetKillAlarmLockCommand() {
-        System.out.println("getKillAlarmLockCommand");
         double version;
         Character letter;
         String result;
@@ -153,7 +146,6 @@ public class GrblUtilsTest {
 
     @Test
     public void testToggleCheckModeCommand() {
-        System.out.println("getToggleCheckModeCommand");
         double version;
         Character letter;
         String result;
@@ -186,7 +178,6 @@ public class GrblUtilsTest {
 
     @Test
     public void testGetViewParserStateCommand() {
-        System.out.println("getViewParserStateCommand");
         double version;
         Character letter;
         String result;
@@ -222,7 +213,6 @@ public class GrblUtilsTest {
      */
     @Test
     public void testGetGrblStatusCapabilities() {
-        System.out.println("getGrblStatusCapabilities");
         double version;
         Character letter;
         Capabilities result;
@@ -269,14 +259,9 @@ public class GrblUtilsTest {
      */
     @Test
     public void testIsGrblStatusString() {
-        System.out.println("isGrblStatusString");
-        String response;
-        Boolean expResult;
-        Boolean result;
-
-        response = "<position string is in angle brackets...>";
-        expResult = true;
-        result = GrblUtils.isGrblStatusString(response);
+        String response = "<position string is in angle brackets...>";
+        boolean expResult = true;
+        boolean result = GrblUtils.isGrblStatusString(response);
         assertEquals(expResult, result);
 
         response = "blah";
@@ -290,16 +275,9 @@ public class GrblUtilsTest {
      */
     @Test
     public void testGetStateFromStatusString() {
-        System.out.println("getStateFromStatusString");
-        String status;
-        Capabilities version = new Capabilities();
-        String expResult;
-        String result;
-
-        status = "<Idle,MPos:5.529,0.560,7.000,WPos:1.529,-5.440,-0.000>";
-        version.addCapability(GrblCapabilitiesConstants.REAL_TIME);
-        expResult = "Idle";
-        result = GrblUtils.getStateFromStatusString(status, version);
+        String status = "<Idle,MPos:5.529,0.560,7.000,WPos:1.529,-5.440,-0.000>";
+        String expResult = "Idle";
+        String result = GrblUtils.getStateFromStatusString(status);
         assertEquals(expResult, result);
     }
 
@@ -319,7 +297,6 @@ public class GrblUtilsTest {
      */
     @Test
     public void testGetMachinePositionFromStatusString() {
-        System.out.println("getMachinePositionFromStatusString");
         String status = "<Idle,MPos:5.529,0.560,7.000,WPos:1.529,-5.440,-0.000>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.REAL_TIME);
@@ -339,12 +316,19 @@ public class GrblUtilsTest {
         assertEquals(expResult, position);
     }
 
+    @Test
+    public void getStatusFromStatusStringShouldReturnAlarmState() {
+        String status = "<Alarm>";
+        Capabilities version = new Capabilities();
+        ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
+        assertEquals(ControllerState.ALARM, controllerStatus.getState());
+    }
+
     /**
      * Test of getWorkPositionFromStatusString method, of class GrblUtils.
      */
     @Test
     public void testGetWorkPositionFromStatusString() {
-        System.out.println("getWorkPositionFromStatusString");
         String status = "<Idle,MPos:5.529,0.560,7.000,WPos:1.529,-5.440,-0.000>";
         Capabilities version = new Capabilities();
         version.addCapability(GrblCapabilitiesConstants.REAL_TIME);
@@ -355,8 +339,6 @@ public class GrblUtilsTest {
 
     @Test
     public void testGetResetCoordCommand() {
-        System.out.println("getResetCoordCommand");
-
         double version = 0.8;
         Character letter = 'c';
         String result;
@@ -634,13 +616,13 @@ public class GrblUtilsTest {
     @Test
     public void parseProbePosition() {
         String ThreeAxisFail = "[PRB:0.000,0.000,0.000:0]";
-        assertEquals(null, GrblUtils.parseProbePosition(ThreeAxisFail, MM));
+        assertNull(GrblUtils.parseProbePosition(ThreeAxisFail, MM));
         String FourAxisFail = "[PRB:0.000,0.000,0.000,0.000:0]";
-        assertEquals(null, GrblUtils.parseProbePosition(FourAxisFail, MM));
+        assertNull(GrblUtils.parseProbePosition(FourAxisFail, MM));
         String FiveAxisFail = "[PRB:0.000,0.000,0.000,0.000,0.000:0]";
-        assertEquals(null, GrblUtils.parseProbePosition(FiveAxisFail, MM));
+        assertNull(GrblUtils.parseProbePosition(FiveAxisFail, MM));
         String SixAxisFail = "[PRB:0.000,0.000,0.000,0.000,0.000,0.000:0]";
-        assertEquals(null, GrblUtils.parseProbePosition(SixAxisFail, MM));
+        assertNull(GrblUtils.parseProbePosition(SixAxisFail, MM));
 
         String ThreeAxis = "[PRB:1.1,2.2,3.3:1]";
         assertEquals(new Position(1.1, 2.2, 3.3, MM), GrblUtils.parseProbePosition(ThreeAxis, MM));


### PR DESCRIPTION
A legacy grbl status seems to send alarm state as `<Alarm>`. The status parser expected a comma after the state string.

Potential fix for #2185