### PR TITLE
Fixes for Raspberry PI 64-bit

### DIFF
--- a/ugs-platform/application/pom.xml
+++ b/ugs-platform/application/pom.xml
@@ -853,7 +853,7 @@
                                         <!-- Download and untar JRE -->
                                         <exec dir="${project.build.directory}" executable="curl" failonerror="true">
                                             <arg line="-L"/>
-                                            <arg line="${ugs.bundle.java.linux.arm.url}"/>
+                                            <arg line="${ugs.bundle.java.linux.aarch64.url}"/>
                                             <arg line="-o"/>
                                             <arg line="jre-linux.tar.gz"/>
                                         </exec>

--- a/ugs-platform/pom.xml
+++ b/ugs-platform/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
       <maven.build.timestamp.format>yyyy.MM.dd.HH.mm</maven.build.timestamp.format>
-      <netbeans.version>RELEASE190</netbeans.version>
+      <netbeans.version>RELEASE180</netbeans.version>
       <ugs.app.title>Universal Gcode Platform ${project.version}</ugs.app.title>
       <ugs.appbundle.name>Universal Gcode Platform</ugs.appbundle.name>
       <parsedVersion.majorVersion>2</parsedVersion.majorVersion>
@@ -39,7 +39,7 @@
 
       <ugs.bundle.java.linux.x64.url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jre_x64_linux_hotspot_17.0.8.1_1.tar.gz</ugs.bundle.java.linux.x64.url>
       <ugs.bundle.java.linux.arm.url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jre_arm_linux_hotspot_17.0.8.1_1.tar.gz</ugs.bundle.java.linux.arm.url>
-      <ugs.bundle.java.linux.aarch64.url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.8.1_1.tar.gz</ugs.bundle.java.linux.aarch64.url>
+      <ugs.bundle.java.linux.aarch64.url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.9_9.tar.gz</ugs.bundle.java.linux.aarch64.url>
 
       <!-- Mac OS X signing identity - must match with a verified Apple developer certificate in the keychain -->
       <ugs.codesign.identity>Developer ID Application</ugs.codesign.identity>


### PR DESCRIPTION
Rolled back to NetBeans 18.0 as there was problems with menus on aarch64. 
Fixed link to aarch64 JRE.