### PR TITLE
Add possibility to export the autoleveled gcode

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/SimpleGcodeStreamWriter.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/SimpleGcodeStreamWriter.java
@@ -1,0 +1,65 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.utils;
+
+import com.willwinder.universalgcodesender.types.GcodeCommand;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Writes the preprocessed gcode to the given file.
+ *
+ * @author Joacim Breiler
+ */
+public class SimpleGcodeStreamWriter implements IGcodeWriter {
+    private final PrintWriter fileWriter;
+
+    public SimpleGcodeStreamWriter(File f) throws FileNotFoundException {
+        try {
+            fileWriter = new PrintWriter(f, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FileNotFoundException("Could not use UTF-8 to output gcode stream file");
+        }
+    }
+
+    @Override
+    public String getCanonicalPath() {
+        return "";
+    }
+
+    @Override
+    public void addLine(GcodeCommand command) {
+        addLine(command.getOriginalCommandString(), command.getCommandString(), command.getComment(), command.getCommandNumber());
+    }
+
+    @Override
+    public void addLine(String original, String processed, String comment, int commandNumber) {
+        fileWriter.append(processed);
+        fileWriter.append("\n");
+    }
+
+    @Override
+    public void close() throws IOException {
+        fileWriter.close();
+    }
+}

--- a/ugs-core/src/resources/MessagesBundle_en_US.properties
+++ b/ugs-core/src/resources/MessagesBundle_en_US.properties
@@ -501,6 +501,8 @@ autoleveler.option.offset-y = Probe Y offset
 autoleveler.option.offset-z = Probe Z offset
 autoleveler.probe-failed = Probe failed
 autoleveler.panel.clear = Clear scan
+autoleveler.panel.export = Export gcode
+autoleveler.panel.export.tooltip = Exports the autoleveled gcode
 experimental.feature = This is an experimental feature. Please use caution and report any bugs you find on GitHub.
 # Window title for platform GUI
 platform-title = Universal Gcode Sender

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/MeshLevelManager.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/MeshLevelManager.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2023 Will Winder
+    Copyright 2023-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -18,11 +18,8 @@
  */
 package com.willwinder.ugs.platform.surfacescanner;
 
-import com.willwinder.universalgcodesender.gcode.GcodePreprocessorUtils;
-import com.willwinder.universalgcodesender.gcode.processors.ArcExpander;
+import static com.willwinder.ugs.platform.surfacescanner.Utils.createCommandProcessor;
 import com.willwinder.universalgcodesender.gcode.processors.CommandProcessorList;
-import com.willwinder.universalgcodesender.gcode.processors.LineSplitter;
-import com.willwinder.universalgcodesender.gcode.processors.MeshLeveler;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.utils.AutoLevelSettings;
 import com.willwinder.universalgcodesender.utils.GUIHelpers;
@@ -51,19 +48,7 @@ public class MeshLevelManager {
                 return;
             }
 
-            commandProcessorList = new CommandProcessorList();
-
-            // Step 1: Convert arcs to line segments.
-            commandProcessorList.add(new ArcExpander(true, autoLevelSettings.getAutoLevelArcSliceLength(), GcodePreprocessorUtils.getDecimalFormatter()));
-
-            // Step 2: Line splitter. No line should be longer than some fraction of "resolution"
-            commandProcessorList.add(new LineSplitter(autoLevelSettings.getStepResolution() / 4));
-
-            // Step 3: Adjust Z heights codes based on mesh offsets.
-            commandProcessorList.add(
-                    new MeshLeveler(autoLevelSettings.getZSurface(),
-                            surfaceScanner.getProbePositionGrid()));
-
+            commandProcessorList = createCommandProcessor(autoLevelSettings, surfaceScanner);
             backend.applyCommandProcessor(commandProcessorList);
         } catch (Exception ex) {
             GUIHelpers.displayErrorDialog(ex.getMessage());

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/ExportGcodeAction.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/ExportGcodeAction.java
@@ -1,0 +1,128 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.platform.surfacescanner.actions;
+
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.ugs.platform.surfacescanner.SurfaceScanner;
+import static com.willwinder.ugs.platform.surfacescanner.Utils.createCommandProcessor;
+import static com.willwinder.ugs.platform.surfacescanner.Utils.fileChooser;
+import com.willwinder.universalgcodesender.gcode.GcodeParser;
+import com.willwinder.universalgcodesender.gcode.processors.CommandProcessorList;
+import com.willwinder.universalgcodesender.gcode.util.GcodeParserException;
+import com.willwinder.universalgcodesender.gcode.util.GcodeParserUtils;
+import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.UGSEventListener;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import com.willwinder.universalgcodesender.model.UGSEvent;
+import com.willwinder.universalgcodesender.model.events.FileStateEvent;
+import com.willwinder.universalgcodesender.uielements.components.GcodeFileTypeFilter;
+import com.willwinder.universalgcodesender.utils.GUIHelpers;
+import com.willwinder.universalgcodesender.utils.SimpleGcodeStreamWriter;
+import org.apache.commons.io.FilenameUtils;
+import org.openide.util.ImageUtilities;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JFileChooser;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * An action that will export the currently loaded gcode with the applied surface scan
+ *
+ * @author Joacim Breiler
+ */
+public class ExportGcodeAction extends AbstractAction implements UGSEventListener {
+    public static final String ICON_BASE = "com/willwinder/ugs/platform/surfacescanner/icons/export.svg";
+    private static final Logger LOGGER = Logger.getLogger(ExportGcodeAction.class.getSimpleName());
+    private final transient SurfaceScanner surfaceScanner;
+    private final transient BackendAPI backend;
+
+    public ExportGcodeAction(SurfaceScanner surfaceScanner) {
+        this.surfaceScanner = surfaceScanner;
+        backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+        backend.addUGSEventListener(this);
+
+        String title = Localization.getString("autoleveler.panel.export");
+        putValue(NAME, title);
+        putValue("menuText", title);
+        putValue(Action.SHORT_DESCRIPTION, Localization.getString("autoleveler.panel.export.tooltip"));
+        putValue("iconBase", ICON_BASE);
+        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(ICON_BASE, false));
+
+        setEnabled(isEnabled());
+        this.surfaceScanner.addListener(() -> setEnabled(isEnabled()));
+    }
+
+    private static Optional<File> chooseSaveFile(File file) {
+        fileChooser.setFileFilter(new GcodeFileTypeFilter());
+        fileChooser.setSelectedFile(file);
+        int result = fileChooser.showSaveDialog(null);
+        if (result != JFileChooser.APPROVE_OPTION) {
+            return Optional.empty();
+        }
+        File selectedFile = fileChooser.getSelectedFile();
+        if (!selectedFile.getName().endsWith(".gcode")) {
+            selectedFile = new File(selectedFile.getAbsolutePath() + ".gcode");
+        }
+        return Optional.of(selectedFile);
+    }
+
+    private Optional<File> getExportFile() {
+        File loadedFile = backend.getGcodeFile();
+        File file = new File(loadedFile.getPath() + File.separator + FilenameUtils.removeExtension(loadedFile.getName()) + "-autoleveled.gcode");
+        return chooseSaveFile(file);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return surfaceScanner.isValid() && backend.getGcodeFile() != null;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        Optional<File> selectedFile = getExportFile();
+        if (selectedFile.isEmpty()) {
+            return;
+        }
+
+        CommandProcessorList commandProcessor = createCommandProcessor(backend.getSettings().getAutoLevelSettings(), surfaceScanner);
+        File gcodeFile = backend.getGcodeFile();
+        GcodeParser gcp = new GcodeParser();
+        gcp.addCommandProcessor(commandProcessor);
+
+        try (SimpleGcodeStreamWriter gcw = new SimpleGcodeStreamWriter(selectedFile.get())) {
+            GcodeParserUtils.processAndExport(gcp, gcodeFile, gcw);
+        } catch (IOException | GcodeParserException ex) {
+            LOGGER.log(Level.SEVERE, "Could not export gcode", ex);
+            GUIHelpers.displayErrorDialog("Could not export the loaded gcode: " + ex.getMessage());
+        }
+    }
+
+    @Override
+    public void UGSEvent(UGSEvent evt) {
+        if (evt instanceof FileStateEvent) {
+            setEnabled(isEnabled());
+        }
+    }
+}

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/ui/AutoLevelerToolbar.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/ui/AutoLevelerToolbar.java
@@ -35,6 +35,7 @@ public class AutoLevelerToolbar extends ToolBar {
         add(new JButton(new SaveScannedSurfaceAction(surfaceScanner)));
         add(new JButton(new ClearScannedSurfaceAction(surfaceScanner)));
         add(Box.createGlue());
+        add(new JButton(new ExportGcodeAction(surfaceScanner)));
         add(new JButton(new GenerateTestDataAction(surfaceScanner)));
         add(new JButton(new OpenSettingsAction()));
     }

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export.svg
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg988"
+   sodipodi:docname="export.svg"
+   width="16"
+   height="16"
+   inkscape:version="1.1-dev (0486c1a, 2020-10-10)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs992" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1929"
+     inkscape:window-height="1135"
+     id="namedview990"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="5.51"
+     inkscape:cx="96.46098"
+     inkscape:cy="17.513612"
+     inkscape:window-x="53"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg988" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="m 10.66725,4.2973672 c 0,-0.1750096 -0.06945,-0.3444633 -0.194455,-0.4694701 L 7.7532019,1.1055259 C 7.6281951,0.980519 7.4587413,0.9110708 7.2809539,0.9110708 H 7.1115001 V 4.4668209 H 10.66725 Z M 15.861978,9.4670954 13.2035,6.7891701 C 12.922929,6.5085992 12.442347,6.7058318 12.442347,7.1030762 v 1.8084326 h -1.777875 v 1.7778762 h 1.777875 v 1.81121 c 0,0.397244 0.480582,0.594477 0.761153,0.313906 l 2.658478,-2.680702 c 0.183344,-0.1833442 0.183344,-0.4833604 0,-0.6667036 z M 5.3336251,10.244916 V 9.3559782 c 0,-0.2444582 0.2000109,-0.4444694 0.4444687,-0.4444694 H 10.66725 V 5.3557584 H 6.8892657 c -0.3666867,0 -0.666703,-0.3000165 -0.666703,-0.6667032 V 0.9110708 H 0.66670314 C 0.29723848,0.9110708 0,1.2083093 0,1.5777739 V 14.467369 c 0,0.369465 0.29723848,0.666703 0.66670314,0.666703 H 10.000547 c 0.369465,0 0.666703,-0.297238 0.666703,-0.666703 V 10.689385 H 5.7780938 c -0.2444578,0 -0.4444687,-0.200011 -0.4444687,-0.444469 z"
+     id="path986"
+     style="fill:#353a40;fill-opacity:1;stroke-width:0.999998" />
+</svg>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export32.svg
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export32.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg988"
+   sodipodi:docname="export32.svg"
+   width="32"
+   height="32"
+   inkscape:version="1.1-dev (0486c1a, 2020-10-10)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs992" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1929"
+     inkscape:window-height="1135"
+     id="namedview990"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="5.9"
+     inkscape:cx="96.355932"
+     inkscape:cy="17.542373"
+     inkscape:window-x="53"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg988" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="m 21.335186,8.3618474 c 0,-0.3500305 -0.138905,-0.6889488 -0.388923,-0.9389704 L 15.506902,1.9779595 C 15.256881,1.7279377 14.917962,1.5890368 14.562376,1.5890368 H 14.223457 V 8.700766 h 7.111729 z m 10.38979,10.3397906 -5.317127,-5.356023 c -0.56116,-0.561159 -1.522355,-0.166682 -1.522355,0.627833 v 3.616981 H 21.32963 v 3.555867 h 3.555864 v 3.622536 c 0,0.794514 0.961195,1.188993 1.522355,0.627833 l 5.317127,-5.361577 c 0.3667,-0.3667 0.3667,-0.966752 0,-1.33345 z m -21.057383,1.555691 v -1.777932 c 0,-0.488932 0.400035,-0.888968 0.888966,-0.888968 h 9.778627 v -7.11173 h -7.556212 c -0.733397,0 -1.333448,-0.6000525 -1.333448,-1.33345 V 1.5890368 H 1.3334491 C 0.59449607,1.5890368 0,2.183533 0,2.9224859 V 28.702507 c 0,0.738954 0.59449607,1.333449 1.3334491,1.333449 H 20.001737 c 0.738954,0 1.333449,-0.594495 1.333449,-1.333449 v -7.556211 h -9.778627 c -0.488931,0 -0.888966,-0.400035 -0.888966,-0.888967 z"
+     id="path986"
+     style="fill:#353a40;fill-opacity:1;stroke-width:0.999998" />
+</svg>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export32_dark.svg
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export32_dark.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg988"
+   sodipodi:docname="export32.svg"
+   width="32"
+   height="32"
+   inkscape:version="1.1-dev (0486c1a, 2020-10-10)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs992" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1929"
+     inkscape:window-height="1135"
+     id="namedview990"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="5.9"
+     inkscape:cx="96.355932"
+     inkscape:cy="17.542373"
+     inkscape:window-x="53"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg988" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="m 21.335186,8.3618474 c 0,-0.3500305 -0.138905,-0.6889488 -0.388923,-0.9389704 L 15.506902,1.9779595 C 15.256881,1.7279377 14.917962,1.5890368 14.562376,1.5890368 H 14.223457 V 8.700766 h 7.111729 z m 10.38979,10.3397906 -5.317127,-5.356023 c -0.56116,-0.561159 -1.522355,-0.166682 -1.522355,0.627833 v 3.616981 H 21.32963 v 3.555867 h 3.555864 v 3.622536 c 0,0.794514 0.961195,1.188993 1.522355,0.627833 l 5.317127,-5.361577 c 0.3667,-0.3667 0.3667,-0.966752 0,-1.33345 z m -21.057383,1.555691 v -1.777932 c 0,-0.488932 0.400035,-0.888968 0.888966,-0.888968 h 9.778627 v -7.11173 h -7.556212 c -0.733397,0 -1.333448,-0.6000525 -1.333448,-1.33345 V 1.5890368 H 1.3334491 C 0.59449607,1.5890368 0,2.183533 0,2.9224859 V 28.702507 c 0,0.738954 0.59449607,1.333449 1.3334491,1.333449 H 20.001737 c 0.738954,0 1.333449,-0.594495 1.333449,-1.333449 v -7.556211 h -9.778627 c -0.488931,0 -0.888966,-0.400035 -0.888966,-0.888967 z"
+     id="path986"
+     style="fill:#afb1b3;fill-opacity:1;stroke-width:0.999998" />
+</svg>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export32_disabled_dark.svg
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export32_disabled_dark.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg988"
+   sodipodi:docname="export32.svg"
+   width="32"
+   height="32"
+   inkscape:version="1.1-dev (0486c1a, 2020-10-10)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs992" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1929"
+     inkscape:window-height="1135"
+     id="namedview990"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="5.9"
+     inkscape:cx="96.355932"
+     inkscape:cy="17.542373"
+     inkscape:window-x="53"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg988" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="m 21.335186,8.3618474 c 0,-0.3500305 -0.138905,-0.6889488 -0.388923,-0.9389704 L 15.506902,1.9779595 C 15.256881,1.7279377 14.917962,1.5890368 14.562376,1.5890368 H 14.223457 V 8.700766 h 7.111729 z m 10.38979,10.3397906 -5.317127,-5.356023 c -0.56116,-0.561159 -1.522355,-0.166682 -1.522355,0.627833 v 3.616981 H 21.32963 v 3.555867 h 3.555864 v 3.622536 c 0,0.794514 0.961195,1.188993 1.522355,0.627833 l 5.317127,-5.361577 c 0.3667,-0.3667 0.3667,-0.966752 0,-1.33345 z m -21.057383,1.555691 v -1.777932 c 0,-0.488932 0.400035,-0.888968 0.888966,-0.888968 h 9.778627 v -7.11173 h -7.556212 c -0.733397,0 -1.333448,-0.6000525 -1.333448,-1.33345 V 1.5890368 H 1.3334491 C 0.59449607,1.5890368 0,2.183533 0,2.9224859 V 28.702507 c 0,0.738954 0.59449607,1.333449 1.3334491,1.333449 H 20.001737 c 0.738954,0 1.333449,-0.594495 1.333449,-1.333449 v -7.556211 h -9.778627 c -0.488931,0 -0.888966,-0.400035 -0.888966,-0.888967 z"
+     id="path986"
+     style="fill:#565656;fill-opacity:1;stroke-width:0.999998" />
+</svg>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export_dark.svg
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export_dark.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg988"
+   sodipodi:docname="export.svg"
+   width="16"
+   height="16"
+   inkscape:version="1.1-dev (0486c1a, 2020-10-10)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs992" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1929"
+     inkscape:window-height="1135"
+     id="namedview990"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="5.51"
+     inkscape:cx="96.46098"
+     inkscape:cy="17.513612"
+     inkscape:window-x="53"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg988" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="m 10.66725,4.2973672 c 0,-0.1750096 -0.06945,-0.3444633 -0.194455,-0.4694701 L 7.7532019,1.1055259 C 7.6281951,0.980519 7.4587413,0.9110708 7.2809539,0.9110708 H 7.1115001 V 4.4668209 H 10.66725 Z M 15.861978,9.4670954 13.2035,6.7891701 C 12.922929,6.5085992 12.442347,6.7058318 12.442347,7.1030762 v 1.8084326 h -1.777875 v 1.7778762 h 1.777875 v 1.81121 c 0,0.397244 0.480582,0.594477 0.761153,0.313906 l 2.658478,-2.680702 c 0.183344,-0.1833442 0.183344,-0.4833604 0,-0.6667036 z M 5.3336251,10.244916 V 9.3559782 c 0,-0.2444582 0.2000109,-0.4444694 0.4444687,-0.4444694 H 10.66725 V 5.3557584 H 6.8892657 c -0.3666867,0 -0.666703,-0.3000165 -0.666703,-0.6667032 V 0.9110708 H 0.66670314 C 0.29723848,0.9110708 0,1.2083093 0,1.5777739 V 14.467369 c 0,0.369465 0.29723848,0.666703 0.66670314,0.666703 H 10.000547 c 0.369465,0 0.666703,-0.297238 0.666703,-0.666703 V 10.689385 H 5.7780938 c -0.2444578,0 -0.4444687,-0.200011 -0.4444687,-0.444469 z"
+     id="path986"
+     style="fill:#afb1b3;fill-opacity:1;stroke-width:0.999998" />
+</svg>

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export_disabled_dark.svg
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/resources/com/willwinder/ugs/platform/surfacescanner/icons/export_disabled_dark.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg988"
+   sodipodi:docname="export.svg"
+   width="16"
+   height="16"
+   inkscape:version="1.1-dev (0486c1a, 2020-10-10)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs992" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1929"
+     inkscape:window-height="1135"
+     id="namedview990"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="5.51"
+     inkscape:cx="96.46098"
+     inkscape:cy="17.513612"
+     inkscape:window-x="53"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg988" />
+  <!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+  <path
+     d="m 10.66725,4.2973672 c 0,-0.1750096 -0.06945,-0.3444633 -0.194455,-0.4694701 L 7.7532019,1.1055259 C 7.6281951,0.980519 7.4587413,0.9110708 7.2809539,0.9110708 H 7.1115001 V 4.4668209 H 10.66725 Z M 15.861978,9.4670954 13.2035,6.7891701 C 12.922929,6.5085992 12.442347,6.7058318 12.442347,7.1030762 v 1.8084326 h -1.777875 v 1.7778762 h 1.777875 v 1.81121 c 0,0.397244 0.480582,0.594477 0.761153,0.313906 l 2.658478,-2.680702 c 0.183344,-0.1833442 0.183344,-0.4833604 0,-0.6667036 z M 5.3336251,10.244916 V 9.3559782 c 0,-0.2444582 0.2000109,-0.4444694 0.4444687,-0.4444694 H 10.66725 V 5.3557584 H 6.8892657 c -0.3666867,0 -0.666703,-0.3000165 -0.666703,-0.6667032 V 0.9110708 H 0.66670314 C 0.29723848,0.9110708 0,1.2083093 0,1.5777739 V 14.467369 c 0,0.369465 0.29723848,0.666703 0.66670314,0.666703 H 10.000547 c 0.369465,0 0.666703,-0.297238 0.666703,-0.666703 V 10.689385 H 5.7780938 c -0.2444578,0 -0.4444687,-0.200011 -0.4444687,-0.444469 z"
+     id="path986"
+     style="fill:#565656;fill-opacity:1;stroke-width:0.999998" />
+</svg>


### PR DESCRIPTION
Added the possibility to export the autoleveled gcode using the export button:
![image](https://github.com/winder/Universal-G-Code-Sender/assets/8962024/2b201bab-9346-4234-b78a-401f28e7354e)
