### PR TITLE
Fixed problem with responses containing "error" not being an error in FluidNC

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -625,11 +625,11 @@ public class GrblUtils {
     }
 
     public static boolean isOkResponse(String response) {
-        return StringUtils.equalsIgnoreCase(response, "ok");
+        return StringUtils.startsWith(response, "ok");
     }
 
     public static boolean isErrorResponse(String response) {
-        return StringUtils.containsIgnoreCase(response, "error");
+        return StringUtils.startsWith(response, "error");
     }
 
     public static boolean isAlarmResponse(String response) {


### PR DESCRIPTION
Now only parses if the line starts with "ok" or "error"