### PR TITLE
Fixed X travel distance in XYZ probing

### DIFF
--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
@@ -19,7 +19,6 @@
 package com.willwinder.ugs.platform.probe;
 
 import com.google.common.base.Preconditions;
-import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.universalgcodesender.Utils;
 import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
 import com.willwinder.universalgcodesender.listeners.ControllerState;

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
@@ -19,6 +19,7 @@
 package com.willwinder.ugs.platform.probe;
 
 import com.google.common.base.Preconditions;
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.universalgcodesender.Utils;
 import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
@@ -84,6 +85,10 @@ public class ProbeService implements UGSEventListener {
     public ProbeService(BackendAPI backend) {
         this.backend = backend;
         this.backend.addUGSEventListener(this);
+    }
+
+    public ProbeService() {
+        this(CentralLookup.getDefault().lookup(BackendAPI.class));
     }
 
     protected static double retractDistance(double spacing, double retractAmount) {

--- a/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
+++ b/ugs-platform/ProbeModule/src/main/java/com/willwinder/ugs/platform/probe/ProbeService.java
@@ -20,7 +20,6 @@ package com.willwinder.ugs.platform.probe;
 
 import com.google.common.base.Preconditions;
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
-import com.willwinder.ugs.platform.probe.renderable.ProbePreviewManager;
 import com.willwinder.universalgcodesender.Utils;
 import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
@@ -32,7 +31,6 @@ import com.willwinder.universalgcodesender.model.UnitUtils.Units;
 import com.willwinder.universalgcodesender.model.WorkCoordinateSystem;
 import com.willwinder.universalgcodesender.model.events.ControllerStateEvent;
 import com.willwinder.universalgcodesender.model.events.ProbeEvent;
-import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;
 
 import java.util.ArrayList;
@@ -87,10 +85,6 @@ public class ProbeService implements UGSEventListener {
     public ProbeService(BackendAPI backend) {
         this.backend = backend;
         this.backend.addUGSEventListener(this);
-    }
-
-    public ProbeService() {
-        this(CentralLookup.getDefault().lookup(BackendAPI.class));
     }
 
     protected static double retractDistance(double spacing, double retractAmount) {
@@ -292,7 +286,7 @@ public class ProbeService implements UGSEventListener {
                 case 4: {
                     gcode(g0Abs + " X" + -params.xSpacing);
                     gcode(g0Abs + " Y" + -params.ySpacing);
-                    gcode(g0Abs + " X" + params.xSpacing);
+                    gcode(g0Abs + " X0");
 
                     // Y
                     probe('Y', params.feedRate, params.ySpacing, params.units);
@@ -441,7 +435,7 @@ public class ProbeService implements UGSEventListener {
             sb.append("Z").append(Utils.formatter.format(z));
         }
 
-        gcode(String.format(WCS_PATTERN, wcs.getPValue(), sb.toString()));
+        gcode(String.format(WCS_PATTERN, wcs.getPValue(), sb));
     }
 
     /**

--- a/ugs-platform/ProbeModule/src/test/java/com/willwinder/ugs/platform/probe/ProbeServiceTest.java
+++ b/ugs-platform/ProbeModule/src/test/java/com/willwinder/ugs/platform/probe/ProbeServiceTest.java
@@ -153,7 +153,6 @@ public class ProbeServiceTest {
         ps.UGSEvent(new ControllerStateEvent(ControllerState.IDLE, ControllerState.RUN));
 
         InOrder order = inOrder(backend);
-
         order.verify(backend, times(1)).sendGcodeCommand(true, "G10 L20 P2 X0Y0Z0");
 
         // Probe Z axis
@@ -172,7 +171,7 @@ public class ProbeServiceTest {
         order.verify(backend, times(1)).probe("X", pc.feedRateSlow, pc.xSpacing, pc.units);
         order.verify(backend, times(1)).sendGcodeCommand(true, "G90 G21 G0 X" + -pc.xSpacing);
         order.verify(backend, times(1)).sendGcodeCommand(true, "G90 G21 G0 Y" + -pc.ySpacing);
-        order.verify(backend, times(1)).sendGcodeCommand(true, "G90 G21 G0 X" + pc.xSpacing);
+        order.verify(backend, times(1)).sendGcodeCommand(true, "G90 G21 G0 X0");
 
         // probe Y axis
         order.verify(backend, times(1)).probe("Y", pc.feedRate, pc.ySpacing, pc.units);


### PR DESCRIPTION
When starting the probe of Y it would move it too far on the X axis using the distance setting. It should instead move to the origin X (0).

![Screenshot from 2023-08-20 07-22-41](https://github.com/winder/Universal-G-Code-Sender/assets/8962024/671918f9-7722-4e92-948c-ce590c4adc0e)

Possible fix for #2287