### PR TITLE
Fixed problems with legacy GRBL version strings

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblVersion.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblVersion.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
  */
 public class GrblVersion {
     public static final GrblVersion NO_VERSION = new GrblVersion("");
-    public static final String VERSION_REGEX = "^\\[VER:([a-zA-Z0-9\\s]*)?[vV]?(?<version>(?<major>\\d+)\\.(?<minor>\\d+)(?<char>[a-zA-Z])?).*?]$";
+    public static final String VERSION_REGEX = "^\\[[a-zA-Z0-9:\\s]*[vV]?(?<version>(?<major>\\d+)\\.(?<minor>\\d+)(?<char>[a-zA-Z])?).*?]$";
     private final double versionNumber;           // The 0.8 in '[VER:0.8c.20220620:Machine1]'
     private final Character versionLetter;  // The c in '[VER:0.8c.20220620:Machine1]'
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommand.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommand.java
@@ -40,7 +40,7 @@ public class GetBuildInfoCommand extends GrblSystemCommand {
 
         // With GRBL 0.9 or older, the version string is only one line and an "ok"
         // treat those as a version string
-        if (lines.length <= 2) {
+        if (lines.length == 2 && StringUtils.equals(lines[1], "ok")) {
             return Optional.of(new GrblVersion(lines[0]));
         }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommand.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommand.java
@@ -36,7 +36,15 @@ public class GetBuildInfoCommand extends GrblSystemCommand {
     }
 
     public Optional<GrblVersion> getVersion() {
-        return Arrays.stream(StringUtils.split(getResponse(), "\n"))
+        String[] lines = StringUtils.split(getResponse(), "\n");
+
+        // With GRBL 0.9 or older, the version string is only one line and an "ok"
+        // treat those as a version string
+        if (lines.length <= 2) {
+            return Optional.of(new GrblVersion(lines[0]));
+        }
+
+        return Arrays.stream(lines)
                 .filter(line -> line.startsWith("[VER"))
                 .map(GrblVersion::new).findFirst();
     }

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/GrblVersionTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/GrblVersionTest.java
@@ -94,4 +94,11 @@ public class GrblVersionTest {
         GrblVersion version = new GrblVersion("[VER:ARM32 V2.1.20220827:]");
         assertEquals(2.1d, version.getVersionNumber(), 0.001);
     }
+
+    @Test
+    public void parseLegacyGrblVersionString() {
+        GrblVersion version = new GrblVersion("[0.9j.2016076:]");
+        assertEquals(0.9d, version.getVersionNumber(), 0.001);
+        assertEquals('j', version.getVersionLetter().charValue());
+    }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommandTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommandTest.java
@@ -1,0 +1,29 @@
+package com.willwinder.universalgcodesender.firmware.grbl.commands;
+
+
+import com.willwinder.universalgcodesender.firmware.grbl.GrblVersion;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GetBuildInfoCommandTest {
+
+    @Test
+    public void getVersionWithMultilineShouldReturnTheVersionNumber() {
+        GetBuildInfoCommand command = new GetBuildInfoCommand();
+        command.appendResponse("[OPT: ABC]");
+        command.appendResponse("[VER: 1.1f]");
+        GrblVersion version = command.getVersion().orElseThrow(RuntimeException::new);
+        assertEquals(1.1, version.getVersionNumber(), 0.01);
+    }
+
+    @Test
+    public void getVersionWithLegacySingleLineVersion() {
+        GetBuildInfoCommand command = new GetBuildInfoCommand();
+        command.appendResponse("[0.9j.20160303:]");
+        command.appendResponse("ok");
+        GrblVersion version = command.getVersion().orElseThrow(RuntimeException::new);
+        assertEquals(0.9, version.getVersionNumber(), 0.01);
+        assertEquals(Character.valueOf('j'), version.getVersionLetter());
+    }
+}

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommandTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/commands/GetBuildInfoCommandTest.java
@@ -13,6 +13,7 @@ public class GetBuildInfoCommandTest {
         GetBuildInfoCommand command = new GetBuildInfoCommand();
         command.appendResponse("[OPT: ABC]");
         command.appendResponse("[VER: 1.1f]");
+        command.appendResponse("ok");
         GrblVersion version = command.getVersion().orElseThrow(RuntimeException::new);
         assertEquals(1.1, version.getVersionNumber(), 0.01);
     }


### PR DESCRIPTION
GRBL version 0.9 and earlier does not print the same output to the $I command.
This will fix that so that the version number is properly parsed.