### PR TITLE
Add Driver selector to Connection setup wizard

### DIFF
--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/components/ConnectionPanel.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/components/ConnectionPanel.java
@@ -51,13 +51,14 @@ public class ConnectionPanel extends JPanel implements UGSEventListener {
         // Driver options
         driverCombo = new JComboBox<>(ConnectionDriver.getPrettyNames());
         driverCombo.addActionListener(d -> this.setDriver());
-        JLabel labelDriver = new JLabel("Driver:");
-        labelDriver.setToolTipText("Select the driver to use to connect to your firmware. Serial connections should use JSerialComm. Network connections should use TCP.");
+        JLabel labelDriver = new JLabel(Localization.getString("settings.connectionDriver"));
+        labelDriver.setToolTipText("Select the driver to use to connect to your controller firmware. Serial connections should use JSerialComm. Network connections should use TCP.");
 
         // Firmware options
         firmwareCombo = new JComboBox<>();
         firmwareCombo.addActionListener(a -> setFirmware());
-        JLabel labelFirmware = new JLabel("Firmware:");
+        JLabel labelFirmware = new JLabel(Localization.getString("mainWindow.swing.firmwareLabel"));
+        labelFirmware.setToolTipText("Select the controller firmware to which you want to connect.");
 
         // Baud rate options
         baudCombo = new BaudComboBox(backend);

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/components/ConnectionPanel.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/components/ConnectionPanel.java
@@ -82,9 +82,6 @@ public class ConnectionPanel extends JPanel implements UGSEventListener {
         add(baudCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 20");
         add(connectButton, "wmin 250, wmax 250, hmin 36, wrap");
 
-        // set the height to be bigger
-        setPreferredSize(new Dimension(640, 640));
-
         updateLabels();
     }
 

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/components/ConnectionPanel.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/components/ConnectionPanel.java
@@ -71,15 +71,15 @@ public class ConnectionPanel extends JPanel implements UGSEventListener {
         JButton connectButton = new JButton(Localization.getString("platform.plugin.setupwizard.connect"));
         connectButton.addActionListener(e -> onConnect.run());
 
-        add(labelDescription, "growx, wrap, gapbottom 10");
+        add(labelDescription, "growx, wrap, gapbottom 5");
         add(labelDriver, "wrap");
-        add(driverCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 10");
+        add(driverCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 5");
         add(labelFirmware, "wrap");
-        add(firmwareCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 10");
+        add(firmwareCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 5");
         add(labelPort, "wrap");
-        add(portCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 10");
+        add(portCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 5");
         add(labelBaud, "wrap");
-        add(baudCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 20");
+        add(baudCombo, "wmin 250, wmax 250, hmax 24, wrap, gapbottom 10");
         add(connectButton, "wmin 250, wmax 250, hmin 36, wrap");
 
         updateLabels();


### PR DESCRIPTION
This PR adds a combo box for selecting the Driver in the Connection setup wizard.

Fixes #2425. 

To do:
- [x] Fix layout issue with Connect button being hidden.
- [x] Move labels/descriptions to localization bundle.