### PR TITLE
Gcode parser now allows multiple spaces and tabs

### DIFF
--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexer.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexer.java
@@ -31,8 +31,8 @@ import static org.apache.commons.lang3.CharUtils.isAsciiNumeric;
  * @author Joacim Breiler
  */
 public class GcodeLexer implements Lexer<GcodeTokenId> {
-    private LexerRestartInfo<GcodeTokenId> info;
-    private LexerInput input;
+    private final LexerRestartInfo<GcodeTokenId> info;
+    private final LexerInput input;
 
     public GcodeLexer(LexerRestartInfo<GcodeTokenId> info) {
         this.info = info;
@@ -163,7 +163,7 @@ public class GcodeLexer implements Lexer<GcodeTokenId> {
 
         while (true) {
             char character = (char) input.read();
-            if (character == ' ' && length == 0) {
+            if ((character == ' ' || character == '\t') && numberCount == 0 && minusCount == 0 && commaCount == 0) {
                 // It's allowed to have a leading space after parameter name
             } else if (!isNumeric(character)) {
                 input.backup(1);

--- a/ugs-platform/ugs-platform-gcode-editor/src/test/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexerTest.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/test/java/com/willwinder/ugs/nbp/editor/lexer/GcodeLexerTest.java
@@ -18,7 +18,6 @@
 */
 package com.willwinder.ugs.nbp.editor.lexer;
 
-import com.willwinder.ugs.nbp.editor.lexer.GcodeTokenId;
 import org.junit.Test;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.api.lexer.TokenHierarchy;
@@ -281,6 +280,67 @@ public class GcodeLexerTest {
         t = ts.token();
         assertEquals(GcodeTokenId.AXIS, t.id());
         assertEquals("Y 10", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("Z 0.3", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.PARAMETER, t.id());
+        assertEquals("S 1000", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.PARAMETER, t.id());
+        assertEquals("F 500", t.text());
+    }
+
+    @Test
+    public void parsingParametersWithMultipleLeadingSpaceShouldBeOk() {
+        String text = "G01 X  -.100 Y\t10 Z 0.3 S 1000 F 500";
+        TokenSequence<GcodeTokenId> ts = parseTokenSequence(text);
+
+        ts.moveNext();
+        Token<?> t = ts.token();
+        assertEquals(GcodeTokenId.MOVEMENT, t.id());
+        assertEquals("G01", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("X  -.100", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.WHITESPACE, t.id());
+        assertEquals(" ", t.text());
+
+        ts.moveNext();
+        t = ts.token();
+        assertEquals(GcodeTokenId.AXIS, t.id());
+        assertEquals("Y\t10", t.text());
 
         ts.moveNext();
         t = ts.token();


### PR DESCRIPTION
Gcode parser can not parse multiple white spaces and tabs between parameter and value.

Fixes #2258
