### PR TITLE
Bugfix for handling gcode state G38

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCController.java
@@ -332,9 +332,9 @@ public class FluidNCController implements IController, ICommunicatorListener {
 
         isInitialized = false;
         positionPollTimer.stop();
-        communicator.connect(connectionDriver, port, portRate);
         setControllerState(ControllerState.CONNECTING);
         messageService.dispatchMessage(MessageType.INFO, "*** Connecting to " + connectionDriver.getProtocol() + port + ":" + portRate + "\n");
+        communicator.connect(connectionDriver, port, portRate);
 
         ThreadHelper.invokeLater(() -> {
             if (StringUtils.isEmpty(firmwareVariant) || semanticVersion == null) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/Code.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/Code.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2017 Will Winder
+    Copyright 2017-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -53,10 +53,10 @@ public enum Code {
     G2(Motion, false, true),
     G3(Motion, false, true),
     G33(Motion),
-    G38_2(Motion),
-    G38_3(Motion),
-    G38_4(Motion),
-    G38_5(Motion),
+    G38_2(Motion, false, true),
+    G38_3(Motion, false, true),
+    G38_4(Motion, false, true),
+    G38_5(Motion, false, true),
     G73(Motion),
     G76(Motion),
     G80(Motion, false, true),

--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtils.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2017-2023 Will Winder
+    Copyright 2017-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -23,6 +23,14 @@ import com.willwinder.universalgcodesender.gcode.DefaultCommandCreator;
 import com.willwinder.universalgcodesender.gcode.GcodeParser;
 import com.willwinder.universalgcodesender.gcode.GcodePreprocessorUtils;
 import com.willwinder.universalgcodesender.gcode.GcodeState;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G20;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G21;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G90;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G90_1;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G91;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G91_1;
+import static com.willwinder.universalgcodesender.gcode.util.Code.ModalGroup.Motion;
+import static com.willwinder.universalgcodesender.gcode.util.Code.UNKNOWN;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UnitUtils;
@@ -49,17 +57,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static com.willwinder.universalgcodesender.gcode.util.Code.G20;
-import static com.willwinder.universalgcodesender.gcode.util.Code.G21;
-import static com.willwinder.universalgcodesender.gcode.util.Code.G90;
-import static com.willwinder.universalgcodesender.gcode.util.Code.G90_1;
-import static com.willwinder.universalgcodesender.gcode.util.Code.G91;
-import static com.willwinder.universalgcodesender.gcode.util.Code.G91_1;
-import static com.willwinder.universalgcodesender.gcode.util.Code.ModalGroup.Motion;
-import static com.willwinder.universalgcodesender.gcode.util.Code.UNKNOWN;
-
 /**
- *
  * @author wwinder
  */
 public class GcodeParserUtils {
@@ -174,6 +172,10 @@ public class GcodeParserUtils {
     }
 
     private static PointSegment addProbePointSegment(Position nextPoint, boolean fastTraverse, int line, GcodeState state) {
+        if (nextPoint == null) {
+            return null;
+        }
+
         PointSegment ps = addLinearPointSegment(nextPoint, fastTraverse, line, state);
         ps.setIsProbe(true);
         return ps;
@@ -391,7 +393,7 @@ public class GcodeParserUtils {
         // Parse the gcode for the buffer.
         Collection<String> lines = gcp.preprocessCommand(command, gcp.getCurrentState());
 
-        for(String processedLine : lines) {
+        for (String processedLine : lines) {
             gsw.addLine(command, processedLine, comment, idx);
         }
 
@@ -400,6 +402,7 @@ public class GcodeParserUtils {
 
     /**
      * Attempts to read the input file in GcodeStream format.
+     *
      * @return whether or not we succeed processing the file.
      */
     private static boolean processAndExportGcodeStream(GcodeParser gcp, InputStream input, IGcodeWriter output)
@@ -424,14 +427,15 @@ public class GcodeParserUtils {
 
     /**
      * Attempts to read the input file in gcode-text format.
+     *
      * @return whether or not we succeed processing the file.
      */
     private static void processAndExportText(GcodeParser gcp, BufferedReader input, IGcodeWriter output)
             throws IOException, GcodeParserException {
         // Preprocess a regular gcode file.
-        try(BufferedReader br = input) {
+        try (BufferedReader br = input) {
             int i = 0;
-            for(String line; (line = br.readLine()) != null; ) {
+            for (String line; (line = br.readLine()) != null; ) {
                 i++;
 
                 String comment = GcodePreprocessorUtils.parseComment(line);

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtilsTest.java
@@ -40,7 +40,7 @@ public class GcodeParserUtilsTest {
         List<GcodeParser.GcodeMeta> metaList = GcodeParserUtils.processCommand("G38.2", 0, new GcodeState());
         GcodeParser.GcodeMeta meta = Iterables.getOnlyElement(metaList);
         assertThat(meta.code).isEqualTo(G38_2);
-        assertThat(meta.state.currentPoint).isEqualTo(new Position(Double.NaN, Double.NaN, Double.NaN, MM));
+        assertThat(meta.state.currentPoint).isEqualTo(new Position(0, 0, 0, MM));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class GcodeParserUtilsTest {
         List<GcodeParser.GcodeMeta> metaList = GcodeParserUtils.processCommand("G3", 0, new GcodeState());
         GcodeParser.GcodeMeta meta = Iterables.getOnlyElement(metaList);
         assertThat(meta.code).isEqualTo(G3);
-        assertThat(meta.state.currentPoint).isEqualTo(new Position(Double.NaN, Double.NaN, Double.NaN, MM));
+        assertThat(meta.state.currentPoint).isEqualTo(new Position(0, 0, 0, MM));
     }
 
     @Test

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/util/GcodeParserUtilsTest.java
@@ -3,19 +3,19 @@ package com.willwinder.universalgcodesender.gcode.util;
 import com.google.common.collect.Iterables;
 import com.willwinder.universalgcodesender.gcode.GcodeParser;
 import com.willwinder.universalgcodesender.gcode.GcodeState;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G0;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G1;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G3;
+import static com.willwinder.universalgcodesender.gcode.util.Code.G38_2;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.Position;
+import static com.willwinder.universalgcodesender.model.UnitUtils.Units.MM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
-
-import static com.willwinder.universalgcodesender.gcode.util.Code.G0;
-import static com.willwinder.universalgcodesender.gcode.util.Code.G1;
-import static com.willwinder.universalgcodesender.gcode.util.Code.G3;
-import static com.willwinder.universalgcodesender.model.UnitUtils.Units.MM;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class GcodeParserUtilsTest {
     @Test
@@ -36,10 +36,11 @@ public class GcodeParserUtilsTest {
     }
 
     @Test
-    public void missingAxisWords() {
-        assertThatThrownBy(() -> GcodeParserUtils.processCommand("G38.2", 0, new GcodeState()))
-                .isInstanceOf(GcodeParserException.class)
-                .hasMessage(Localization.getString("parser.gcode.missing-axis-commands") + ": G38.2");
+    public void missingAxisWords() throws GcodeParserException {
+        List<GcodeParser.GcodeMeta> metaList = GcodeParserUtils.processCommand("G38.2", 0, new GcodeState());
+        GcodeParser.GcodeMeta meta = Iterables.getOnlyElement(metaList);
+        assertThat(meta.code).isEqualTo(G38_2);
+        assertThat(meta.state.currentPoint).isEqualTo(new Position(Double.NaN, Double.NaN, Double.NaN, MM));
     }
 
     @Test
@@ -91,7 +92,7 @@ public class GcodeParserUtilsTest {
         List<GcodeParser.GcodeMeta> metaList = GcodeParserUtils.processCommand("G3", 0, new GcodeState());
         GcodeParser.GcodeMeta meta = Iterables.getOnlyElement(metaList);
         assertThat(meta.code).isEqualTo(G3);
-        assertThat(meta.state.currentPoint).isEqualTo(new Position(0, 0, 0, MM));
+        assertThat(meta.state.currentPoint).isEqualTo(new Position(Double.NaN, Double.NaN, Double.NaN, MM));
     }
 
     @Test


### PR DESCRIPTION
UGS parser expects G38 to have an axis parameter. However, if the controller is in a G38 modal state and a gcode parser state command is issued these commands can't be applied to the gcode state:
```
[GC:G38.2 G54 G17 G21 G90 G94 M5 M9 T0 F100 S0]
```

With this fix, the internal parser will not make it mandatory to have an axis to a probe command, leaving the command validation to the controller.

Fix for #2386