### PR TITLE
Bugfixes on probing

### DIFF
--- a/ugs-core/src/resources/MessagesBundle_en_US.properties
+++ b/ugs-core/src/resources/MessagesBundle_en_US.properties
@@ -508,6 +508,7 @@ probe.measure-rate = Slow measure rate
 probe.x-distance = Probe X Distance
 probe.y-distance = Probe Y Distance
 probe.retract-amount = Retract amount
+probe.retract-amount.tooltip = Distance to retract after the fast probe cycle before running the slow probe
 probe.hole-diameter = Approximate hole diameter
 probe.hole-center-hint = Move probe to approximate center
 probe.work-coordinates = Work Coordinates

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeParameters.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeParameters.java
@@ -36,6 +36,10 @@ public class ProbeParameters {
     public final double holeDiameter;
     public final double feedRate;
     public final double feedRateSlow;
+
+    /**
+     * The distance to retract after first fast probe cycle before running the next slow probe cycle
+     */
     public final double retractAmount;
     public final WorkCoordinateSystem wcsToUpdate;
     public final UnitUtils.Units units;

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeTopComponent.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeTopComponent.java
@@ -68,7 +68,7 @@ public final class ProbeTopComponent extends TopComponent implements UGSEventLis
     public final static String ProbeActionId = "com.willwinder.ugs.platform.probe.ProbeTopComponent.renamed";
     public final static String ProbeCategory = LocalizingService.CATEGORY_WINDOW;
     // hole diameter tab
-    private static final String HC_TAB = "HC";
+    private static final String HC_TAB = "Hole center";
     // xyz tab
     private static final String XYZ_TAB = "XYZ";
     // outside tab
@@ -163,7 +163,17 @@ public final class ProbeTopComponent extends TopComponent implements UGSEventLis
 
     @Override
     public void componentClosed() {
-        probePreviewManager.clear();
+        probePreviewManager.inactivate();
+    }
+
+    @Override
+    protected void componentHidden() {
+        probePreviewManager.inactivate();
+    }
+
+    @Override
+    protected void componentShowing() {
+        probePreviewManager.activate();
     }
 
     @OnStart

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/actions/AbstractProbeAction.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/actions/AbstractProbeAction.java
@@ -94,7 +94,7 @@ public abstract class AbstractProbeAction extends AbstractAction implements UGSE
     @Override
     public void UGSEvent(UGSEvent evt) {
         if (evt instanceof ControllerStateEvent) {
-            setEnabled(isEnabled());
+            SwingUtilities.invokeLater(() -> setEnabled(isEnabled()));
         }
     }
 

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/renderable/ProbePreviewManager.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/renderable/ProbePreviewManager.java
@@ -37,7 +37,7 @@ public class ProbePreviewManager {
     }
 
     public void setActive(String name) {
-        clear();
+        inactivate();
         AbstractProbePreview currentPreview = probePreviewMap.get(name);
         activePreview.set(currentPreview);
         if (currentPreview != null) {
@@ -46,7 +46,7 @@ public class ProbePreviewManager {
         }
     }
 
-    public void clear() {
+    public void inactivate() {
         AbstractProbePreview currentPreview = activePreview.get();
         if (currentPreview != null) {
             RenderableUtils.removeRenderable(currentPreview);
@@ -64,6 +64,13 @@ public class ProbePreviewManager {
         AbstractProbePreview currentPreview = activePreview.get();
         if (currentPreview != null) {
             currentPreview.updateSettings();
+        }
+    }
+
+    public void activate() {
+        AbstractProbePreview currentPreview = activePreview.get();
+        if (currentPreview != null) {
+            RenderableUtils.registerRenderable(currentPreview);
         }
     }
 }

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ui/SettingsPanel.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ui/SettingsPanel.java
@@ -75,7 +75,9 @@ public class SettingsPanel extends JPanel {
         add(new JSpinner(settingsSlowMeasureRate), "growx");
 
         add(new JLabel(Localization.getString("probe.retract-amount") + ":"), "al right");
-        add(new JSpinner(settingsRetractAmount), "growx");
+        JSpinner retractSpinner = new JSpinner(settingsRetractAmount);
+        retractSpinner.setToolTipText(Localization.getString("probe.retract-amount.tooltip"));
+        add(retractSpinner, "growx");
     }
 
     private void registerListeners() {

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/AutoLevelerTopComponent.java
@@ -103,7 +103,6 @@ public final class AutoLevelerTopComponent extends TopComponent implements UGSEv
 
         if (autoLevelPreview == null) {
             autoLevelPreview = new AutoLevelPreview(Localization.getString("platform.visualizer.renderable.autolevel-preview"));
-            RenderableUtils.registerRenderable(autoLevelPreview);
         }
 
         initComponents();
@@ -115,6 +114,20 @@ public final class AutoLevelerTopComponent extends TopComponent implements UGSEv
         RenderableUtils.removeRenderable(autoLevelPreview);
         autoLevelPreview = null;
         meshLevelManager.clear();
+    }
+
+    @Override
+    protected void componentHidden() {
+        if (autoLevelPreview != null) {
+            RenderableUtils.removeRenderable(autoLevelPreview);
+        }
+    }
+
+    @Override
+    protected void componentShowing() {
+        if (autoLevelPreview != null) {
+            RenderableUtils.registerRenderable(autoLevelPreview);
+        }
     }
 
     private void updatePreview() {

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
@@ -166,7 +166,10 @@ public class SurfaceScanner {
         Position expectedProbePosition = pendingPositions.pop();
         Position probedPosition = p.getPositionIn(expectedProbePosition.getUnits());
 
-        if (!isEqual(probedPosition.getX(), expectedProbePosition.getX(), 0.0001) || !isEqual(probedPosition.getY(), expectedProbePosition.getY(), 0.0001)) {
+        // The position reported from controller might lack some precision on the X/Y position.
+        // We therefore need to lower the precision when checking the probed X/Y axes
+        double delta = expectedProbePosition.getUnits() == Units.MM ? 0.01 : 0.001;
+        if (!isEqual(probedPosition.getX(), expectedProbePosition.getX(), delta) || !isEqual(probedPosition.getY(), expectedProbePosition.getY(), delta)) {
             reset();
             throw new RuntimeException(String.format("Unexpected probe location, expected %s to be %s", probedPosition, expectedProbePosition));
         }

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/ui/AutoLevelerPanel.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/ui/AutoLevelerPanel.java
@@ -69,7 +69,7 @@ public class AutoLevelerPanel extends JPanel {
     }
 
     private void initComponents() {
-        xMin = new Spinner(autoLevelSettings.getMinZ());
+        xMin = new Spinner(autoLevelSettings.getMinX());
         yMin = new Spinner(autoLevelSettings.getMinY());
         zMin = new Spinner(autoLevelSettings.getMinZ());
         xMax = new Spinner(autoLevelSettings.getMaxX(), 0.0001);

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/shared/GcodeRenderer.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/shared/GcodeRenderer.java
@@ -41,9 +41,9 @@ import org.openide.util.lookup.ServiceProviders;
 
 import java.awt.*;
 import java.awt.event.InputEvent;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -111,7 +111,7 @@ public class GcodeRenderer implements GLEventListener, IRenderableRegistrationSe
     private Overlay overlay;
     private final String dimensionsLabel = "";
 
-    private final ArrayList<Renderable> objects;
+    private final java.util.List<Renderable> objects;
     private boolean idle = true;
 
     // Preferences
@@ -133,7 +133,7 @@ public class GcodeRenderer implements GLEventListener, IRenderableRegistrationSe
         setVerticalTranslationVector();
         setHorizontalTranslationVector();
 
-        objects = new ArrayList<>();
+        objects = new CopyOnWriteArrayList<>();
         objects.add(new MachineBoundries(Localization.getString("platform.visualizer.renderable.machine-boundries")));
         objects.add(new Tool(Localization.getString("platform.visualizer.renderable.tool-location")));
         objects.add(new MouseOver(Localization.getString("platform.visualizer.renderable.mouse-indicator")));


### PR DESCRIPTION
Fixes for a couple of bugs on probing:
* Fixed problem with setting enable which can't be done in the event thread causing exceptions
* Added a tooltip that describes how the retract amount works
* Shows/hides the probing/autoleveling preview when the component is shown
* Fixed the wrong mapping of X -> Y value in autoleveler
* Fixed problem with equals matching doubles, lowered the precision.
* Fixed problem with concurrent updates to list of renderables