### PR TITLE
Reworked the overrides panel

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/G2CoreController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/G2CoreController.java
@@ -20,14 +20,15 @@ package com.willwinder.universalgcodesender;
 
 import com.google.gson.JsonObject;
 import com.willwinder.universalgcodesender.communicator.ICommunicator;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
+import com.willwinder.universalgcodesender.firmware.g2core.G2CoreOverrideManager;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatusBuilder;
 import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.CommunicatorState;
-import com.willwinder.universalgcodesender.model.PartialPosition;
-
 import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
+import com.willwinder.universalgcodesender.model.PartialPosition;
 
 /**
  * G2Core Control layer.
@@ -41,13 +42,16 @@ public class G2CoreController extends TinyGController {
      * A temporary flag for emulating a JOG state when parsing the controller status
      */
     private boolean isJogging = false;
+    private final IOverrideManager overrideManager;
 
     public G2CoreController() {
         super();
+        overrideManager = new G2CoreOverrideManager(this, getCommunicator());
     }
 
     public G2CoreController(ICommunicator communicator) {
         super(communicator);
+        overrideManager = new G2CoreOverrideManager(this, communicator);
     }
 
     @Override
@@ -90,7 +94,7 @@ public class G2CoreController extends TinyGController {
         capabilities.addCapability(CapabilitiesConstants.CONTINUOUS_JOGGING);
         capabilities.addCapability(CapabilitiesConstants.HOMING);
         capabilities.addCapability(CapabilitiesConstants.FIRMWARE_SETTINGS);
-        capabilities.addCapability(CapabilitiesConstants.OVERRIDES);
+        capabilities.removeCapability(CapabilitiesConstants.OVERRIDES);
         capabilities.removeCapability(CapabilitiesConstants.SETUP_WIZARD);
 
         setCurrentState(COMM_IDLE);
@@ -190,5 +194,10 @@ public class G2CoreController extends TinyGController {
         }
 
         return controllerStatus;
+    }
+
+    @Override
+    public IOverrideManager getOverrideManager() {
+        return overrideManager;
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2023 Will Winder
+    Copyright 2013-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -33,6 +33,8 @@ import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.Axis;
 import com.willwinder.universalgcodesender.model.CommunicatorState;
+import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
+import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
 import com.willwinder.universalgcodesender.model.Overrides;
 import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.Position;
@@ -49,9 +51,6 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
-
 /**
  * GRBL Control layer, coordinates all aspects of control.
  *
@@ -66,7 +65,12 @@ public class GrblController extends AbstractController {
     private GrblControllerInitializer initializer;
     private Capabilities capabilities = new Capabilities();
     // Polling state
-    private ControllerStatus controllerStatus = new ControllerStatus(ControllerState.DISCONNECTED, new Position(0, 0, 0, Units.MM), new Position(0, 0, 0, Units.MM));
+    private ControllerStatus controllerStatus = ControllerStatusBuilder.newInstance()
+            .setState(ControllerState.DISCONNECTED)
+            .setWorkCoord(Position.ZERO)
+            .setMachineCoord(Position.ZERO)
+            .build();
+
     // Canceling state
     private Boolean isCanceling = false;     // Set for the position polling thread.
     private int attemptsRemaining;

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2012-2023 Will Winder
+    Copyright 2012-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -21,21 +21,27 @@ package com.willwinder.universalgcodesender;
 
 import com.willwinder.universalgcodesender.firmware.grbl.commands.GetStatusCommand;
 import com.willwinder.universalgcodesender.firmware.grbl.commands.GrblSystemCommand;
+import com.willwinder.universalgcodesender.listeners.AccessoryStates;
+import com.willwinder.universalgcodesender.listeners.AccessoryStatesBuilder;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.ControllerStatus.AccessoryStates;
-import com.willwinder.universalgcodesender.listeners.ControllerStatus.EnabledPins;
-import com.willwinder.universalgcodesender.listeners.ControllerStatus.OverridePercents;
+import com.willwinder.universalgcodesender.listeners.ControllerStatusBuilder;
+import com.willwinder.universalgcodesender.listeners.EnabledPins;
+import com.willwinder.universalgcodesender.listeners.EnabledPinsBuilder;
 import com.willwinder.universalgcodesender.listeners.MessageType;
-import com.willwinder.universalgcodesender.model.*;
+import com.willwinder.universalgcodesender.listeners.OverridePercents;
+import com.willwinder.universalgcodesender.model.Alarm;
+import com.willwinder.universalgcodesender.model.Axis;
+import com.willwinder.universalgcodesender.model.Overrides;
+import com.willwinder.universalgcodesender.model.PartialPosition;
+import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UnitUtils.Units;
+import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndWaitForCompletion;
+import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndWaitForCompletionWithRetry;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndWaitForCompletion;
-import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndWaitForCompletionWithRetry;
 
 /**
  * Collection of useful Grbl related utilities.
@@ -347,10 +353,11 @@ public class GrblUtils {
     public static ControllerStatus getStatusFromStatusStringLegacy(String status, Units reportingUnits) {
         String stateString = StringUtils.defaultString(getStateFromStatusString(status), "unknown");
         ControllerState state = getControllerStateFromStateString(stateString);
-        return new ControllerStatus(
-                state,
-                getMachinePositionFromStatusString(status, reportingUnits),
-                getWorkPositionFromStatusString(status, reportingUnits));
+        return ControllerStatusBuilder.newInstance()
+                .setState(state)
+                .setWorkCoord(getWorkPositionFromStatusString(status, reportingUnits))
+                .setMachineCoord(getMachinePositionFromStatusString(status, reportingUnits))
+                .build();
     }
 
     /**
@@ -422,11 +429,11 @@ public class GrblUtils {
             }
             else if (part.startsWith("Pn:")) {
                 String value = part.substring(part.indexOf(':')+1);
-                pins = new EnabledPins(value);
+                pins = parseEnabledPins(value);
             }
             else if (part.startsWith("A:")) {
                 String value = part.substring(part.indexOf(':')+1);
-                accessoryStates = new AccessoryStates(value);
+                accessoryStates = parseAccessoryStates(value);
             }
         }
 
@@ -459,6 +466,37 @@ public class GrblUtils {
 
         ControllerState state = getControllerStateFromStateString(stateString);
         return new ControllerStatus(state, subStateString, MPos, WPos, feedSpeed, reportingUnits, spindleSpeed, overrides, WCO, pins, accessoryStates);
+    }
+
+    private static EnabledPins parseEnabledPins(String value) {
+        String enabledUpper = value.toUpperCase();
+        return  new EnabledPinsBuilder()
+                .setX(enabledUpper.contains("X"))
+                .setY(enabledUpper.contains("Y"))
+                .setZ(enabledUpper.contains("Z"))
+                .setA(enabledUpper.contains("A"))
+                .setB(enabledUpper.contains("B"))
+                .setC(enabledUpper.contains("C"))
+                .setProbe(enabledUpper.contains("P"))
+                .setDoor(enabledUpper.contains("D"))
+                .setHold(enabledUpper.contains("H"))
+                .setSoftReset(enabledUpper.contains("R"))
+                .setCycleStart(enabledUpper.contains("S"))
+                .createEnabledPins();
+    }
+
+    /**
+     * Parses the accessory state string
+     *
+     * @param accessoryStates as a string
+     * @return the parsed accessory state
+     */
+    private static AccessoryStates parseAccessoryStates(String accessoryStates) {
+        String enabledUpper = accessoryStates.toUpperCase();
+        boolean spindleCW = enabledUpper.contains("S");
+        boolean flood = enabledUpper.contains("F");
+        boolean mist = enabledUpper.contains("M");
+        return new AccessoryStatesBuilder().setSpindleCW(spindleCW).setFlood(flood).setMist(mist).createAccessoryStates();
     }
 
     /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -40,6 +40,7 @@ import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndW
 import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndWaitForCompletionWithRetry;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -411,13 +412,7 @@ public class GrblUtils {
             }
             else if (part.startsWith("Ov:")) {
                 isOverrideReport = true;
-                String[] overrideParts = part.substring(3).trim().split(",");
-                if (overrideParts.length == 3) {
-                    overrides = new OverridePercents(
-                            Integer.parseInt(overrideParts[0]),
-                            Integer.parseInt(overrideParts[1]),
-                            Integer.parseInt(overrideParts[2]));
-                }
+                overrides = parseOverrides(part).orElse(OverridePercents.EMTPY_OVERRIDE_PERCENTS);
             }
             else if (part.startsWith("F:")) {
                 feedSpeed = parseFeedSpeed(part);
@@ -466,6 +461,17 @@ public class GrblUtils {
 
         ControllerState state = getControllerStateFromStateString(stateString);
         return new ControllerStatus(state, subStateString, MPos, WPos, feedSpeed, reportingUnits, spindleSpeed, overrides, WCO, pins, accessoryStates);
+    }
+
+    private static Optional<OverridePercents> parseOverrides(String value) {
+        String[] overrideParts = value.substring(3).trim().split(",");
+        if (overrideParts.length == 3) {
+            return Optional.of(new OverridePercents(
+                    Integer.parseInt(overrideParts[0]),
+                    Integer.parseInt(overrideParts[1]),
+                    Integer.parseInt(overrideParts[2])));
+        }
+        return Optional.empty();
     }
 
     private static EnabledPins parseEnabledPins(String value) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/IController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/IController.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2015-2023 Will Winder
+    Copyright 2015-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -26,13 +26,13 @@ import com.willwinder.universalgcodesender.gcode.ICommandCreator;
 import com.willwinder.universalgcodesender.listeners.ControllerListener;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.model.Axis;
-import com.willwinder.universalgcodesender.model.Overrides;
-import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.CommunicatorState;
+import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.services.MessageService;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.IGcodeStreamReader;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
 
 import java.util.Optional;
 
@@ -128,11 +128,6 @@ public interface IController {
      */
     void probe(String axis, double feedRate, double distance, UnitUtils.Units units) throws Exception;
     void offsetTool(String axis, double offset, UnitUtils.Units units) throws Exception;
-
-    /*
-    Overrides
-    */
-    void sendOverrideCommand(Overrides command) throws Exception;
 
     /*
     Behavior
@@ -246,4 +241,11 @@ public interface IController {
      * @return a command creator for this controller
      */
     ICommandCreator getCommandCreator();
+
+    /**
+     * Gets the manager for handling overrides.
+     *
+     * @return the override manager.
+     */
+    IOverrideManager getOverrideManager();
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2023 Will Winder
+    Copyright 2013-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -32,18 +32,17 @@ import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatusBuilder;
 import com.willwinder.universalgcodesender.listeners.MessageType;
-import com.willwinder.universalgcodesender.listeners.OverridePercents;
 import com.willwinder.universalgcodesender.model.CommunicatorState;
 import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
 import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
-import com.willwinder.universalgcodesender.model.Overrides;
 import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.ControllerUtils;
+import com.willwinder.universalgcodesender.firmware.DefaultOverrideManager;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -408,15 +407,6 @@ public class TinyGController extends AbstractController {
     }
 
     @Override
-    public void sendOverrideCommand(Overrides command) throws Exception {
-        OverridePercents currentOverrides = controllerStatus.getOverrides();
-        Optional<GcodeCommand> gcodeCommand = TinyGUtils.createOverrideCommand(getCommandCreator(), currentOverrides, command);
-        if (gcodeCommand.isPresent()) {
-            sendCommandImmediately(gcodeCommand.get());
-	    }
-    }
-
-    @Override
     public String getFirmwareVersion() {
         return firmwareVersion;
     }
@@ -424,6 +414,11 @@ public class TinyGController extends AbstractController {
     @Override
     public ControllerStatus getControllerStatus() {
         return controllerStatus;
+    }
+
+    @Override
+    public IOverrideManager getOverrideManager() {
+        return new DefaultOverrideManager();
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/TinyGController.java
@@ -23,26 +23,29 @@ import com.willwinder.universalgcodesender.communicator.ICommunicator;
 import com.willwinder.universalgcodesender.communicator.TinyGCommunicator;
 import com.willwinder.universalgcodesender.firmware.IFirmwareSettings;
 import com.willwinder.universalgcodesender.firmware.tinyg.TinyGFirmwareSettings;
-import com.willwinder.universalgcodesender.gcode.ICommandCreator;
 import com.willwinder.universalgcodesender.firmware.tinyg.TinyGGcodeCommandCreator;
+import com.willwinder.universalgcodesender.firmware.tinyg.commands.TinyGGcodeCommand;
+import com.willwinder.universalgcodesender.gcode.ICommandCreator;
 import com.willwinder.universalgcodesender.gcode.util.GcodeUtils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatusBuilder;
 import com.willwinder.universalgcodesender.listeners.MessageType;
-import com.willwinder.universalgcodesender.model.*;
+import com.willwinder.universalgcodesender.listeners.OverridePercents;
+import com.willwinder.universalgcodesender.model.CommunicatorState;
+import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
+import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
+import com.willwinder.universalgcodesender.model.Overrides;
+import com.willwinder.universalgcodesender.model.PartialPosition;
+import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
-import com.willwinder.universalgcodesender.firmware.tinyg.commands.TinyGGcodeCommand;
 import com.willwinder.universalgcodesender.utils.ControllerUtils;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
 
 /**
  * TinyG Control layer, coordinates all aspects of control.
@@ -74,7 +77,7 @@ public class TinyGController extends AbstractController {
         firmwareSettings = new TinyGFirmwareSettings(this);
         communicator.addListener(firmwareSettings);
 
-        controllerStatus = new ControllerStatus(ControllerState.DISCONNECTED, new Position(0, 0, 0, UnitUtils.Units.MM), new Position(0, 0, 0, UnitUtils.Units.MM));
+        controllerStatus = ControllerStatus.EMPTY_CONTROLLER_STATUS;
         firmwareVersion = "TinyG unknown version";
     }
 
@@ -406,7 +409,7 @@ public class TinyGController extends AbstractController {
 
     @Override
     public void sendOverrideCommand(Overrides command) throws Exception {
-        ControllerStatus.OverridePercents currentOverrides = controllerStatus.getOverrides();
+        OverridePercents currentOverrides = controllerStatus.getOverrides();
         Optional<GcodeCommand> gcodeCommand = TinyGUtils.createOverrideCommand(getCommandCreator(), currentOverrides, command);
         if (gcodeCommand.isPresent()) {
             sendCommandImmediately(gcodeCommand.get());

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/AbstractOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/AbstractOverrideManager.java
@@ -1,0 +1,172 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.firmware;
+
+import com.willwinder.universalgcodesender.IController;
+import static com.willwinder.universalgcodesender.Utils.roundToNearestStepValue;
+import com.willwinder.universalgcodesender.communicator.ICommunicator;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
+import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.DefaultControllerListener;
+import com.willwinder.universalgcodesender.listeners.OverridePercents;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+import com.willwinder.universalgcodesender.model.Overrides;
+
+/**
+ * An abstract override manager with some default implementation of common functions.
+ *
+ * @author Joacim Breiler
+ */
+public abstract class AbstractOverrideManager implements IOverrideManager {
+    public static final int SETTLE_TIME_MS = 50;
+
+    protected final IController controller;
+    protected final ICommunicator communicator;
+
+    protected int targetFeedSpeed = 100;
+    protected int targetSpindleSpeed = 100;
+
+    private boolean isRunning = false;
+    private long lastSentCommand = 0;
+
+    protected AbstractOverrideManager(IController controller, ICommunicator communicator) {
+        this.controller = controller;
+        this.communicator = communicator;
+        this.controller.addListener(new DefaultControllerListener() {
+            @Override
+            public void statusStringListener(ControllerStatus status) {
+                onControllerStatus(status);
+            }
+        });
+    }
+
+    private void onControllerStatus(ControllerStatus controllerStatus) {
+        if (!isRunning) {
+            targetFeedSpeed = controllerStatus.getOverrides().feed();
+            targetSpindleSpeed = controllerStatus.getOverrides().spindle();
+            return;
+        }
+
+        // Wait for the override to settle
+        if (lastSentCommand + SETTLE_TIME_MS > System.currentTimeMillis()) {
+            return;
+        }
+        lastSentCommand = System.currentTimeMillis();
+
+        OverridePercents currentOverridePercents = controllerStatus.getOverrides();
+        adjustFeedOverride(currentOverridePercents);
+        adjustSpindleOverride(currentOverridePercents);
+
+        if (hasSettled()) {
+            stop();
+        }
+    }
+
+    protected void adjustFeedOverride(OverridePercents currentOverridePercents) {
+        if (currentOverridePercents.feed() == targetFeedSpeed) {
+            return;
+        }
+
+        float currentFeed = currentOverridePercents.feed();
+        int majorSteps = (int) ((targetFeedSpeed - currentFeed) / getSpeedMajorStep(OverrideType.FEED_SPEED));
+        int minorSteps = (int) ((targetFeedSpeed - currentFeed) / getSpeedMinorStep(OverrideType.FEED_SPEED));
+
+        try {
+            if (majorSteps < 0) {
+                sendOverrideCommand(Overrides.CMD_FEED_OVR_COARSE_MINUS);
+            } else if (majorSteps > 0) {
+                sendOverrideCommand(Overrides.CMD_FEED_OVR_COARSE_PLUS);
+            } else if (minorSteps < 0) {
+                sendOverrideCommand(Overrides.CMD_FEED_OVR_FINE_MINUS);
+            } else if (minorSteps > 0) {
+                sendOverrideCommand(Overrides.CMD_FEED_OVR_FINE_PLUS);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected void adjustSpindleOverride(OverridePercents currentOverridePercents) {
+        if (currentOverridePercents.spindle() == targetSpindleSpeed) {
+            return;
+        }
+
+        float currentSpindle = currentOverridePercents.spindle();
+        int majorSteps = (int) ((targetSpindleSpeed - currentSpindle) / getSpeedMajorStep(OverrideType.SPINDLE_SPEED));
+        int minorSteps = (int) ((targetSpindleSpeed - currentSpindle) / getSpeedMinorStep(OverrideType.SPINDLE_SPEED));
+
+        try {
+            if (majorSteps < 0) {
+                sendOverrideCommand(Overrides.CMD_SPINDLE_OVR_COARSE_MINUS);
+            } else if (majorSteps > 0) {
+                sendOverrideCommand(Overrides.CMD_SPINDLE_OVR_COARSE_PLUS);
+            } else if (minorSteps < 0) {
+                sendOverrideCommand(Overrides.CMD_SPINDLE_OVR_FINE_MINUS);
+            } else if (minorSteps > 0) {
+                sendOverrideCommand(Overrides.CMD_SPINDLE_OVR_FINE_PLUS);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected abstract int getSpeedMinorStep(OverrideType overrideType);
+
+    protected abstract float getSpeedMajorStep(OverrideType overrideType);
+
+    public boolean isAvailable() {
+        ControllerState state = controller.getControllerStatus().getState();
+        return controller.getCapabilities().hasOverrides() && (state == ControllerState.HOLD || state == ControllerState.IDLE || state == ControllerState.RUN);
+    }
+
+    /**
+     * Starts sending continuous override commands to achieve the target speeds
+     */
+    protected void start() {
+        if (!isRunning) {
+            isRunning = true;
+            onControllerStatus(controller.getControllerStatus());
+        }
+    }
+
+    /**
+     * Stops sending override commands
+     */
+    private void stop() {
+        isRunning = false;
+    }
+
+    @Override
+    public boolean hasSettled() {
+        OverridePercents overrides = controller.getControllerStatus().getOverrides();
+        return overrides.spindle() == targetSpindleSpeed && overrides.feed() == targetFeedSpeed;
+    }
+
+    @Override
+    public void setSpeedTarget(OverrideType type, int percent) {
+        percent = (int) Math.round(roundToNearestStepValue(percent, getSpeedMin(type), getSpeedMax(type), getSpeedStep(type)));
+        if (type == OverrideType.FEED_SPEED) {
+            targetFeedSpeed = percent;
+        } else if (type == OverrideType.SPINDLE_SPEED) {
+            targetSpindleSpeed = percent;
+        }
+
+        start();
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/AbstractOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/AbstractOverrideManager.java
@@ -56,7 +56,7 @@ public abstract class AbstractOverrideManager implements IOverrideManager {
         });
     }
 
-    private void onControllerStatus(ControllerStatus controllerStatus) {
+    public void onControllerStatus(ControllerStatus controllerStatus) {
         if (!isRunning) {
             targetFeedSpeed = controllerStatus.getOverrides().feed();
             targetSpindleSpeed = controllerStatus.getOverrides().spindle();
@@ -128,9 +128,15 @@ public abstract class AbstractOverrideManager implements IOverrideManager {
 
     protected abstract int getSpeedMinorStep(OverrideType overrideType);
 
-    protected abstract float getSpeedMajorStep(OverrideType overrideType);
+    protected abstract int getSpeedMajorStep(OverrideType overrideType);
 
     public boolean isAvailable() {
+        if (controller == null || controller.getControllerStatus() == null ||
+                controller.getControllerStatus().getState() == null ||
+                controller.getCapabilities() == null) {
+            return false;
+        }
+
         ControllerState state = controller.getControllerStatus().getState();
         return controller.getCapabilities().hasOverrides() && (state == ControllerState.HOLD || state == ControllerState.IDLE || state == ControllerState.RUN);
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/DefaultOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/DefaultOverrideManager.java
@@ -1,0 +1,97 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.firmware;
+
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+import com.willwinder.universalgcodesender.model.Overrides;
+
+import java.util.List;
+
+/**
+ * A default empty implementation of an override manager which can be used if the
+ * controller does not support overrides.
+ *
+ * @author Joacim Breiler
+ */
+public class DefaultOverrideManager implements IOverrideManager {
+    @Override
+    public void setSpeedTarget(OverrideType type, int value) {
+        // Not implemented
+    }
+
+    @Override
+    public boolean hasSettled() {
+        return true;
+    }
+
+    @Override
+    public int getSpeedMax(OverrideType type) {
+        return 0;
+    }
+
+    @Override
+    public int getSpeedMin(OverrideType type) {
+        return 0;
+    }
+
+    @Override
+    public int getSpeedStep(OverrideType type) {
+        return 0;
+    }
+
+    @Override
+    public void sendOverrideCommand(Overrides command) {
+        // Not implemented
+    }
+
+    @Override
+    public int getSpeedDefault(OverrideType overrideType) {
+        return 0;
+    }
+
+    @Override
+    public int getSpeedTargetValue(OverrideType type) {
+        return 0;
+    }
+
+    @Override
+    public List<OverrideType> getSpeedTypes() {
+        return List.of();
+    }
+
+    @Override
+    public List<OverrideType> getToggleTypes() {
+        return List.of();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return false;
+    }
+
+    @Override
+    public void toggle(OverrideType overrideType) {
+        // Not implemented
+    }
+
+    @Override
+    public boolean isToggled(OverrideType overrideType) {
+        return false;
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/IOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/IOverrideManager.java
@@ -1,0 +1,104 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.firmware;
+
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+import com.willwinder.universalgcodesender.model.Overrides;
+
+import java.util.List;
+
+/**
+ * The override manager is used to apply overrides to the controller
+ *
+ * @author Joacim Breiler
+ */
+public interface IOverrideManager {
+    /**
+     * Sets the new override percents for the given type. If the controller doesn't support given override value
+     * the nearest will be used instead. If the override type does not support setting a speed step it is ignored.
+     * Which {@link OverrideType} that can be used with this function is determined with the {@link #getSpeedTypes}.
+     *
+     * @param type  the override value to set
+     * @param value new controller override value in percent
+     */
+    void setSpeedTarget(OverrideType type, int value);
+
+    int getSpeedMax(OverrideType type);
+
+    int getSpeedMin(OverrideType type);
+
+    int getSpeedStep(OverrideType type);
+
+    void sendOverrideCommand(Overrides command);
+
+    int getSpeedDefault(OverrideType type);
+
+    /**
+     * Get the target speed for the given override type. Which {@link OverrideType} that can be used with this
+     * function is determined with the {@link #getSpeedTypes}.
+     *
+     * @param type the override type to get the target speed for.
+     * @return the target speed in percent
+     */
+    int getSpeedTargetValue(OverrideType type);
+
+    /**
+     * Returns true if the changes to be made with the override manager has settled and are done.
+     *
+     * @return true if the changes are done
+     */
+    boolean hasSettled();
+
+    /**
+     * Returns the override types that can be set with speed settings
+     *
+     * @return a list of override speed types
+     */
+    List<OverrideType> getSpeedTypes();
+
+    /**
+     * Returns the override types that can be toggled
+     *
+     * @return a list of toggleable override types
+     */
+    List<OverrideType> getToggleTypes();
+
+    /**
+     * Returns true when override functions are available
+     *
+     * @return true when it is available and can be used to override behaviour on the controller
+     */
+    boolean isAvailable();
+
+    /**
+     * Toggles the given override. Which {@link OverrideType} that can be used with this function is determined
+     * with the {@link #getToggleTypes()}.
+     *
+     * @param type the
+     */
+    void toggle(OverrideType type);
+
+    /**
+     * Returns if the given override is currently toggled.
+     *
+     * @param type the override type
+     * @return true if the override is active
+     */
+    boolean isToggled(OverrideType type);
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/OverrideException.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/OverrideException.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2024 Will Winder
+    Copyright 2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -16,17 +16,10 @@
     You should have received a copy of the GNU General Public License
     along with UGS.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.willwinder.universalgcodesender.listeners;
+package com.willwinder.universalgcodesender.firmware;
 
-/**
- * Overrides given as percents where the value 100 is the normal speed to 100%.
- * The value range is dependant on the controller but can normally be given as a
- * value between 10 - 200 %
- *
- * @param feed the feed speed in percent
- * @param rapid the rapid speed in percent
- * @param spindle  the spindle speed in percent
- */
-public record OverridePercents(int feed, int rapid, int spindle) {
-    public static final OverridePercents EMTPY_OVERRIDE_PERCENTS = new OverridePercents(100, 100, 100);
+public class OverrideException extends RuntimeException {
+    public OverrideException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/g2core/G2CoreOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/g2core/G2CoreOverrideManager.java
@@ -1,0 +1,148 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.firmware.g2core;
+
+import com.willwinder.universalgcodesender.IController;
+import com.willwinder.universalgcodesender.TinyGUtils;
+import com.willwinder.universalgcodesender.communicator.ICommunicator;
+import com.willwinder.universalgcodesender.firmware.AbstractOverrideManager;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+import com.willwinder.universalgcodesender.model.Overrides;
+import com.willwinder.universalgcodesender.types.GcodeCommand;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+public class G2CoreOverrideManager extends AbstractOverrideManager implements IOverrideManager {
+    private static final Logger LOGGER = Logger.getLogger(G2CoreOverrideManager.class.getSimpleName());
+    private static final int MINOR_STEP = 1;
+    private static final int MAJOR_STEP = 10;
+    private static final int FEED_MIN = 10;
+    private static final int FEED_MAX = 200;
+    private static final int FEED_DEFAULT = 100;
+    private static final int SPINDLE_MIN = 10;
+    private static final int SPINDLE_MAX = 200;
+    private static final int SPINDLE_DEFAULT = 100;
+
+    public G2CoreOverrideManager(IController controller, ICommunicator communicator) {
+        super(controller, communicator);
+    }
+
+    @Override
+    protected int getSpeedMinorStep(OverrideType overrideType) {
+        return MINOR_STEP;
+    }
+
+    @Override
+    protected float getSpeedMajorStep(OverrideType overrideType) {
+        return MAJOR_STEP;
+    }
+
+    public void sendOverrideCommand(Overrides command) {
+        Optional<GcodeCommand> gcodeCommand = TinyGUtils.createOverrideCommand(controller.getCommandCreator(), controller.getControllerStatus().getOverrides(), command);
+        if (gcodeCommand.isEmpty()) {
+            return;
+        }
+
+        try {
+            controller.sendCommandImmediately(gcodeCommand.get());
+        } catch (Exception e) {
+            LOGGER.info("Could not send override command " + command);
+        }
+    }
+
+    @Override
+    public int getSpeedDefault(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> FEED_DEFAULT;
+            case SPINDLE_SPEED -> SPINDLE_DEFAULT;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public int getSpeedTargetValue(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> targetFeedSpeed;
+            case SPINDLE_SPEED -> targetSpindleSpeed;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public List<OverrideType> getSpeedTypes() {
+        return List.of(OverrideType.FEED_SPEED, OverrideType.SPINDLE_SPEED);
+    }
+
+    @Override
+    public List<OverrideType> getToggleTypes() {
+        return List.of(OverrideType.SPINDLE_TOGGLE, OverrideType.MIST_TOGGLE, OverrideType.FLOOD_TOGGLE);
+    }
+
+    @Override
+    public void toggle(OverrideType type) {
+        switch (type) {
+            case SPINDLE_TOGGLE -> sendOverrideCommand(Overrides.CMD_TOGGLE_SPINDLE);
+            case MIST_TOGGLE -> sendOverrideCommand(Overrides.CMD_TOGGLE_MIST_COOLANT);
+            case FLOOD_TOGGLE -> sendOverrideCommand(Overrides.CMD_TOGGLE_FLOOD_COOLANT);
+            default -> throw new IllegalStateException("Unexpected value: " + type);
+        }
+    }
+
+    @Override
+    public boolean isToggled(OverrideType overrideType) {
+        return switch (overrideType) {
+            case MIST_TOGGLE -> controller.getControllerStatus().getAccessoryStates().mist();
+            case FLOOD_TOGGLE -> controller.getControllerStatus().getAccessoryStates().flood();
+            case SPINDLE_TOGGLE -> (controller.getControllerStatus().getSpindleSpeed() > 0);
+            default -> false;
+        };
+    }
+
+    @Override
+    public int getSpeedMax(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> FEED_MAX;
+            case SPINDLE_SPEED -> SPINDLE_MAX;
+            case RAPID_SPEED -> 100;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public int getSpeedMin(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> FEED_MIN;
+            case SPINDLE_SPEED -> SPINDLE_MIN;
+            case RAPID_SPEED -> 25;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public int getSpeedStep(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED, SPINDLE_SPEED -> MINOR_STEP;
+            default -> 0;
+        };
+    }
+
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/g2core/G2CoreOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/g2core/G2CoreOverrideManager.java
@@ -52,7 +52,7 @@ public class G2CoreOverrideManager extends AbstractOverrideManager implements IO
     }
 
     @Override
-    protected float getSpeedMajorStep(OverrideType overrideType) {
+    protected int getSpeedMajorStep(OverrideType overrideType) {
         return MAJOR_STEP;
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblOverrideManager.java
@@ -1,0 +1,141 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.firmware.grbl;
+
+import com.willwinder.universalgcodesender.GrblUtils;
+import com.willwinder.universalgcodesender.IController;
+import com.willwinder.universalgcodesender.communicator.ICommunicator;
+import com.willwinder.universalgcodesender.firmware.AbstractOverrideManager;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
+import com.willwinder.universalgcodesender.firmware.OverrideException;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+import com.willwinder.universalgcodesender.model.Overrides;
+
+import java.util.List;
+
+public class GrblOverrideManager extends AbstractOverrideManager implements IOverrideManager {
+    private static final int MINOR_STEP = 1;
+    private static final int MAJOR_STEP = 10;
+    private static final int FEED_MIN = 10;
+    private static final int FEED_MAX = 200;
+    private static final int FEED_DEFAULT = 100;
+    private static final int SPINDLE_MIN = 10;
+    private static final int SPINDLE_MAX = 200;
+    private static final int SPINDLE_DEFAULT = 100;
+
+    public GrblOverrideManager(IController controller, ICommunicator communicator) {
+        super(controller, communicator);
+    }
+
+    @Override
+    protected int getSpeedMinorStep(OverrideType overrideType) {
+        return MINOR_STEP;
+    }
+
+    @Override
+    protected float getSpeedMajorStep(OverrideType overrideType) {
+        return MAJOR_STEP;
+    }
+
+    public void sendOverrideCommand(Overrides command) {
+        Byte realTimeCommand = GrblUtils.getOverrideForEnum(command, controller.getCapabilities());
+        if (realTimeCommand != null) {
+            try {
+                communicator.sendByteImmediately(realTimeCommand);
+            } catch (Exception e) {
+                throw new OverrideException("Could not send override command", e);
+            }
+        }
+    }
+
+    @Override
+    public int getSpeedDefault(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> FEED_DEFAULT;
+            case SPINDLE_SPEED -> SPINDLE_DEFAULT;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public int getSpeedTargetValue(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> targetFeedSpeed;
+            case SPINDLE_SPEED -> targetSpindleSpeed;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public List<OverrideType> getSpeedTypes() {
+        return List.of(OverrideType.FEED_SPEED, OverrideType.SPINDLE_SPEED);
+    }
+
+    @Override
+    public List<OverrideType> getToggleTypes() {
+        return List.of(OverrideType.SPINDLE_TOGGLE, OverrideType.MIST_TOGGLE, OverrideType.FLOOD_TOGGLE);
+    }
+
+    @Override
+    public void toggle(OverrideType type) {
+        switch (type) {
+            case SPINDLE_TOGGLE -> sendOverrideCommand(Overrides.CMD_TOGGLE_SPINDLE);
+            case MIST_TOGGLE -> sendOverrideCommand(Overrides.CMD_TOGGLE_MIST_COOLANT);
+            case FLOOD_TOGGLE -> sendOverrideCommand(Overrides.CMD_TOGGLE_FLOOD_COOLANT);
+            default -> throw new IllegalStateException("Unexpected value: " + type);
+        }
+    }
+
+    @Override
+    public boolean isToggled(OverrideType overrideType) {
+        return switch (overrideType) {
+            case MIST_TOGGLE -> controller.getControllerStatus().getAccessoryStates().mist();
+            case FLOOD_TOGGLE -> controller.getControllerStatus().getAccessoryStates().flood();
+            case SPINDLE_TOGGLE -> (controller.getControllerStatus().getSpindleSpeed() > 0);
+            default -> false;
+        };
+    }
+
+    @Override
+    public int getSpeedMax(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> FEED_MAX;
+            case SPINDLE_SPEED -> SPINDLE_MAX;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public int getSpeedMin(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED -> FEED_MIN;
+            case SPINDLE_SPEED -> SPINDLE_MIN;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public int getSpeedStep(OverrideType type) {
+        return switch (type) {
+            case FEED_SPEED, SPINDLE_SPEED -> MINOR_STEP;
+            default -> 0;
+        };
+    }
+
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblOverrideManager.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblOverrideManager.java
@@ -49,7 +49,7 @@ public class GrblOverrideManager extends AbstractOverrideManager implements IOve
     }
 
     @Override
-    protected float getSpeedMajorStep(OverrideType overrideType) {
+    protected int getSpeedMajorStep(OverrideType overrideType) {
         return MAJOR_STEP;
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/commands/GetStatusCommand.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/commands/GetStatusCommand.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2023 Will Winder
+    Copyright 2023-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -27,8 +27,8 @@ import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 
 public class GetStatusCommand extends GcodeCommand {
-    public static final ControllerStatus EMPTY_STATUS = new ControllerStatus(ControllerState.DISCONNECTED, Position.ZERO, Position.ZERO);
-    private ControllerStatus controllerStatus = ControllerStatusBuilder.newInstance().build();
+    public static final ControllerStatus EMPTY_STATUS = new ControllerStatus(ControllerState.UNKNOWN, Position.ZERO, Position.ZERO);
+    private ControllerStatus controllerStatus = ControllerStatusBuilder.newInstance().setState(ControllerState.UNKNOWN).build();
 
     public GetStatusCommand() {
         super("?");

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/smoothie/SmoothieController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/smoothie/SmoothieController.java
@@ -33,20 +33,20 @@ import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.ControllerStatusBuilder;
 import com.willwinder.universalgcodesender.listeners.MessageType;
 import com.willwinder.universalgcodesender.model.CommunicatorState;
-import com.willwinder.universalgcodesender.model.Overrides;
+import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
+import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_DISCONNECTED;
+import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
 import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
 import com.willwinder.universalgcodesender.utils.ControllerUtils;
+import com.willwinder.universalgcodesender.firmware.DefaultOverrideManager;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
 import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
-
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_CHECK;
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_DISCONNECTED;
-import static com.willwinder.universalgcodesender.model.CommunicatorState.COMM_IDLE;
 
 /**
  * Controller implementation for Smoothieware
@@ -222,11 +222,6 @@ public class SmoothieController extends AbstractController {
     }
 
     @Override
-    public void sendOverrideCommand(Overrides command) {
-
-    }
-
-    @Override
     public boolean getStatusUpdatesEnabled() {
         return statusPollTimer.isEnabled();
     }
@@ -275,6 +270,11 @@ public class SmoothieController extends AbstractController {
     @Override
     public ControllerStatus getControllerStatus() {
         return controllerStatus;
+    }
+
+    @Override
+    public IOverrideManager getOverrideManager() {
+        return new DefaultOverrideManager();
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/AccessoryStates.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/AccessoryStates.java
@@ -1,0 +1,26 @@
+/*
+    Copyright 2013-2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+/**
+ * A class for storing the accessory states
+ */
+public record AccessoryStates(boolean spindleCW, boolean flood, boolean mist) {
+    public static final AccessoryStates EMPTY_ACCESSORY_STATE = new AccessoryStatesBuilder().createAccessoryStates();
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/AccessoryStatesBuilder.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/AccessoryStatesBuilder.java
@@ -1,0 +1,47 @@
+/*
+    Copyright 2013-2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+/**
+ * A class for storing the accessory states
+ */
+public class AccessoryStatesBuilder {
+    private boolean spindleCW = true;
+    private boolean flood;
+    private boolean mist;
+
+    public AccessoryStatesBuilder setSpindleCW(boolean spindleCW) {
+        this.spindleCW = spindleCW;
+        return this;
+    }
+
+    public AccessoryStatesBuilder setFlood(boolean flood) {
+        this.flood = flood;
+        return this;
+    }
+
+    public AccessoryStatesBuilder setMist(boolean mist) {
+        this.mist = mist;
+        return this;
+    }
+
+    public AccessoryStates createAccessoryStates() {
+        return new AccessoryStates(spindleCW, flood, mist);
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatus.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2023 Will Winder
+    Copyright 2016-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  * @author wwinder
  */
 public class ControllerStatus {
+    public static final ControllerStatus EMPTY_CONTROLLER_STATUS = ControllerStatusBuilder.newInstance().build();
     private final Position machineCoord;
     private final Position workCoord;
     private final Position workCoordinateOffset;
@@ -48,17 +49,7 @@ public class ControllerStatus {
      * @param workCoord    controller work coordinates
      */
     public ControllerStatus(ControllerState state, Position machineCoord, Position workCoord) {
-        this(state, machineCoord, workCoord, 0d, UnitUtils.Units.MM, 0d, null, null, null, null);
-    }
-
-    /**
-     * Additional parameters
-     */
-    public ControllerStatus(ControllerState state, Position machineCoord,
-                            Position workCoord, Double feedSpeed, UnitUtils.Units feedSpeedUnits, Double spindleSpeed,
-                            OverridePercents overrides, Position workCoordinateOffset,
-                            EnabledPins pins, AccessoryStates states) {
-        this(state, "", machineCoord, workCoord, feedSpeed, feedSpeedUnits, spindleSpeed, overrides, workCoordinateOffset, pins, states);
+        this(state, "", machineCoord, workCoord, 0d, UnitUtils.Units.MM, 0d, null, null, null, null);
     }
 
     /**
@@ -79,10 +70,6 @@ public class ControllerStatus {
         this.overrides = overrides;
         this.pins = pins;
         this.accessoryStates = states;
-    }
-
-    public ControllerStatus() {
-        this(ControllerState.DISCONNECTED, Position.ZERO, Position.ZERO);
     }
 
     public ControllerState getState() {
@@ -139,92 +126,4 @@ public class ControllerStatus {
         return subState;
     }
 
-    public static class EnabledPins {
-        public static final EnabledPins EMPTY_PINS = new EnabledPins("");
-
-        final public boolean X;
-        final public boolean Y;
-        final public boolean Z;
-        final public boolean A;
-        final public boolean B;
-        final public boolean C;
-        final public boolean Probe;
-        final public boolean Door;
-        final public boolean Hold;
-        final public boolean SoftReset;
-        final public boolean CycleStart;
-
-        public EnabledPins(String enabled) {
-            String enabledUpper = enabled.toUpperCase();
-            X = enabledUpper.contains("X");
-            Y = enabledUpper.contains("Y");
-            Z = enabledUpper.contains("Z");
-            A = enabledUpper.contains("A");
-            B = enabledUpper.contains("B");
-            C = enabledUpper.contains("C");
-            Probe = enabledUpper.contains("P");
-            Door = enabledUpper.contains("D");
-            Hold = enabledUpper.contains("H");
-            SoftReset = enabledUpper.contains("R");
-            CycleStart = enabledUpper.contains("S");
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return EqualsBuilder.reflectionEquals(this, o);
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.reflectionHashCode(this);
-        }
-    }
-
-    public static class AccessoryStates {
-        public static final AccessoryStates EMPTY_ACCESSORY_STATE = new AccessoryStates("");
-        final public boolean SpindleCW;
-        final public boolean SpindleCCW;
-        final public boolean Flood;
-        final public boolean Mist;
-
-        public AccessoryStates(String enabled) {
-            String enabledUpper = enabled.toUpperCase();
-            SpindleCW = enabledUpper.contains("S");
-            SpindleCCW = enabledUpper.contains("C");
-            Flood = enabledUpper.contains("F");
-            Mist = enabledUpper.contains("M");
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return EqualsBuilder.reflectionEquals(this, o);
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.reflectionHashCode(this);
-        }
-    }
-
-    public static class OverridePercents {
-        final public int feed;
-        final public int rapid;
-        final public int spindle;
-
-        public OverridePercents(int feed, int rapid, int spindle) {
-            this.feed = feed;
-            this.rapid = rapid;
-            this.spindle = spindle;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return EqualsBuilder.reflectionEquals(this, o);
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.reflectionHashCode(this);
-        }
-    }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatusBuilder.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/ControllerStatusBuilder.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2019 Will Winder
+    Copyright 2016-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -27,16 +27,16 @@ import com.willwinder.universalgcodesender.model.UnitUtils;
  * @author Joacim Breiler
  */
 public class ControllerStatusBuilder {
-    private ControllerState state = ControllerState.UNKNOWN;
+    private ControllerState state = ControllerState.DISCONNECTED;
     private Position machineCoord = Position.ZERO;
     private Position workCoord = Position.ZERO;
     private Double feedSpeed = 0d;
     private UnitUtils.Units feedSpeedUnits = UnitUtils.Units.MM;
     private Double spindleSpeed = 0d;
-    private ControllerStatus.OverridePercents overrides = null;
+    private OverridePercents overrides = OverridePercents.EMTPY_OVERRIDE_PERCENTS;
     private Position workCoordinateOffset = Position.ZERO;
-    private ControllerStatus.EnabledPins pins = null;
-    private ControllerStatus.AccessoryStates states = null;
+    private EnabledPins pins = EnabledPins.EMPTY_PINS;
+    private AccessoryStates states = AccessoryStates.EMPTY_ACCESSORY_STATE;
     private String subState = "";
 
     public static ControllerStatusBuilder newInstance() {
@@ -97,7 +97,7 @@ public class ControllerStatusBuilder {
         return this;
     }
 
-    public ControllerStatusBuilder setOverrides(ControllerStatus.OverridePercents overrides) {
+    public ControllerStatusBuilder setOverrides(OverridePercents overrides) {
         this.overrides = overrides;
         return this;
     }
@@ -107,12 +107,12 @@ public class ControllerStatusBuilder {
         return this;
     }
 
-    public ControllerStatusBuilder setPins(ControllerStatus.EnabledPins pins) {
+    public ControllerStatusBuilder setPins(EnabledPins pins) {
         this.pins = pins;
         return this;
     }
 
-    public ControllerStatusBuilder setStates(ControllerStatus.AccessoryStates states) {
+    public ControllerStatusBuilder setStates(AccessoryStates states) {
         this.states = states;
         return this;
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/DefaultControllerListener.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/DefaultControllerListener.java
@@ -1,0 +1,86 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+import com.willwinder.universalgcodesender.model.Alarm;
+import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.types.GcodeCommand;
+
+/**
+ * A controller listener that has empty default implementations of the interface.
+ * Override only the things that you need.
+ *
+ * @author Joacim Breiler
+ */
+public class DefaultControllerListener implements ControllerListener {
+    @Override
+    public void streamCanceled() {
+        // Not implemented
+    }
+
+    @Override
+    public void streamStarted() {
+        // Not implemented
+    }
+
+    @Override
+    public void streamPaused() {
+        // Not implemented
+    }
+
+    @Override
+    public void streamResumed() {
+        // Not implemented
+    }
+
+    @Override
+    public void streamComplete() {
+        // Not implemented
+    }
+
+    @Override
+    public void receivedAlarm(Alarm alarm) {
+        // Not implemented
+    }
+
+    @Override
+    public void commandSkipped(GcodeCommand command) {
+        // Not implemented
+    }
+
+    @Override
+    public void commandSent(GcodeCommand command) {
+        // Not implemented
+    }
+
+    @Override
+    public void commandComplete(GcodeCommand command) {
+        // Not implemented
+    }
+
+    @Override
+    public void probeCoordinates(Position p) {
+        // Not implemented
+    }
+
+    @Override
+    public void statusStringListener(ControllerStatus status) {
+        // Not implemented
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/EnabledPins.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/EnabledPins.java
@@ -1,0 +1,24 @@
+/*
+    Copyright 2013-2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+public record EnabledPins(boolean x, boolean y, boolean z, boolean a, boolean b, boolean c, boolean probe, boolean door,
+                          boolean hold, boolean softReset, boolean cycleStart) {
+    public static final EnabledPins EMPTY_PINS = new EnabledPinsBuilder().createEnabledPins();
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/EnabledPinsBuilder.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/EnabledPinsBuilder.java
@@ -1,0 +1,92 @@
+/*
+    Copyright 2013-2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+public class EnabledPinsBuilder {
+    private boolean x = false;
+    private boolean y = false;
+    private boolean z = false;
+    private boolean a = false;
+    private boolean b = false;
+    private boolean c = false;
+    private boolean probe = false;
+    private boolean door = false;
+    private boolean hold = false;
+    private boolean softReset = false;
+    private boolean cycleStart = false;
+
+    public EnabledPinsBuilder setX(boolean x) {
+        this.x = x;
+        return this;
+    }
+
+    public EnabledPinsBuilder setY(boolean y) {
+        this.y = y;
+        return this;
+    }
+
+    public EnabledPinsBuilder setZ(boolean z) {
+        this.z = z;
+        return this;
+    }
+
+    public EnabledPinsBuilder setA(boolean a) {
+        this.a = a;
+        return this;
+    }
+
+    public EnabledPinsBuilder setB(boolean b) {
+        this.b = b;
+        return this;
+    }
+
+    public EnabledPinsBuilder setC(boolean c) {
+        this.c = c;
+        return this;
+    }
+
+    public EnabledPinsBuilder setProbe(boolean probe) {
+        this.probe = probe;
+        return this;
+    }
+
+    public EnabledPinsBuilder setDoor(boolean door) {
+        this.door = door;
+        return this;
+    }
+
+    public EnabledPinsBuilder setHold(boolean hold) {
+        this.hold = hold;
+        return this;
+    }
+
+    public EnabledPinsBuilder setSoftReset(boolean softReset) {
+        this.softReset = softReset;
+        return this;
+    }
+
+    public EnabledPinsBuilder setCycleStart(boolean cycleStart) {
+        this.cycleStart = cycleStart;
+        return this;
+    }
+
+    public EnabledPins createEnabledPins() {
+        return new EnabledPins(x, y, z, a, b, c, probe, door, hold, softReset, cycleStart);
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/OverridePercents.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/OverridePercents.java
@@ -1,0 +1,23 @@
+/*
+    Copyright 2013-2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.listeners;
+
+public record OverridePercents(int feed, int rapid, int spindle) {
+    public static final OverridePercents EMTPY_OVERRIDE_PERCENTS = new OverridePercents(100, 100, 100);
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/listeners/OverrideType.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/listeners/OverrideType.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2024 Will Winder
+    Copyright 2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -18,15 +18,23 @@
  */
 package com.willwinder.universalgcodesender.listeners;
 
-/**
- * Overrides given as percents where the value 100 is the normal speed to 100%.
- * The value range is dependant on the controller but can normally be given as a
- * value between 10 - 200 %
- *
- * @param feed the feed speed in percent
- * @param rapid the rapid speed in percent
- * @param spindle  the spindle speed in percent
- */
-public record OverridePercents(int feed, int rapid, int spindle) {
-    public static final OverridePercents EMTPY_OVERRIDE_PERCENTS = new OverridePercents(100, 100, 100);
+import com.willwinder.universalgcodesender.uielements.panels.OverrideLabels;
+
+public enum OverrideType {
+    SPINDLE_SPEED(OverrideLabels.SPINDLE_SHORT),
+    FEED_SPEED(OverrideLabels.FEED_SHORT),
+    MIST_TOGGLE(OverrideLabels.MIST),
+    SPINDLE_TOGGLE(OverrideLabels.SPINDLE_SHORT),
+    FLOOD_TOGGLE(OverrideLabels.FLOOD),
+    RAPID_SPEED(OverrideLabels.RAPID_SHORT);
+
+    private final String label;
+
+    OverrideType(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/BackendAPI.java
@@ -166,10 +166,6 @@ public interface BackendAPI extends BackendAPIReadOnly {
     void issueSoftReset() throws Exception;
     void requestParserState() throws Exception;
 
-    // Programatically call an override.
-    void sendOverrideCommand(Overrides override) throws Exception;
-           
-    // Shouldn't be needed often.
     IController getController();
 
     /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/GUIBackend.java
@@ -794,9 +794,4 @@ public class GUIBackend implements BackendAPI {
             logger.info("Took " + (end - start) + "ms to preprocess");
         }
     }
-
-    @Override
-    public void sendOverrideCommand(Overrides override) throws Exception {
-        this.controller.sendOverrideCommand(override);
-    }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/Overrides.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/Overrides.java
@@ -19,25 +19,32 @@
 package com.willwinder.universalgcodesender.model;
 
 /**
- *
  * @author wwinder
  */
 public enum Overrides {
-    //CMD_DEBUG_REPORT, // 0x85 // Only when DEBUG enabled, sends debug report in '{}' braces.
-    CMD_FEED_OVR_RESET, // 0x90         // Restores feed override value to 100%.
-    CMD_FEED_OVR_COARSE_PLUS, // 0x91
-    CMD_FEED_OVR_COARSE_MINUS, // 0x92
-    CMD_FEED_OVR_FINE_PLUS , // 0x93
-    CMD_FEED_OVR_FINE_MINUS , // 0x94
-    CMD_RAPID_OVR_RESET, // 0x95        // Restores rapid override value to 100%.
-    CMD_RAPID_OVR_MEDIUM, // 0x96
-    CMD_RAPID_OVR_LOW, // 0x97
-    CMD_SPINDLE_OVR_RESET, // 0x99      // Restores spindle override value to 100%.
-    CMD_SPINDLE_OVR_COARSE_PLUS, // 0x9A
-    CMD_SPINDLE_OVR_COARSE_MINUS, // 0x9B
-    CMD_SPINDLE_OVR_FINE_PLUS, // 0x9C
-    CMD_SPINDLE_OVR_FINE_MINUS, // 0x9D
-    CMD_TOGGLE_SPINDLE, // 0x9E
-    CMD_TOGGLE_FLOOD_COOLANT, // 0xA0
-    CMD_TOGGLE_MIST_COOLANT, // 0xA1
+    /**
+     * Restores feed override value to 100%.
+     */
+    CMD_FEED_OVR_RESET,
+    CMD_FEED_OVR_COARSE_PLUS,
+    CMD_FEED_OVR_COARSE_MINUS,
+    CMD_FEED_OVR_FINE_PLUS,
+    CMD_FEED_OVR_FINE_MINUS,
+    /**
+     * Restores rapid override value to 100%.
+     */
+    CMD_RAPID_OVR_RESET,
+    CMD_RAPID_OVR_MEDIUM,
+    CMD_RAPID_OVR_LOW,
+    /**
+     * Restores spindle override value to 100%.
+     */
+    CMD_SPINDLE_OVR_RESET,
+    CMD_SPINDLE_OVR_COARSE_PLUS,
+    CMD_SPINDLE_OVR_COARSE_MINUS,
+    CMD_SPINDLE_OVR_FINE_PLUS,
+    CMD_SPINDLE_OVR_FINE_MINUS,
+    CMD_TOGGLE_SPINDLE,
+    CMD_TOGGLE_FLOOD_COOLANT,
+    CMD_TOGGLE_MIST_COOLANT;
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/model/UGSEventDispatcher.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/UGSEventDispatcher.java
@@ -57,7 +57,7 @@ public class UGSEventDispatcher implements ControllerListener, IFirmwareSettings
     /**
      * A cached instance of the controller status for preventing duplicate status events to be dispatched
      */
-    private ControllerStatus controllerStatus = new ControllerStatus();
+    private ControllerStatus controllerStatus = ControllerStatus.EMPTY_CONTROLLER_STATUS;
 
     public void sendUGSEvent(UGSEvent event) {
         LOGGER.log(Level.FINEST, "Sending event {0}.", event.getClass().getSimpleName());
@@ -73,14 +73,14 @@ public class UGSEventDispatcher implements ControllerListener, IFirmwareSettings
 
     public void addListener(UGSEventListener listener) {
         if (!listeners.contains(listener)) {
-            LOGGER.log(Level.INFO, "Adding UGSEvent listener: {0}", listener.getClass().getSimpleName());
+            LOGGER.log(Level.FINE, "Adding UGSEvent listener: {0}", listener.getClass().getSimpleName());
             listeners.add(listener);
         }
     }
 
     public void removeListener(UGSEventListener listener) {
         if (listeners.contains(listener)) {
-            LOGGER.log(Level.INFO, "Removing UGSEvent listener: {0}", listener.getClass().getSimpleName());
+            LOGGER.log(Level.FINE, "Removing UGSEvent listener: {0}", listener.getClass().getSimpleName());
             listeners.remove(listener);
         }
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverrideLabels.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverrideLabels.java
@@ -1,0 +1,40 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.uielements.panels;
+
+import com.willwinder.universalgcodesender.i18n.Localization;
+
+public class OverrideLabels {
+    public static final String FEED_SHORT = Localization.getString("overrides.feed.short");
+    public static final String SPINDLE_SHORT = Localization.getString("overrides.spindle.short");
+    public static final String RAPID_SHORT = Localization.getString("overrides.rapid.short");
+    public static final String TOGGLE_SHORT = Localization.getString("overrides.toggle.short");
+    public static final String RESET_SPINDLE = Localization.getString("overrides.spindle.reset");
+    public static final String RESET_FEED = Localization.getString("overrides.feed.reset");
+    public static final String MINUS_COARSE = "--";
+    public static final String MINUS_FINE = "-";
+    public static final String PLUS_COARSE = "++";
+    public static final String PLUS_FINE = "+";
+    public static final String RAPID_LOW = Localization.getString("overrides.rapid.low");
+    public static final String RAPID_MEDIUM = Localization.getString("overrides.rapid.medium");
+    public static final String RAPID_FULL = Localization.getString("overrides.rapid.full");
+    public static final String MIST = Localization.getString("overrides.mist");
+    public static final String FLOOD = Localization.getString("overrides.flood");
+    public static final String NOT_SUPPORTED = Localization.getString("overrides.not.supported");
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverridesPanel.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/panels/OverridesPanel.java
@@ -18,23 +18,32 @@
  */
 package com.willwinder.universalgcodesender.uielements.panels;
 
-import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.listeners.ControllerStatus.AccessoryStates;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
-import com.willwinder.universalgcodesender.model.Overrides;
 import com.willwinder.universalgcodesender.model.UGSEvent;
 import com.willwinder.universalgcodesender.model.events.ControllerStateEvent;
 import com.willwinder.universalgcodesender.model.events.ControllerStatusEvent;
+import static com.willwinder.universalgcodesender.uielements.panels.OverrideLabels.TOGGLE_SHORT;
+import com.willwinder.universalgcodesender.utils.ThreadHelper;
 import net.miginfocom.swing.MigLayout;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSlider;
+import javax.swing.JToggleButton;
+import javax.swing.SwingConstants;
 import java.awt.event.ActionEvent;
-import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Send speed override commands to the backend.
@@ -42,47 +51,14 @@ import java.util.logging.Logger;
  * @author wwinder
  */
 public final class OverridesPanel extends JPanel implements UGSEventListener {
-    private final BackendAPI backend;
-    private final ArrayList<Component> components = new ArrayList<>();
+    private final transient BackendAPI backend;
+    private final JPanel overridesControlsPanel = new JPanel(new MigLayout("fillx"));
+    private final JLabel notConnectedLabel = new JLabel("Not connected", SwingConstants.CENTER);
+    private final JLabel notSupportedLabel = new JLabel("<html>" + OverrideLabels.NOT_SUPPORTED + "</html>", SwingConstants.CENTER);
+    private final Map<OverrideType, JSlider> speedSliders = new ConcurrentHashMap<>();
+    private final Map<OverrideType, JToggleButton> toggleButtons = new ConcurrentHashMap<>();
 
-    private final JLabel feedSpeed = new JLabel("100%");
-    private final JRadioButton feedRadio = new JRadioButton(FEED_SHORT);
-
-    private final JLabel spindleSpeed = new JLabel("100%");
-    private final JRadioButton spindleRadio = new JRadioButton(SPINDLE_SHORT);
-
-    private final JLabel rapidSpeed = new JLabel("100%");
-    private final JRadioButton rapidRadio = new JRadioButton(RAPID_SHORT);
-
-    private final JButton adjust1 = new JButton("");
-    private final JButton adjust2 = new JButton("");
-    private final JButton adjust3 = new JButton("");
-    private final JButton adjust4 = new JButton("");
-    private final JButton adjust5 = new JButton("");
-
-    private final JButton toggleSpindle = new JButton(SPINDLE_SHORT);
-    private final JButton toggleFloodCoolant = new JButton(FLOOD);
-    private final JButton toggleMistCoolant = new JButton(MIST);
-
-    private final ArrayList<RealTimeAction> rapidActions = new ArrayList<>();
-    private final ArrayList<RealTimeAction> spindleActions = new ArrayList<>();
-    private final ArrayList<RealTimeAction> feedActions = new ArrayList<>();
-
-    public static final String FEED_SHORT = Localization.getString("overrides.feed.short");
-    public static final String SPINDLE_SHORT = Localization.getString("overrides.spindle.short");
-    public static final String RAPID_SHORT = Localization.getString("overrides.rapid.short");
-    public static final String TOGGLE_SHORT = Localization.getString("overrides.toggle.short");
-    public static final String RESET_SPINDLE = Localization.getString("overrides.spindle.reset");
-    public static final String RESET_FEED = Localization.getString("overrides.feed.reset");
-    public static final String MINUS_COARSE = "--";
-    public static final String MINUS_FINE = "-";
-    public static final String PLUS_COARSE = "++";
-    public static final String PLUS_FINE = "+";
-    public static final String RAPID_LOW = Localization.getString("overrides.rapid.low");
-    public static final String RAPID_MEDIUM = Localization.getString("overrides.rapid.medium");
-    public static final String RAPID_FULL = Localization.getString("overrides.rapid.full");
-    public static final String MIST = Localization.getString("overrides.mist");
-    public static final String FLOOD = Localization.getString("overrides.flood");
+    private boolean overridesPanelInitiated = false;
 
     public OverridesPanel(BackendAPI backend) {
         this.backend = backend;
@@ -90,194 +66,123 @@ public final class OverridesPanel extends JPanel implements UGSEventListener {
             backend.addUGSEventListener(this);
         }
 
-        initComponents();
+        setLayout(new MigLayout("fillx, hidemode 3"));
+        add(overridesControlsPanel, "grow");
+        add(notConnectedLabel, "spanx, growx, gaptop 16, wrap");
+        add(notSupportedLabel, "spanx, growx, gaptop 16, wrap");
         updateControls();
     }
 
     public void updateControls() {
-        boolean enabled = backend.isConnected() &&
-                backend.getController().getCapabilities().hasOverrides();
-
-        this.setEnabled(enabled);
-        for (Component c : components) { 
-            c.setEnabled(enabled);
+        if (backend.getControllerState() == ControllerState.DISCONNECTED || backend.getControllerState() == ControllerState.CONNECTING) {
+            removeComponents();
+            return;
+        } else if (!backend.getController().getCapabilities().hasOverrides() || (backend.getController().getOverrideManager().getSpeedTypes().isEmpty() && backend.getController().getOverrideManager().getToggleTypes().isEmpty())) {
+            showNotSupportedPanel();
+            return;
+        } else if (!overridesPanelInitiated) {
+            initAndShowOverridesPanel();
         }
 
-        if (enabled) {
-            radioSelected();
-        } else {
-            toggleSpindle.setBackground(null);
-            toggleMistCoolant.setBackground(null);
-            toggleFloodCoolant.setBackground(null);
-        }
+        setEnabled(backend.getController().getOverrideManager().isAvailable());
+    }
+
+    private void showNotSupportedPanel() {
+        notSupportedLabel.setVisible(true);
+        notConnectedLabel.setVisible(false);
+        overridesControlsPanel.setVisible(false);
+        revalidate();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        Arrays.stream(getComponents()).forEach(c -> c.setEnabled(enabled));
     }
 
     @Override
     public void UGSEvent(UGSEvent evt) {
         if (evt instanceof ControllerStateEvent) {
             updateControls();
-        } else if (evt instanceof ControllerStatusEvent) {
-            ControllerStatus status = ((ControllerStatusEvent) evt).getStatus();
+        } else if (evt instanceof ControllerStatusEvent controllerStatusEvent) {
+            ControllerStatus status = controllerStatusEvent.getStatus();
             if (status.getOverrides() != null) {
-                this.feedSpeed.setText(status.getOverrides().feed + "%");
-                this.spindleSpeed.setText(status.getOverrides().spindle + "%");
-                this.rapidSpeed.setText(status.getOverrides().rapid + "%");
-            }
-            if (status.getAccessoryStates() != null) {
-                AccessoryStates states = status.getAccessoryStates();
-
-                toggleSpindle.setBackground((states.SpindleCW || states.SpindleCCW) ? Color.GREEN : Color.RED);
-                toggleFloodCoolant.setBackground(states.Flood ? Color.GREEN : Color.RED);
-                toggleMistCoolant.setBackground(states.Mist ? Color.GREEN : Color.RED);
-
-                toggleSpindle.setOpaque(true);
-                toggleFloodCoolant.setOpaque(true);
-                toggleMistCoolant.setOpaque(true);
+                speedSliders.keySet().forEach(type -> speedSliders.get(type).setValue(backend.getController().getOverrideManager().getSpeedTargetValue(type)));
+                toggleButtons.keySet().forEach(type -> toggleButtons.get(type).setSelected(backend.getController().getOverrideManager().isToggled(type)));
             }
         }
     }
 
-    public void add(Component comp, String str) {
-        super.add(comp, str);
-        if (comp instanceof JButton || comp instanceof JRadioButton)
-            components.add(comp);
+    private void removeComponents() {
+        overridesControlsPanel.removeAll();
+        speedSliders.clear();
+        toggleButtons.clear();
+        overridesControlsPanel.setVisible(false);
+        notConnectedLabel.setVisible(true);
+        notSupportedLabel.setVisible(false);
+        overridesPanelInitiated = false;
+        revalidate();
     }
 
-    public Component add(Component comp) {
-        Component ret = super.add(comp);
-        if (comp instanceof JButton || comp instanceof JRadioButton)
-            components.add(comp);
-        return ret;
-    }
+    private void initAndShowOverridesPanel() {
+        overridesPanelInitiated = true;
+        overridesControlsPanel.setVisible(true);
+        notSupportedLabel.setVisible(false);
+        notConnectedLabel.setVisible(false);
 
-    private void radioSelected() {
-        if (rapidRadio.isSelected()) {
-            adjust2.setEnabled(false);
-            adjust5.setEnabled(false);
-
-            adjust1.setText(RAPID_LOW);
-            adjust2.setText("");
-            adjust3.setText(RAPID_MEDIUM);
-            adjust4.setText(RAPID_FULL);
-            adjust5.setText("");
-
-            adjust1.setAction(rapidActions.get(0));
-            adjust3.setAction(rapidActions.get(1));
-            adjust4.setAction(rapidActions.get(2));
-        } else {
-            adjust2.setEnabled(true);
-            adjust5.setEnabled(true);
-
-            adjust1.setText(MINUS_COARSE);
-            adjust2.setText(MINUS_FINE);
-            adjust4.setText(PLUS_FINE);
-            adjust5.setText(PLUS_COARSE);
-
-            ArrayList<RealTimeAction> actions = null;
-            if (feedRadio.isSelected()) {
-                adjust3.setText(RESET_FEED);
-                actions = feedActions;
-            } else if (spindleRadio.isSelected()) {
-                adjust3.setText(RESET_SPINDLE);
-                actions = spindleActions;
-            }
-
-            if (actions != null) {
-                adjust1.setAction(actions.get(0));
-                adjust2.setAction(actions.get(1));
-                adjust3.setAction(actions.get(2));
-                adjust4.setAction(actions.get(3));
-                adjust5.setAction(actions.get(4));
-            }
-        }
-    }
-
-    private void initComponents() {
-        rapidActions.add(new RealTimeAction(RAPID_LOW, Overrides.CMD_RAPID_OVR_LOW, backend));
-        rapidActions.add(new RealTimeAction(RAPID_MEDIUM, Overrides.CMD_RAPID_OVR_MEDIUM, backend));
-        rapidActions.add(new RealTimeAction(RAPID_FULL, Overrides.CMD_RAPID_OVR_RESET, backend));
-
-        spindleActions.add(new RealTimeAction(MINUS_COARSE, Overrides.CMD_SPINDLE_OVR_COARSE_MINUS, backend));
-        spindleActions.add(new RealTimeAction(MINUS_FINE, Overrides.CMD_SPINDLE_OVR_FINE_MINUS, backend));
-        spindleActions.add(new RealTimeAction(RESET_SPINDLE, Overrides.CMD_SPINDLE_OVR_RESET, backend));
-        spindleActions.add(new RealTimeAction(PLUS_FINE, Overrides.CMD_SPINDLE_OVR_FINE_PLUS, backend));
-        spindleActions.add(new RealTimeAction(PLUS_COARSE, Overrides.CMD_SPINDLE_OVR_COARSE_PLUS, backend));
-
-        feedActions.add(new RealTimeAction(MINUS_COARSE, Overrides.CMD_FEED_OVR_COARSE_MINUS, backend));
-        feedActions.add(new RealTimeAction(MINUS_FINE, Overrides.CMD_FEED_OVR_FINE_MINUS, backend));
-        feedActions.add(new RealTimeAction(RESET_FEED, Overrides.CMD_FEED_OVR_RESET, backend));
-        feedActions.add(new RealTimeAction(PLUS_FINE, Overrides.CMD_FEED_OVR_FINE_PLUS, backend));
-        feedActions.add(new RealTimeAction(PLUS_COARSE, Overrides.CMD_FEED_OVR_COARSE_PLUS, backend));
-
-        adjust1.setEnabled(false);
-        adjust2.setEnabled(false);
-        adjust3.setEnabled(false);
-        adjust4.setEnabled(false);
-        adjust5.setEnabled(false);
-
-        ButtonGroup group = new ButtonGroup();
-        group.add(feedRadio);
-        group.add(spindleRadio);
-        group.add(rapidRadio);
-
-        // Initialize callbacks
-        // Radio buttons
-        feedRadio.addActionListener((ActionEvent ae) -> radioSelected());
-        spindleRadio.addActionListener((ActionEvent ae) -> radioSelected());
-        rapidRadio.addActionListener((ActionEvent ae) -> radioSelected());
-        // Toggle actions
-        toggleSpindle.setAction(new RealTimeAction("spindle", Overrides.CMD_TOGGLE_SPINDLE, backend));
-        toggleSpindle.setBackground(Color.RED);
-        toggleFloodCoolant.setAction(new RealTimeAction("flood", Overrides.CMD_TOGGLE_FLOOD_COOLANT, backend));
-        toggleFloodCoolant.setBackground(Color.RED);
-        toggleMistCoolant.setAction(new RealTimeAction("mist", Overrides.CMD_TOGGLE_MIST_COOLANT, backend));
-        toggleMistCoolant.setBackground(Color.RED);
-
-        // Layout components
-        this.setLayout(new MigLayout("wrap 4"));
-
-        this.add(feedRadio);
-        this.add(spindleRadio);
-        this.add(rapidRadio, "wrap");
-
-        this.add(new JLabel(FEED_SHORT + ":"));
-        this.add(feedSpeed);
-        this.add(adjust1);
-        this.add(adjust2);
-
-        this.add(new JLabel(SPINDLE_SHORT + ":"));
-        this.add(spindleSpeed);
-        this.add(adjust3, "span 2");
-
-        this.add(new JLabel("Rapid:"));
-        this.add(rapidSpeed);
-        this.add(adjust4);
-        this.add(adjust5, "wrap");
-
-        this.add(new JLabel(TOGGLE_SHORT + ":"));
-        this.add(toggleSpindle);
-        this.add(toggleFloodCoolant);
-        this.add(toggleMistCoolant);
-    }
-
-    private static class RealTimeAction extends AbstractAction {
-        private final Overrides command;
-        private final BackendAPI backend;
-        public RealTimeAction(String name, Overrides override, BackendAPI backend) {
-            this.putValue(Action.NAME, name);
-            this.command = override;
-            this.backend = backend;
+        overridesControlsPanel.removeAll();
+        IOverrideManager overrideManager = backend.getController().getOverrideManager();
+        if (!overrideManager.getToggleTypes().isEmpty()) {
+            overridesControlsPanel.add(new JLabel(TOGGLE_SHORT), "spanx, grow, wrap, gaptop 10");
+            overrideManager.getToggleTypes().forEach(this::createAndAddToggleButtons);
         }
 
-        @Override
-        public void actionPerformed(ActionEvent e) {
-            if (isEnabled()) {
-                try {
-                    backend.sendOverrideCommand(command);
-                } catch (Exception ex) {
-                    Logger.getLogger(OverridesPanel.class.getName()).log(Level.SEVERE, null, ex);
-                }
+        overrideManager.getSpeedTypes().forEach(this::createAndAddSpeedSlider);
+        revalidate();
+    }
+
+    private void createAndAddToggleButtons(OverrideType overrideType) {
+        IOverrideManager overrideManager = backend.getController().getOverrideManager();
+        JToggleButton toggleSpindle = new JToggleButton(overrideType.name());
+        toggleSpindle.setAction(new AbstractAction(overrideType.getLabel()) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                overrideManager.toggle(overrideType);
+                toggleSpindle.setSelected(!overrideManager.isToggled(overrideType));
+                ThreadHelper.invokeLater(() -> toggleSpindle.setSelected(overrideManager.isToggled(overrideType)), 200);
             }
+        });
+        overridesControlsPanel.add(toggleSpindle, "growx");
+        toggleButtons.put(overrideType, toggleSpindle);
+    }
+
+    private void createAndAddSpeedSlider(OverrideType type) {
+        IOverrideManager overrideManager = backend.getController().getOverrideManager();
+
+        JSlider speedSlider = new JSlider(0, overrideManager.getSpeedMax(type), overrideManager.getSpeedDefault(type));
+        speedSlider.setMinorTickSpacing(0);
+        speedSlider.setMajorTickSpacing(10);
+        speedSliders.put(type, speedSlider);
+
+        Dictionary<Integer, JComponent> dict = new Hashtable<>();
+        for (int i = 0; i <= overrideManager.getSpeedMax(type); i += 100) {
+            dict.put(i, new JLabel(i + "%"));
         }
+
+        speedSlider.setLabelTable(dict);
+        speedSlider.setPaintLabels(true);
+        speedSlider.setPaintTicks(true);
+        speedSlider.setPaintTrack(true);
+        speedSlider.addChangeListener(l -> updateSpeed(type, speedSlider));
+        overridesControlsPanel.add(new JLabel(type.getLabel()), "spanx, grow, newline, wrap, gaptop 10");
+        overridesControlsPanel.add(speedSlider, "spanx, grow, wrap");
+    }
+
+    private void updateSpeed(OverrideType type, JSlider slider) {
+        if (backend.getController() == null || !backend.isConnected()) {
+            return;
+        }
+
+        backend.getController().getOverrideManager().setSpeedTarget(type, slider.getValue());
     }
 }

--- a/ugs-core/src/resources/MessagesBundle_en_US.properties
+++ b/ugs-core/src/resources/MessagesBundle_en_US.properties
@@ -457,6 +457,7 @@ overrides.rapid.full = Full
 overrides.mist = Mist Coolant
 overrides.flood = Flood Coolant
 overrides.toggle.short = Toggle
+overrides.not.supported = Overrides are not supported for this controller
 restart = Restart is needed
 platform.window.restart.changed.settings = <html><a href\="\#">Click here to restart the platform and apply your settings.
 mainWindow.ui.connect = Connect
@@ -702,6 +703,8 @@ platform.plugin.joystick.paddle3 = Paddle 3
 platform.plugin.joystick.paddle4 = Paddle 4
 platform.plugin.joystick.touchpad = Touchpad
 platform.plugin.joystick.action.continuousJogging = Analog jog
+platform.plugin.joystick.action.analogFeed = Analog feed override
+platform.plugin.joystick.action.analogSpindle = Analog spindle override
 platform.plugin.joystick.reverseAxis = Reverse
 platform.plugin.joystick.axisThreshold = Zero threshold (%)
 platform.plugin.cloud.s3Id = AWS Access Key ID

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2013-2023 Will Winder
+    Copyright 2013-2024 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -341,15 +341,15 @@ public class GrblUtilsTest {
 
         String status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0>";
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusStringV1(null, status, MM);
-        assertFalse(controllerStatus.getEnabledPins().CycleStart);
+        assertFalse(controllerStatus.getEnabledPins().cycleStart());
 
         status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0|Pn:S>";
         controllerStatus = GrblUtils.getStatusFromStatusStringV1(null, status, MM);
-        assertTrue(controllerStatus.getEnabledPins().CycleStart);
+        assertTrue(controllerStatus.getEnabledPins().cycleStart());
 
         status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0>";
         controllerStatus = GrblUtils.getStatusFromStatusStringV1(controllerStatus, status, MM);
-        assertFalse(controllerStatus.getEnabledPins().CycleStart);
+        assertFalse(controllerStatus.getEnabledPins().cycleStart());
     }
 
     @Test
@@ -359,23 +359,23 @@ public class GrblUtilsTest {
 
         String status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0>";
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusStringV1(null, status, MM);
-        assertFalse(controllerStatus.getAccessoryStates().Flood);
+        assertFalse(controllerStatus.getAccessoryStates().flood());
 
         status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0|Ov:100,100,100|A:F>";
         controllerStatus = GrblUtils.getStatusFromStatusStringV1(controllerStatus, status, MM);
-        assertTrue(controllerStatus.getAccessoryStates().Flood);
+        assertTrue(controllerStatus.getAccessoryStates().flood());
 
         status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0>";
         controllerStatus = GrblUtils.getStatusFromStatusStringV1(controllerStatus, status, MM);
-        assertTrue("The accessory states should be retained even if it isn't included in the report", controllerStatus.getAccessoryStates().Flood);
+        assertTrue("The accessory states should be retained even if it isn't included in the report", controllerStatus.getAccessoryStates().flood());
 
         status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0|Ov:100,100,100>";
         controllerStatus = GrblUtils.getStatusFromStatusStringV1(controllerStatus, status, MM);
-        assertFalse("The accessory states should be set to disabled if not included in overrides report", controllerStatus.getAccessoryStates().Flood);
+        assertFalse("The accessory states should be set to disabled if not included in overrides report", controllerStatus.getAccessoryStates().flood());
 
         status = "<Idle|MPos:0.000,0.000,0.000|FS:0,0|A:F>";
         controllerStatus = GrblUtils.getStatusFromStatusStringV1(controllerStatus, status, MM);
-        assertTrue("The accessory state should be set even if not a overrides report", controllerStatus.getAccessoryStates().Flood);
+        assertTrue("The accessory state should be set even if not a overrides report", controllerStatus.getAccessoryStates().flood());
     }
 
     @Test
@@ -502,26 +502,25 @@ public class GrblUtilsTest {
         assertEquals(new Position(4.4, 5.5, 6.6, MM), controllerStatus.getWorkCoord());
         assertEquals(new Position(7.7, 8.8, 9.9, MM), controllerStatus.getWorkCoordinateOffset());
 
-        assertEquals(1, controllerStatus.getOverrides().feed);
-        assertEquals(2, controllerStatus.getOverrides().rapid);
-        assertEquals(3, controllerStatus.getOverrides().spindle);
+        assertEquals(1, controllerStatus.getOverrides().feed());
+        assertEquals(2, controllerStatus.getOverrides().rapid());
+        assertEquals(3, controllerStatus.getOverrides().spindle());
 
         assertEquals(Double.valueOf(12345.7), controllerStatus.getFeedSpeed());
         assertEquals(Double.valueOf(65432.1), controllerStatus.getSpindleSpeed());
 
-        assertTrue(controllerStatus.getEnabledPins().CycleStart);
-        assertTrue(controllerStatus.getEnabledPins().Door);
-        assertTrue(controllerStatus.getEnabledPins().Hold);
-        assertTrue(controllerStatus.getEnabledPins().SoftReset);
-        assertTrue(controllerStatus.getEnabledPins().Probe);
-        assertTrue(controllerStatus.getEnabledPins().X);
-        assertTrue(controllerStatus.getEnabledPins().Y);
-        assertTrue(controllerStatus.getEnabledPins().Z);
+        assertTrue(controllerStatus.getEnabledPins().cycleStart());
+        assertTrue(controllerStatus.getEnabledPins().door());
+        assertTrue(controllerStatus.getEnabledPins().hold());
+        assertTrue(controllerStatus.getEnabledPins().softReset());
+        assertTrue(controllerStatus.getEnabledPins().probe());
+        assertTrue(controllerStatus.getEnabledPins().x());
+        assertTrue(controllerStatus.getEnabledPins().y());
+        assertTrue(controllerStatus.getEnabledPins().z());
 
-        assertTrue(controllerStatus.getAccessoryStates().Flood);
-        assertTrue(controllerStatus.getAccessoryStates().Mist);
-        assertTrue(controllerStatus.getAccessoryStates().SpindleCCW);
-        assertTrue(controllerStatus.getAccessoryStates().SpindleCW);
+        assertTrue(controllerStatus.getAccessoryStates().flood());
+        assertTrue(controllerStatus.getAccessoryStates().mist());
+        assertTrue(controllerStatus.getAccessoryStates().spindleCW());
     }
 
     @Test
@@ -605,14 +604,14 @@ public class GrblUtilsTest {
 
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
-        assertFalse(controllerStatus.getEnabledPins().CycleStart);
-        assertFalse(controllerStatus.getEnabledPins().Door);
-        assertFalse(controllerStatus.getEnabledPins().Hold);
-        assertFalse(controllerStatus.getEnabledPins().SoftReset);
-        assertFalse(controllerStatus.getEnabledPins().Probe);
-        assertFalse(controllerStatus.getEnabledPins().X);
-        assertFalse(controllerStatus.getEnabledPins().Y);
-        assertFalse(controllerStatus.getEnabledPins().Z);
+        assertFalse(controllerStatus.getEnabledPins().cycleStart());
+        assertFalse(controllerStatus.getEnabledPins().door());
+        assertFalse(controllerStatus.getEnabledPins().hold());
+        assertFalse(controllerStatus.getEnabledPins().softReset());
+        assertFalse(controllerStatus.getEnabledPins().probe());
+        assertFalse(controllerStatus.getEnabledPins().x());
+        assertFalse(controllerStatus.getEnabledPins().y());
+        assertFalse(controllerStatus.getEnabledPins().z());
     }
 
     @Test
@@ -623,10 +622,9 @@ public class GrblUtilsTest {
 
         ControllerStatus controllerStatus = GrblUtils.getStatusFromStatusString(null, status, version, MM);
 
-        assertFalse(controllerStatus.getAccessoryStates().Flood);
-        assertFalse(controllerStatus.getAccessoryStates().Mist);
-        assertFalse(controllerStatus.getAccessoryStates().SpindleCCW);
-        assertFalse(controllerStatus.getAccessoryStates().SpindleCW);
+        assertFalse(controllerStatus.getAccessoryStates().flood());
+        assertFalse(controllerStatus.getAccessoryStates().mist());
+        assertTrue(controllerStatus.getAccessoryStates().spindleCW());
     }
 
     @Test
@@ -638,10 +636,9 @@ public class GrblUtilsTest {
 
         assertEquals(ControllerState.IDLE, controllerStatus.getState());
         assertNotNull(controllerStatus.getAccessoryStates());
-        assertFalse(controllerStatus.getAccessoryStates().Flood);
-        assertFalse(controllerStatus.getAccessoryStates().Mist);
-        assertFalse(controllerStatus.getAccessoryStates().SpindleCCW);
-        assertFalse(controllerStatus.getAccessoryStates().SpindleCW);
+        assertFalse(controllerStatus.getAccessoryStates().flood());
+        assertFalse(controllerStatus.getAccessoryStates().mist());
+        assertFalse(controllerStatus.getAccessoryStates().spindleCW());
     }
 
     @Test
@@ -658,9 +655,9 @@ public class GrblUtilsTest {
         assertEquals(new Position(7.7, 8.8, 9.9, 10.10, 11.11, 12.12, MM), controllerStatus.getWorkCoord());
         assertEquals(new Position(13.13, 14.14, 15.15, 16.16, 17.17, 18.18, MM), controllerStatus.getWorkCoordinateOffset());
 
-        assertTrue(controllerStatus.getEnabledPins().A);
-        assertTrue(controllerStatus.getEnabledPins().B);
-        assertTrue(controllerStatus.getEnabledPins().C);
+        assertTrue(controllerStatus.getEnabledPins().a());
+        assertTrue(controllerStatus.getEnabledPins().b());
+        assertTrue(controllerStatus.getEnabledPins().c());
     }
 
     @Test
@@ -676,9 +673,9 @@ public class GrblUtilsTest {
         assertEquals(new Position(1.1, 2.2, 3.3, 4.4, 5.5, Double.NaN, MM), controllerStatus.getMachineCoord());
         assertEquals(new Position(7.7, 8.8, 9.9, 10.10, 11.11, Double.NaN, MM), controllerStatus.getWorkCoord());
         assertEquals(new Position(13.13, 14.14, 15.15, 16.16, 17.17, Double.NaN, MM), controllerStatus.getWorkCoordinateOffset());
-        assertTrue(controllerStatus.getEnabledPins().A);
-        assertTrue(controllerStatus.getEnabledPins().B);
-        assertFalse(controllerStatus.getEnabledPins().C);
+        assertTrue(controllerStatus.getEnabledPins().a());
+        assertTrue(controllerStatus.getEnabledPins().b());
+        assertFalse(controllerStatus.getEnabledPins().c());
     }
 
     @Test
@@ -695,9 +692,9 @@ public class GrblUtilsTest {
         assertEquals(new Position(7.7, 8.8, 9.9, 10.10, Double.NaN, Double.NaN, MM), controllerStatus.getWorkCoord());
         assertEquals(new Position(13.13, 14.14, 15.15, 16.16, Double.NaN, Double.NaN, MM), controllerStatus.getWorkCoordinateOffset());
 
-        assertTrue(controllerStatus.getEnabledPins().A);
-        assertFalse(controllerStatus.getEnabledPins().B);
-        assertFalse(controllerStatus.getEnabledPins().C);
+        assertTrue(controllerStatus.getEnabledPins().a());
+        assertFalse(controllerStatus.getEnabledPins().b());
+        assertFalse(controllerStatus.getEnabledPins().c());
     }
 
     @Test

--- a/ugs-core/test/com/willwinder/universalgcodesender/TinyGUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/TinyGUtilsTest.java
@@ -24,15 +24,19 @@ import com.willwinder.universalgcodesender.gcode.GcodeState;
 import com.willwinder.universalgcodesender.gcode.util.Code;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.ControllerStatus;
-import com.willwinder.universalgcodesender.model.*;
+import com.willwinder.universalgcodesender.listeners.OverridePercents;
+import com.willwinder.universalgcodesender.model.Axis;
+import com.willwinder.universalgcodesender.model.Overrides;
+import com.willwinder.universalgcodesender.model.PartialPosition;
+import com.willwinder.universalgcodesender.model.Position;
+import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.types.GcodeCommand;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Optional;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the TinyGUtils class
@@ -204,7 +208,7 @@ public class TinyGUtilsTest {
 
     @Test
     public void createOverrideCommandForFeedOverride() {
-        ControllerStatus.OverridePercents overridePercents = new ControllerStatus.OverridePercents(100, 150, 175);
+        OverridePercents overridePercents = new OverridePercents(100, 150, 175);
         Optional<GcodeCommand> overrideCommand = TinyGUtils.createOverrideCommand(new DefaultCommandCreator(), overridePercents, Overrides.CMD_FEED_OVR_COARSE_PLUS);
         assertEquals("{mfo:1.1}", overrideCommand.get().getCommandString());
 
@@ -220,7 +224,7 @@ public class TinyGUtilsTest {
 
     @Test
     public void createOverrideCommandForSpindleOverride() {
-        ControllerStatus.OverridePercents overridePercents = new ControllerStatus.OverridePercents(150, 175, 100);
+        OverridePercents overridePercents = new OverridePercents(150, 175, 100);
         Optional<GcodeCommand> overrideCommand = TinyGUtils.createOverrideCommand(new DefaultCommandCreator(), overridePercents, Overrides.CMD_SPINDLE_OVR_COARSE_PLUS);
         assertEquals("{sso:1.1}", overrideCommand.get().getCommandString());
 
@@ -240,11 +244,11 @@ public class TinyGUtilsTest {
 
         JsonObject response = TinyGUtils.jsonToObject("{sr:{mfo:1.4}}");
         ControllerStatus controllerStatus = TinyGUtils.updateControllerStatus(lastControllerStatus, response);
-        assertEquals(140, controllerStatus.getOverrides().feed);
+        assertEquals(140, controllerStatus.getOverrides().feed());
 
         response = TinyGUtils.jsonToObject("{sr:{mfo:0.8}}");
         controllerStatus = TinyGUtils.updateControllerStatus(lastControllerStatus, response);
-        assertEquals(80, controllerStatus.getOverrides().feed);
+        assertEquals(80, controllerStatus.getOverrides().feed());
     }
 
     @Test
@@ -253,10 +257,10 @@ public class TinyGUtilsTest {
 
         JsonObject response = TinyGUtils.jsonToObject("{sr:{sso:1.4}}");
         ControllerStatus controllerStatus = TinyGUtils.updateControllerStatus(lastControllerStatus, response);
-        assertEquals(140, controllerStatus.getOverrides().spindle);
+        assertEquals(140, controllerStatus.getOverrides().spindle());
 
         response = TinyGUtils.jsonToObject("{sr:{sso:0.8}}");
         controllerStatus = TinyGUtils.updateControllerStatus(lastControllerStatus, response);
-        assertEquals(80, controllerStatus.getOverrides().spindle);
+        assertEquals(80, controllerStatus.getOverrides().spindle());
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/UtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/UtilsTest.java
@@ -86,4 +86,34 @@ public class UtilsTest {
         fail("The test case is a prototype.");
         */
     }
+
+    @Test
+    public void roundToNearestStepValueWithOnePercentIncrements() {
+        assertEquals("Should round to lowest value", 0.01f, Utils.roundToNearestStepValue(0.001f, 0.01f, 2.00f, 0.01f), 0.0001f);
+        assertEquals(0.01f, Utils.roundToNearestStepValue(0.014f, 0.01f, 2.00f, 0.01f), 0.0001f);
+        assertEquals(0.02f, Utils.roundToNearestStepValue(0.015f, 0.01f, 2.00f, 0.01f), 0.0001f);
+        assertEquals(1.00f, Utils.roundToNearestStepValue(1.001f, 0.01f, 2.00f, 0.01f), 0.0001f);
+        assertEquals(2.00f, Utils.roundToNearestStepValue(2.001f, 0.01f, 2.00f, 0.01f), 0.0001f);
+        assertEquals(2.00f, Utils.roundToNearestStepValue(1.995f, 0.01f, 2.00f, 0.01f), 0.0001f);
+    }
+
+    @Test
+    public void roundToNearestStepValueWithOnePercentIncrementsAsIntegerValues() {
+        assertEquals("Should round to lowest value", 1, Utils.roundToNearestStepValue(0.1, 1, 200, 1), 0.01);
+        assertEquals(1d, Utils.roundToNearestStepValue(1.4, 1, 200, 1), 0.01);
+        assertEquals(2d, Utils.roundToNearestStepValue(1.5, 1, 200, 1), 0.01);
+        assertEquals(100d, Utils.roundToNearestStepValue(100.1, 1, 200, 1), 0.01);
+        assertEquals(200d, Utils.roundToNearestStepValue(200.1, 1, 200, 1), 0.01);
+        assertEquals(200d, Utils.roundToNearestStepValue(199.5, 1, 200, 1), 0.01);
+    }
+
+    @Test
+    public void roundToNearestStepValueWith25PercentIncrements() {
+        assertEquals(0.25f, Utils.roundToNearestStepValue(0.001f, 0.25f, 1.00f, 0.25f), 0.0001f);
+        assertEquals(0.25f, Utils.roundToNearestStepValue(0.24f, 0.25f, 1.00f, 0.25f), 0.0001f);
+        assertEquals(0.25f, Utils.roundToNearestStepValue(0.30f, 0.25f, 1.00f, 0.25f), 0.0001f);
+        assertEquals(0.50f, Utils.roundToNearestStepValue(0.375f, 0.25f, 1.00f, 0.25f), 0.0001f);
+        assertEquals(0.75f, Utils.roundToNearestStepValue(0.76f, 0.25f, 1.00f, 0.25f), 0.0001f);
+        assertEquals(1f, Utils.roundToNearestStepValue(2f, 0.25f, 1.00f, 0.25f), 0.0001f);
+    }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/GrblOverrideManagerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/grbl/GrblOverrideManagerTest.java
@@ -1,0 +1,165 @@
+package com.willwinder.universalgcodesender.firmware.grbl;
+
+import com.willwinder.universalgcodesender.Capabilities;
+import com.willwinder.universalgcodesender.CapabilitiesConstants;
+import com.willwinder.universalgcodesender.IController;
+import com.willwinder.universalgcodesender.communicator.ICommunicator;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
+import com.willwinder.universalgcodesender.listeners.ControllerStatus;
+import com.willwinder.universalgcodesender.listeners.ControllerStatusBuilder;
+import com.willwinder.universalgcodesender.listeners.OverridePercents;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+import com.willwinder.universalgcodesender.model.Overrides;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.ArgumentMatchers.anyByte;
+import org.mockito.Mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+public class GrblOverrideManagerTest {
+
+    @Mock
+    private IController controller;
+
+    @Mock
+    private ICommunicator communicator;
+    private GrblOverrideManager overrideManager;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        overrideManager = new GrblOverrideManager(controller, communicator);
+    }
+
+    @Test
+    public void isAvailableShouldReturnFalseIfControllerStatusIsNull() {
+        when(controller.getControllerStatus()).thenReturn(null);
+        assertFalse(overrideManager.isAvailable());
+    }
+
+    @Test
+    public void isAvailableShouldReturnFalseIfControllerCapabilitiesIsNull() {
+        when(controller.getControllerStatus()).thenReturn(null);
+        assertFalse(overrideManager.isAvailable());
+    }
+
+    @Test
+    public void isAvailableShouldReturnTrueIfControllerIsInHoldState() {
+        mockOverrideCapabilities();
+        mockControllerStatus(ControllerState.HOLD);
+
+        assertTrue(overrideManager.isAvailable());
+    }
+
+    @Test
+    public void isAvailableShouldReturnTrueIfControllerIsInIdleState() {
+        mockOverrideCapabilities();
+        mockControllerStatus(ControllerState.IDLE);
+
+        assertTrue(overrideManager.isAvailable());
+    }
+
+    @Test
+    public void isAvailableShouldReturnTrueIfControllerIsInRunState() {
+        mockOverrideCapabilities();
+        mockControllerStatus(ControllerState.RUN);
+
+        assertTrue(overrideManager.isAvailable());
+    }
+
+    @Test
+    public void sendOverrideCommandShouldSendCommandByteToCommunicator() throws Exception {
+        mockOverrideCapabilities();
+        mockControllerStatus(ControllerState.RUN);
+
+        overrideManager.sendOverrideCommand(Overrides.CMD_TOGGLE_SPINDLE);
+
+        verify(communicator, times(1)).sendByteImmediately(anyByte());
+    }
+
+    @Test
+    public void getSpeedValuesShouldReturnBasedOnOverrideType() {
+        mockOverrideCapabilities();
+        mockControllerStatus(ControllerState.RUN);
+
+        assertEquals(100, overrideManager.getSpeedDefault(OverrideType.SPINDLE_SPEED));
+        assertEquals(100, overrideManager.getSpeedDefault(OverrideType.FEED_SPEED));
+        assertEquals(0, overrideManager.getSpeedDefault(OverrideType.RAPID_SPEED));
+        assertEquals(0, overrideManager.getSpeedDefault(OverrideType.MIST_TOGGLE));
+
+        assertEquals(200, overrideManager.getSpeedMax(OverrideType.SPINDLE_SPEED));
+        assertEquals(200, overrideManager.getSpeedMax(OverrideType.FEED_SPEED));
+        assertEquals(0, overrideManager.getSpeedMax(OverrideType.RAPID_SPEED));
+        assertEquals(0, overrideManager.getSpeedMax(OverrideType.MIST_TOGGLE));
+
+        assertEquals(10, overrideManager.getSpeedMin(OverrideType.SPINDLE_SPEED));
+        assertEquals(10, overrideManager.getSpeedMin(OverrideType.FEED_SPEED));
+        assertEquals(0, overrideManager.getSpeedMin(OverrideType.RAPID_SPEED));
+        assertEquals(0, overrideManager.getSpeedMin(OverrideType.MIST_TOGGLE));
+
+        assertEquals(100, overrideManager.getSpeedTargetValue(OverrideType.SPINDLE_SPEED));
+        assertEquals(100, overrideManager.getSpeedTargetValue(OverrideType.FEED_SPEED));
+        assertEquals(0, overrideManager.getSpeedTargetValue(OverrideType.RAPID_SPEED));
+        assertEquals(0, overrideManager.getSpeedTargetValue(OverrideType.MIST_TOGGLE));
+
+        assertEquals(1, overrideManager.getSpeedStep(OverrideType.SPINDLE_SPEED));
+        assertEquals(1, overrideManager.getSpeedStep(OverrideType.FEED_SPEED));
+        assertEquals(0, overrideManager.getSpeedStep(OverrideType.RAPID_SPEED));
+        assertEquals(0, overrideManager.getSpeedStep(OverrideType.MIST_TOGGLE));
+
+        assertEquals(10, overrideManager.getSpeedMajorStep(OverrideType.SPINDLE_SPEED));
+        assertEquals(10, overrideManager.getSpeedMajorStep(OverrideType.FEED_SPEED));
+
+        assertEquals(1, overrideManager.getSpeedMinorStep(OverrideType.SPINDLE_SPEED));
+        assertEquals(1, overrideManager.getSpeedMinorStep(OverrideType.FEED_SPEED));
+
+        assertEquals(List.of(OverrideType.FEED_SPEED, OverrideType.SPINDLE_SPEED), overrideManager.getSpeedTypes());
+    }
+
+    @Test
+    public void setSpeedTargetShouldSendCommand() throws Exception {
+        mockControllerStatus(ControllerState.IDLE);
+        mockOverrideCapabilities();
+
+        overrideManager.setSpeedTarget(OverrideType.FEED_SPEED, 10);
+        verify(communicator, times(1)).sendByteImmediately(anyByte());
+        assertFalse(overrideManager.hasSettled());
+
+
+        ControllerStatus controllerStatus = ControllerStatusBuilder.newInstance().setState(ControllerState.RUN).setOverrides(new OverridePercents(10, 0, 0)).build();
+        when(controller.getControllerStatus()).thenReturn(controllerStatus);
+        assertFalse(overrideManager.hasSettled());
+    }
+
+    @Test
+    public void hasSettledShouldReturnTrueWhenOverridePercentReachesTarget() {
+        mockControllerStatus(ControllerState.IDLE);
+        mockOverrideCapabilities();
+
+        overrideManager.setSpeedTarget(OverrideType.FEED_SPEED, 10);
+        ControllerStatus controllerStatus = ControllerStatusBuilder.newInstance().setState(ControllerState.RUN).setOverrides(new OverridePercents(10, 100, 100)).build();
+        when(controller.getControllerStatus()).thenReturn(controllerStatus);
+        overrideManager.onControllerStatus(controllerStatus);
+
+        assertTrue(overrideManager.hasSettled());
+    }
+
+    private void mockControllerStatus(ControllerState controllerState) {
+        ControllerStatus controllerStatus = ControllerStatusBuilder.newInstance().setOverrides(new OverridePercents(100, 100, 100)).setState(controllerState).build();
+        when(controller.getControllerStatus()).thenReturn(controllerStatus);
+    }
+
+    private void mockOverrideCapabilities() {
+        Capabilities capabilites = new Capabilities();
+        capabilites.addCapability(CapabilitiesConstants.OVERRIDES);
+        when(controller.getCapabilities()).thenReturn(capabilites);
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-dro/src/main/java/com/willwinder/ugs/nbp/dro/panels/Translations.java
+++ b/ugs-platform/ugs-platform-plugin-dro/src/main/java/com/willwinder/ugs/nbp/dro/panels/Translations.java
@@ -1,0 +1,20 @@
+package com.willwinder.ugs.nbp.dro.panels;
+
+import com.willwinder.universalgcodesender.i18n.Localization;
+
+class Translations {
+    static final String OFFLINE = Localization.getString("mainWindow.status.offline").toUpperCase();
+    static final String PIN_X = Localization.getString("machineStatus.pin.x").toUpperCase();
+    static final String PIN_Y = Localization.getString("machineStatus.pin.y").toUpperCase();
+    static final String PIN_Z = Localization.getString("machineStatus.pin.z").toUpperCase();
+    static final String PIN_A = Localization.getString("machineStatus.pin.a").toUpperCase();
+    static final String PIN_B = Localization.getString("machineStatus.pin.b").toUpperCase();
+    static final String PIN_C = Localization.getString("machineStatus.pin.c").toUpperCase();
+    static final String PIN_PROBE = Localization.getString("machineStatus.pin.probe").toUpperCase();
+    static final String PIN_DOOR = Localization.getString("machineStatus.pin.door").toUpperCase();
+    static final String PIN_HOLD = Localization.getString("machineStatus.pin.hold").toUpperCase();
+    static final String PIN_SOFT_RESET = Localization.getString("machineStatus.pin.softReset").toUpperCase();
+    static final String PIN_CYCLE_STARY = Localization.getString("machineStatus.pin.cycleStart").toUpperCase();
+    private Translations() {
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/action/AnalogFeedOverrideAction.java
+++ b/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/action/AnalogFeedOverrideAction.java
@@ -1,0 +1,35 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.joystick.action;
+
+import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+
+/**
+ * An action for setting the analog feed override
+ *
+ * @author Joacim Breiler
+ */
+public class AnalogFeedOverrideAction extends AnalogOverrideAction {
+
+    public AnalogFeedOverrideAction() {
+        super(OverrideType.FEED_SPEED);
+        this.putValue(NAME, Localization.getString("platform.plugin.joystick.action.analogFeed"));
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/action/AnalogOverrideAction.java
+++ b/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/action/AnalogOverrideAction.java
@@ -1,0 +1,73 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.joystick.action;
+
+import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
+import com.willwinder.universalgcodesender.listeners.ControllerState;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+import com.willwinder.universalgcodesender.listeners.UGSEventListener;
+import com.willwinder.universalgcodesender.model.BackendAPI;
+import com.willwinder.universalgcodesender.model.UGSEvent;
+import com.willwinder.universalgcodesender.model.events.ControllerStateEvent;
+import com.willwinder.universalgcodesender.firmware.IOverrideManager;
+
+import javax.swing.AbstractAction;
+import java.awt.event.ActionEvent;
+
+/**
+ * Makes it possible to do an analog override
+ *
+ * @author Joacim Breiler
+ */
+public abstract class AnalogOverrideAction extends AbstractAction implements AnalogAction, UGSEventListener {
+    private final transient BackendAPI backend;
+    private final OverrideType overrideType;
+    private float value;
+
+    protected AnalogOverrideAction(OverrideType overrideType) {
+        this.overrideType = overrideType;
+        setEnabled(false);
+
+        backend = CentralLookup.getDefault().lookup(BackendAPI.class);
+        backend.addUGSEventListener(this);
+    }
+
+    @Override
+    public void UGSEvent(UGSEvent evt) {
+        if (evt instanceof ControllerStateEvent controllerStateEvent) {
+            ControllerState state = controllerStateEvent.getState();
+            setEnabled(state == ControllerState.IDLE || state == ControllerState.RUN);
+        }
+    }
+
+    @Override
+    public void setValue(float value) {
+        this.value = value;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (!isEnabled() || backend.getController() == null || backend.getController().getOverrideManager() == null) {
+            return;
+        }
+
+        IOverrideManager overrideManager = backend.getController().getOverrideManager();
+        overrideManager.setSpeedTarget(overrideType, Math.round(value * overrideManager.getSpeedMax(overrideType) + overrideManager.getSpeedDefault(overrideType)));
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/action/AnalogSpindleOverrideAction.java
+++ b/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/action/AnalogSpindleOverrideAction.java
@@ -1,0 +1,34 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.joystick.action;
+
+import com.willwinder.universalgcodesender.i18n.Localization;
+import com.willwinder.universalgcodesender.listeners.OverrideType;
+
+/**
+ * An action for setting the analog spindle override
+ *
+ * @author Joacim Breiler
+ */
+public class AnalogSpindleOverrideAction extends AnalogOverrideAction {
+    public AnalogSpindleOverrideAction() {
+        super(OverrideType.SPINDLE_SPEED);
+        this.putValue(NAME, Localization.getString("platform.plugin.joystick.action.analogSpindle"));
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/service/JoystickServiceImpl.java
+++ b/ugs-platform/ugs-platform-plugin-joystick/src/main/java/com/willwinder/ugs/nbp/joystick/service/JoystickServiceImpl.java
@@ -34,7 +34,9 @@ import static com.willwinder.ugs.nbp.joystick.Utils.ACTION_Z_DOWN;
 import static com.willwinder.ugs.nbp.joystick.Utils.ACTION_Z_UP;
 import com.willwinder.ugs.nbp.joystick.action.ActionDispatcher;
 import com.willwinder.ugs.nbp.joystick.action.ActionManager;
+import com.willwinder.ugs.nbp.joystick.action.AnalogFeedOverrideAction;
 import com.willwinder.ugs.nbp.joystick.action.AnalogJogAction;
+import com.willwinder.ugs.nbp.joystick.action.AnalogSpindleOverrideAction;
 import com.willwinder.ugs.nbp.joystick.driver.JamepadJoystickDriver;
 import com.willwinder.ugs.nbp.joystick.driver.JoystickDriver;
 import com.willwinder.ugs.nbp.joystick.driver.JoystickDriverListener;
@@ -61,6 +63,8 @@ import java.util.logging.Logger;
  */
 public class JoystickServiceImpl implements JoystickService, JoystickDriverListener {
     public static final String CONTINUOUS_JOG_ACTION_CATEGORY = "Actions/Machine";
+    public static final String CONTINUOUS_OVERRIDE_ACTION_CATEGORY = "Actions/Overrides";
+
     private static final Logger LOGGER = Logger.getLogger(JoystickServiceImpl.class.getSimpleName());
 
     /**
@@ -90,6 +94,8 @@ public class JoystickServiceImpl implements JoystickService, JoystickDriverListe
         actionManager.registerAction("continuousJogAAction", CONTINUOUS_JOG_ACTION_CATEGORY, new AnalogJogAction(continuousJogWorker, Axis.A));
         actionManager.registerAction("continuousJogBAction", CONTINUOUS_JOG_ACTION_CATEGORY, new AnalogJogAction(continuousJogWorker, Axis.B));
         actionManager.registerAction("continuousJogCAction", CONTINUOUS_JOG_ACTION_CATEGORY, new AnalogJogAction(continuousJogWorker, Axis.C));
+        actionManager.registerAction("analogFeedOverrideAction", CONTINUOUS_OVERRIDE_ACTION_CATEGORY, new AnalogFeedOverrideAction());
+        actionManager.registerAction("analogSpindleOverrideAction", CONTINUOUS_OVERRIDE_ACTION_CATEGORY, new AnalogSpindleOverrideAction());
 
         joystickActionDispatcher = new ActionDispatcher(actionManager, continuousJogWorker);
         addListener(joystickActionDispatcher);

--- a/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelHardLimits.java
+++ b/ugs-platform/ugs-platform-plugin-setup-wizard/src/main/java/com/willwinder/ugs/nbp/setupwizard/panels/WizardPanelHardLimits.java
@@ -22,7 +22,6 @@ import com.willwinder.ugs.nbp.setupwizard.AbstractWizardPanel;
 import com.willwinder.universalgcodesender.firmware.FirmwareSettingsException;
 import com.willwinder.universalgcodesender.firmware.IFirmwareSettings;
 import com.willwinder.universalgcodesender.i18n.Localization;
-import com.willwinder.universalgcodesender.listeners.ControllerStatus;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.Alarm;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -38,8 +37,12 @@ import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import java.awt.Color;
+import java.awt.Font;
 
 /**
  * A wizard step panel for configuring hard limits on a controller.
@@ -94,7 +97,7 @@ public class WizardPanelHardLimits extends AbstractWizardPanel implements UGSEve
         checkboxEnableHardLimits = new JCheckBox("Enable limit switches");
         checkboxEnableHardLimits.addActionListener(event -> onHardLimitsClicked());
 
-        labelHardLimitsNotSupported = new JLabel("<html><body>" + Localization.getString("platform.plugin.setupwizard.limit-switches.not-available") + "</body></html>", ImageUtilities.loadImageIcon("icons/information24.png", false), JLabel.LEFT);
+        labelHardLimitsNotSupported = new JLabel("<html><body>" + Localization.getString("platform.plugin.setupwizard.limit-switches.not-available") + "</body></html>", ImageUtilities.loadImageIcon("icons/information24.png", false), SwingConstants.LEFT);
         labelHardLimitsNotSupported.setVisible(false);
 
         labelLimitX = createLimitLabel("X");
@@ -118,7 +121,7 @@ public class WizardPanelHardLimits extends AbstractWizardPanel implements UGSEve
     }
 
     private JLabel createLimitLabel(String text) {
-        JLabel label = new JLabel(text, JLabel.CENTER);
+        JLabel label = new JLabel(text, SwingConstants.CENTER);
         label.setFont(label.getFont().deriveFont(Font.BOLD));
         label.setBorder(new RoundedBorder(8));
         label.setForeground(Color.WHITE);
@@ -157,14 +160,13 @@ public class WizardPanelHardLimits extends AbstractWizardPanel implements UGSEve
     public void UGSEvent(UGSEvent evt) {
         if (evt instanceof FirmwareSettingEvent) {
             refreshComponents();
-        } else if (evt instanceof ControllerStatusEvent) {
+        } else if (evt instanceof ControllerStatusEvent controllerStatus) {
             ThreadHelper.invokeLater(() -> {
-                ControllerStatus controllerStatus = ((ControllerStatusEvent) evt).getStatus();
-                labelLimitX.setBackground(controllerStatus.getEnabledPins().X ? ThemeColors.RED : ThemeColors.LIGHT_GREEN);
-                labelLimitY.setBackground(controllerStatus.getEnabledPins().Y ? ThemeColors.RED : ThemeColors.LIGHT_GREEN);
-                labelLimitZ.setBackground(controllerStatus.getEnabledPins().Z ? ThemeColors.RED : ThemeColors.LIGHT_GREEN);
+                labelLimitX.setBackground(controllerStatus.getStatus().getEnabledPins().x() ? ThemeColors.RED : ThemeColors.LIGHT_GREEN);
+                labelLimitY.setBackground(controllerStatus.getStatus().getEnabledPins().y() ? ThemeColors.RED : ThemeColors.LIGHT_GREEN);
+                labelLimitZ.setBackground(controllerStatus.getStatus().getEnabledPins().z() ? ThemeColors.RED : ThemeColors.LIGHT_GREEN);
             });
-        } else if (evt instanceof AlarmEvent && ((AlarmEvent) evt).getAlarm() == Alarm.HARD_LIMIT) {
+        } else if (evt instanceof AlarmEvent alarmEvent && alarmEvent.getAlarm() == Alarm.HARD_LIMIT) {
             ThreadHelper.invokeLater(() -> {
                 try {
                     getBackend().issueSoftReset();


### PR DESCRIPTION
I have introduced a new OverrideManager that will be responsible for handling all types of overrides for the controller. It will exist in a couple of flavors for different controllers and provide a unified interface for dealing with override operations.

For instance, the min and max feed override values may be differ between controller types.
The override panel will detect which controls it can present.

The override panel now has sliders for feed and spindle speed where the target value will be acheived by the OverrideManager:
![image](https://github.com/winder/Universal-G-Code-Sender/assets/8962024/7270dfbf-aceb-464b-98a5-7b2586dc0ede)

Since the override values now can be given within an interval we can now also apply this with an analog input on a gamepad:

![image](https://github.com/winder/Universal-G-Code-Sender/assets/8962024/b02e74fe-cecd-4778-a65c-2593eef6e9ac)

I have also disabled the override functionality on g2core as it is not (and has never been) working properly.