### PR TITLE
added macro versioning

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/types/Macro.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/types/Macro.java
@@ -17,7 +17,7 @@ public class Macro implements Serializable {
     private String name;
     private String description;
     private String gcode;
-    private Integer version;
+    private MacroVersion version;
 
     public Macro() {
     }
@@ -70,12 +70,12 @@ public class Macro implements Serializable {
         this.gcode = gcode;
     }
 
-    public Integer getVersion() {
+    public MacroVersion getVersion() {
         return version;
     }
 
-    public void setVersion(Integer version) {
-        this.version = Objects.requireNonNullElse(version, 1);
+    public void setVersion(MacroVersion version) {
+        this.version = Objects.requireNonNullElse(version, MacroVersion.V1);
     }
 
     @Override
@@ -91,13 +91,13 @@ public class Macro implements Serializable {
 
     @Serial
     public Object readResolve() {
-        this.version = Objects.requireNonNullElse(this.version, 1);
+        this.version = Objects.requireNonNullElse(this.version, MacroVersion.V2);
         return this;
     }
 
     @Serial
     public Object writeReplace() {
-        this.version = Objects.requireNonNullElse(this.version, 1);
+        this.version = Objects.requireNonNullElse(this.version, MacroVersion.V1);
         return this;
     }
 

--- a/ugs-core/src/com/willwinder/universalgcodesender/types/Macro.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/types/Macro.java
@@ -4,6 +4,8 @@ import com.google.common.base.Strings;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.io.Serial;
+import java.util.Objects;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -15,6 +17,7 @@ public class Macro implements Serializable {
     private String name;
     private String description;
     private String gcode;
+    private Integer version;
 
     public Macro() {
     }
@@ -67,6 +70,14 @@ public class Macro implements Serializable {
         this.gcode = gcode;
     }
 
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = Objects.requireNonNullElse(version, 1);
+    }
+
     @Override
     public String toString() {
         return "Macro{" +
@@ -74,7 +85,20 @@ public class Macro implements Serializable {
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
                 ", gcode='" + gcode + '\'' +
+                ", version=" + version +
                 '}';
+    }
+
+    @Serial
+    public Object readResolve() {
+        this.version = Objects.requireNonNullElse(this.version, 1);
+        return this;
+    }
+
+    @Serial
+    public Object writeReplace() {
+        this.version = Objects.requireNonNullElse(this.version, 1);
+        return this;
     }
 
     @Override

--- a/ugs-core/src/com/willwinder/universalgcodesender/types/MacroVersion.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/types/MacroVersion.java
@@ -1,0 +1,29 @@
+package com.willwinder.universalgcodesender.types;
+
+public enum MacroVersion {
+    /**
+     * The first version of the macro system.
+     * This version allows pseudo-multiline macros separated by a semicolon.
+     * It also allows for the use of the {prompt|name} macros and machine and work coordinate substitution.
+     * This version is compatible with the newer macro system, but will not be separated in multiple lines.
+     */
+    V1(1),
+
+    // TODO: Add more documentation when the second version is implemented.
+    /**
+     * The second version of the macro system.
+     * This version will be backwards compatible with the first version, but will allow for the use of
+     * multi-line macros and more TBA.
+     */
+    V2(2);
+
+    private final int version;
+
+    MacroVersion(int version) {
+        this.version = version;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+}

--- a/ugs-pendant/src/main/java/com/willwinder/universalgcodesender/pendantui/v1/model/Macro.java
+++ b/ugs-pendant/src/main/java/com/willwinder/universalgcodesender/pendantui/v1/model/Macro.java
@@ -9,7 +9,6 @@ public class Macro implements Serializable {
     private String gcode;
     private String description;
     private String name;
-    private Integer version;
 
     public String getGcode() {
         return gcode;
@@ -33,13 +32,5 @@ public class Macro implements Serializable {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public Integer getVersion() {
-        return version;
-    }
-
-    public void setVersion(Integer version) {
-        this.version = version;
     }
 }

--- a/ugs-pendant/src/main/java/com/willwinder/universalgcodesender/pendantui/v1/model/Macro.java
+++ b/ugs-pendant/src/main/java/com/willwinder/universalgcodesender/pendantui/v1/model/Macro.java
@@ -9,6 +9,7 @@ public class Macro implements Serializable {
     private String gcode;
     private String description;
     private String name;
+    private Integer version;
 
     public String getGcode() {
         return gcode;
@@ -32,5 +33,13 @@ public class Macro implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
     }
 }


### PR DESCRIPTION
As discussed in #2404 this change will allow macro versioning for backwards compatibility.

When reading a macro from settings, it will default to `version = MacroVersion.V1` if there is no version associated to the macro.