### PR TITLE
Fixed problem with the default LaF on MacOSX

### DIFF
--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/lifecycle/LookAndFeelInstaller.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/lifecycle/LookAndFeelInstaller.java
@@ -18,6 +18,7 @@
  */
 package com.willwinder.ugs.nbp.core.lifecycle;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.openide.modules.ModuleInstall;
 import org.openide.util.NbPreferences;
 
@@ -30,9 +31,26 @@ public class LookAndFeelInstaller extends ModuleInstall {
 
     @Override
     public void validate() {
+        if (SystemUtils.IS_OS_MAC_OSX) {
+            // FlatlLaf look and feel doesn't work on MacOSXs
+            setMacOSLaF();
+        } else {
+            setLaF();
+        }
+    }
+
+    private void setLaF() {
         Preferences prefs = NbPreferences.root().node("laf");
         if (prefs.get("laf", "").isBlank()) {
             prefs.put("laf", "com.formdev.flatlaf.FlatLightLaf");
+        }
+    }
+
+    private void setMacOSLaF() {
+        Preferences prefs = NbPreferences.root().node("laf");
+        String currentLaF = prefs.get("laf", "");
+        if (currentLaF.isBlank() || currentLaF.equals("com.formdev.flatlaf.FlatLightLaf")) {
+            prefs.put("laf", "com.apple.laf.AquaLookAndFeel");
         }
     }
 }


### PR DESCRIPTION
Now uses AquaLookAndFeel and disable FlatLaFLight as it doesn't work.

Should fix the problems #2382 and #2383