### PR TITLE
fix: Set focus to first field in macro popup

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
@@ -22,6 +22,7 @@ import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.model.BackendAPI;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.services.KeyboardService;
+import com.willwinder.universalgcodesender.uielements.components.RequestFocusListener;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/MacroHelper.java
@@ -166,6 +166,9 @@ public class MacroHelper {
             myPanel.setLayout(new MigLayout("wrap 2, width 200"));
             for (Prompt s : prompts) {
                 JTextField field = new JTextField(s.defaultValue);
+                if (fields.size() == 0){
+                    field.addHierarchyListener(new RequestFocusListener());
+                }
                 myPanel.add(new JLabel(s.prompt + ":"));
                 myPanel.add(field, "growx, pushx");
                 fields.add(field);

--- a/ugs-core/src/com/willwinder/universalgcodesender/RequestFocusListener.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/RequestFocusListener.java
@@ -1,0 +1,27 @@
+package com.willwinder.universalgcodesender;
+
+import java.awt.Component;
+import java.awt.Window;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.HierarchyListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.SwingUtilities;
+
+public class RequestFocusListener implements HierarchyListener {
+
+    @Override
+    public void hierarchyChanged(HierarchyEvent e) {
+        final Component c = e.getComponent();
+        if (c.isShowing() && (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0) {
+            Window toplevel = SwingUtilities.getWindowAncestor(c);
+            toplevel.addWindowFocusListener(new WindowAdapter() {
+
+                @Override
+                public void windowGainedFocus(WindowEvent e) {
+                    c.requestFocus();
+                }
+            });
+        }
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/RequestFocusListener.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/components/RequestFocusListener.java
@@ -1,4 +1,4 @@
-package com.willwinder.universalgcodesender;
+package com.willwinder.universalgcodesender.uielements.components;
 
 import java.awt.Component;
 import java.awt.Window;
@@ -8,6 +8,11 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.SwingUtilities;
 
+/**
+ * Used for focusing a field in an JOptionDialog.
+ * 
+ * Source from: https://tips4java.wordpress.com/2010/03/14/dialog-focus/
+ */
 public class RequestFocusListener implements HierarchyListener {
 
     @Override


### PR DESCRIPTION
Resolves: https://github.com/winder/Universal-G-Code-Sender/issues/2473

I've not touched Java in many years so this solution is taken mostly from here: 

https://tips4java.wordpress.com/2010/03/14/dialog-focus/

It seems to behave differently on different platforms. HierarchyListener was the only listener that worked on Linux.