### PR TITLE
Reads the max spindle speed from the controller 

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/DefaultFirmwareSettings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/DefaultFirmwareSettings.java
@@ -145,6 +145,11 @@ public class DefaultFirmwareSettings implements IFirmwareSettings {
     }
 
     @Override
+    public int getMaxSpindleSpeed() throws FirmwareSettingsException {
+        return 0;
+    }
+
+    @Override
     public UnitUtils.Units getReportingUnits() {
         return UnitUtils.Units.UNKNOWN;
     }

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/IFirmwareSettings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/IFirmwareSettings.java
@@ -142,7 +142,7 @@ public interface IFirmwareSettings {
     /**
      * Sets the number of steps needed to move the machine one millimeter.
      *
-     * @param axis the axis to retrieve the setting for
+     * @param axis               the axis to retrieve the setting for
      * @param stepsPerMillimeter the number of steps to move one millimeter
      * @throws FirmwareSettingsException if the settings couldn't be saved
      */
@@ -185,7 +185,7 @@ public interface IFirmwareSettings {
     /**
      * Sets if the homing direction should be inverted for the given axis
      *
-     * @param axis the axis to make the setting for
+     * @param axis     the axis to make the setting for
      * @param inverted set to true if homing should be performed in a negative direction
      */
     void setHomingDirectionInverted(Axis axis, boolean inverted) throws FirmwareSettingsException;
@@ -218,4 +218,11 @@ public interface IFirmwareSettings {
      * @return the maximum rate in mm/min
      */
     double getMaximumRate(Axis axis) throws FirmwareSettingsException;
+
+    /**
+     * Returns the controller max spindle speed
+     *
+     * @return the max spindle speed
+     */
+    int getMaxSpindleSpeed() throws FirmwareSettingsException;
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/SpeedMap.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/SpeedMap.java
@@ -1,0 +1,49 @@
+/*
+    Copyright 2024 Will Winder
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.universalgcodesender.firmware.fluidnc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A class for parsing FluidNC speed maps
+ *
+ * @author Joacim Breiler
+ */
+public class SpeedMap {
+    private final Map<Integer, Double> speeds = new HashMap<>();
+
+    public SpeedMap(String speedMaps) {
+        String[] speeds = speedMaps.split(" ");
+        for (String speedMap : speeds) {
+            String[] split = speedMap.split("=");
+            if (split.length != 2) {
+                continue;
+            }
+
+            this.speeds.put(Integer.parseInt(split[0].trim()), Double.parseDouble(split[1].trim().replace("%", "")));
+        }
+    }
+
+    public int getMax() {
+        return speeds.keySet().stream()
+                .max((s1, s2) -> speeds.get(s1).compareTo(speeds.get(s2)))
+                .orElse(0);
+    }
+}

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/commands/GetFirmwareSettingsCommand.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/commands/GetFirmwareSettingsCommand.java
@@ -51,7 +51,7 @@ public class GetFirmwareSettingsCommand extends SystemCommand {
                 .filter(Objects::nonNull)
                 .flatMap(this::flatten)
                 .collect(LinkedHashMap::new, (map, entry) ->
-                        map.put(entry.getKey(), entry.getValue().toString()), LinkedHashMap::putAll);
+                        map.put(entry.getKey().toLowerCase(), entry.getValue().toString()), LinkedHashMap::putAll);
     }
 
     private Stream<Map.Entry<String, Object>> flatten(Map.Entry<String, Object> entry) {
@@ -63,7 +63,7 @@ public class GetFirmwareSettingsCommand extends SystemCommand {
         if (value instanceof Map<?, ?>) {
             Map<?, ?> properties = (Map<?, ?>) value;
             return properties.entrySet().stream()
-                    .flatMap(e -> flatten(new AbstractMap.SimpleEntry<>(entry.getKey() + "/" + e.getKey(), e.getValue())));
+                    .flatMap(e -> flatten(new AbstractMap.SimpleEntry<>(entry.getKey().toLowerCase() + "/" + e.getKey().toString().toLowerCase(), e.getValue())));
         }
 
         return Stream.of(entry);

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblFirmwareSettings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/grbl/GrblFirmwareSettings.java
@@ -59,6 +59,7 @@ public class GrblFirmwareSettings implements ICommunicatorListener, IFirmwareSet
     private static final String KEY_HARD_LIMITS_ENABLED = "$21";
     private static final String KEY_HOMING_ENABLED = "$22";
     private static final String KEY_HOMING_INVERT_DIRECTION = "$23";
+    private static final String KEY_MAX_SPINDLE_SPEED = "$30";
     private static final String KEY_INVERT_DIRECTION = "$3";
     private static final String KEY_INVERT_LIMIT_PINS = "$5";
     private static final String KEY_STEPS_PER_MM_X = "$100";
@@ -368,6 +369,14 @@ public class GrblFirmwareSettings implements ICommunicatorListener, IFirmwareSet
             default:
                 throw new FirmwareSettingsException("Couldn't get maximum rate setting for axis " + axis + ", it's not supported by the controller");
         }
+    }
+
+    @Override
+    public int getMaxSpindleSpeed() throws FirmwareSettingsException {
+        return getSetting(KEY_MAX_SPINDLE_SPEED)
+                .map(FirmwareSetting::getValue)
+                .map(Integer::valueOf)
+                .orElse(0);
     }
 
     private int getInvertDirectionMask() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/tinyg/TinyGFirmwareSettings.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/tinyg/TinyGFirmwareSettings.java
@@ -191,6 +191,11 @@ public class TinyGFirmwareSettings implements ICommunicatorListener, IFirmwareSe
         return 0;
     }
 
+    @Override
+    public int getMaxSpindleSpeed() throws FirmwareSettingsException {
+        throw new FirmwareSettingsException("Not implemented");
+    }
+
     /*
      * IFirmwareSettingsListener
      */

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/SpeedMapTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/SpeedMapTest.java
@@ -1,0 +1,31 @@
+package com.willwinder.universalgcodesender.firmware.fluidnc;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class SpeedMapTest {
+
+    @Test
+    public void getMaxShouldReturnTheHundredPercentMaxSpindleSpeed() {
+        SpeedMap speedMap = new SpeedMap("0=0.00% 0=0.00% 5000=100.00%");
+        assertEquals(5000, speedMap.getMax());
+    }
+
+    @Test
+    public void getMaxShouldReturnTheMaxSpindleSpeedRegardlessOfOrder() {
+        SpeedMap speedMap = new SpeedMap("5000=100.00% 0=0.00% ");
+        assertEquals(5000, speedMap.getMax());
+    }
+
+    @Test
+    public void getMaxShouldReturnValueOfTheHighestPercent() {
+        SpeedMap speedMap = new SpeedMap("5000=99.00% 0=0.00% 4000=100%");
+        assertEquals(4000, speedMap.getMax());
+    }
+
+    @Test
+    public void speedMapShouldHandleExtraSpacing() {
+        SpeedMap speedMap = new SpeedMap("0=0.00%  5000=50.00%  10000=100.00%");
+        assertEquals(10000, speedMap.getMax());
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntitySetting.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntitySetting.java
@@ -55,6 +55,8 @@ public enum EntitySetting {
             EntitySetting.ROTATION,
             EntitySetting.START_DEPTH,
             EntitySetting.TARGET_DEPTH,
+            EntitySetting.SPINDLE_SPEED,
+            EntitySetting.FEED_RATE,
             EntitySetting.TEXT);
 
     public static final List<EntitySetting> DEFAULT_LASER_SETTINGS = List.of(

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolSettingsPanel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/ToolSettingsPanel.java
@@ -25,6 +25,7 @@ import com.willwinder.universalgcodesender.uielements.TextFieldUnit;
 import com.willwinder.universalgcodesender.uielements.TextFieldWithUnit;
 import net.miginfocom.swing.MigLayout;
 
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
@@ -45,7 +46,7 @@ public class ToolSettingsPanel extends JPanel {
     private JTextField depthPerPass;
     private JTextField stepOver;
     private JTextField safeHeight;
-    private JTextField spindleSpeed;
+    private JCheckBox detectMaxSpindleSpeed;
     private TextFieldWithUnit laserDiameter;
     private TextFieldWithUnit maxSpindleSpeed;
 
@@ -63,7 +64,14 @@ public class ToolSettingsPanel extends JPanel {
         toolDiameter = new TextFieldWithUnit(TextFieldUnit.MM, 3, controller.getSettings().getToolDiameter());
         add(toolDiameter, TOOL_FIELD_CONSTRAINT);
 
-        add(new JLabel("Feed speed" ));
+        add(new JLabel("Tool step over" ));
+        stepOver = new TextFieldWithUnit(TextFieldUnit.PERCENT, 2,
+                controller.getSettings().getToolStepOver());
+        add(stepOver, TOOL_FIELD_CONSTRAINT);
+
+        add(new JSeparator(SwingConstants.HORIZONTAL), "spanx, grow, wrap, hmin 2" );
+
+        add(new JLabel("Default feed speed" ));
         feedSpeed = new TextFieldWithUnit(TextFieldUnit.MM_PER_MINUTE, 0, controller.getSettings().getFeedSpeed());
         add(feedSpeed, TOOL_FIELD_CONSTRAINT);
 
@@ -75,19 +83,15 @@ public class ToolSettingsPanel extends JPanel {
         depthPerPass = new TextFieldWithUnit(TextFieldUnit.MM, 2, controller.getSettings().getDepthPerPass());
         add(depthPerPass, TOOL_FIELD_CONSTRAINT);
 
-        add(new JLabel("Step over" ));
-        stepOver = new TextFieldWithUnit(TextFieldUnit.PERCENT, 2,
-                controller.getSettings().getToolStepOver());
-        add(stepOver, TOOL_FIELD_CONSTRAINT);
-
         add(new JLabel("Safe height" ));
         safeHeight = new TextFieldWithUnit(TextFieldUnit.MM, 2, controller.getSettings().getSafeHeight());
         add(safeHeight, TOOL_FIELD_CONSTRAINT);
 
         add(new JSeparator(SwingConstants.HORIZONTAL), "spanx, grow, wrap, hmin 2" );
-        add(new JLabel("Spindle speed" ));
-        spindleSpeed = new TextFieldWithUnit(TextFieldUnit.ROTATIONS_PER_MINUTE, 0, controller.getSettings().getSpindleSpeed());
-        add(spindleSpeed, TOOL_FIELD_CONSTRAINT);
+
+        add(new JLabel("Detect max spindle speed" ));
+        detectMaxSpindleSpeed = new JCheckBox("", controller.getSettings().getDetectMaxSpindleSpeed());
+        add(detectMaxSpindleSpeed, TOOL_FIELD_CONSTRAINT);
 
         add(new JLabel("Max spindle speed" ));
         maxSpindleSpeed = new TextFieldWithUnit(TextFieldUnit.ROTATIONS_PER_MINUTE, 0, controller.getSettings().getMaxSpindleSpeed());
@@ -148,14 +152,6 @@ public class ToolSettingsPanel extends JPanel {
         }
     }
 
-    public double getSpindleSpeed() {
-        try {
-            return Utils.formatter.parse(spindleSpeed.getText()).doubleValue();
-        } catch (ParseException e) {
-            return controller.getSettings().getSpindleSpeed();
-        }
-    }
-
     private double getLaserDiameter() {
         try {
             return Utils.formatter.parse(laserDiameter.getText()).doubleValue();
@@ -172,6 +168,10 @@ public class ToolSettingsPanel extends JPanel {
         }
     }
 
+    private boolean getDetectMaxSpindleSpeed() {
+        return detectMaxSpindleSpeed.isSelected();
+    }
+
     public Settings getSettings() {
         Settings settings = new Settings();
         settings.applySettings(controller.getSettings());
@@ -181,9 +181,9 @@ public class ToolSettingsPanel extends JPanel {
         settings.setToolDiameter(getToolDiameter());
         settings.setToolStepOver(getStepOver());
         settings.setPlungeSpeed(getPlungeSpeed());
-        settings.setSpindleSpeed(getSpindleSpeed());
         settings.setLaserDiameter(getLaserDiameter());
         settings.setMaxSpindleSpeed((int) getMaxSpindleSpeed());
+        settings.setDetectMaxSpindleSpeed(getDetectMaxSpindleSpeed());
         return settings;
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsModel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsModel.java
@@ -24,6 +24,8 @@ import com.willwinder.ugs.nbp.designer.entities.EntitySetting;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.CutType;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.Group;
 import com.willwinder.ugs.nbp.designer.entities.cuttable.Text;
+import com.willwinder.ugs.nbp.designer.logic.Controller;
+import com.willwinder.ugs.nbp.designer.logic.ControllerFactory;
 
 import java.awt.Font;
 import java.io.Serializable;
@@ -133,6 +135,7 @@ public class SelectionSettingsModel implements Serializable {
         setStartDepth(0);
         setTargetDepth(0);
         setSpindleSpeed(0);
+        setFeedRate(0);
         setText("");
         setFontFamily(Font.SANS_SERIF);
     }
@@ -182,11 +185,14 @@ public class SelectionSettingsModel implements Serializable {
     }
 
     public int getSpindleSpeed() {
-        return (Integer) settings.getOrDefault(EntitySetting.SPINDLE_SPEED, 0);
+        return (Integer) settings.getOrDefault(EntitySetting.SPINDLE_SPEED, 100);
     }
 
     public void setSpindleSpeed(Integer speed) {
         if (!valuesEquals(getSpindleSpeed(), speed)) {
+            if (speed == 0) {
+                speed = 100;
+            }
             settings.put(EntitySetting.SPINDLE_SPEED, speed);
             notifyListeners(EntitySetting.SPINDLE_SPEED);
         }
@@ -205,15 +211,25 @@ public class SelectionSettingsModel implements Serializable {
     }
 
     public int getFeedRate() {
-        return (Integer) settings.getOrDefault(EntitySetting.FEED_RATE, 50);
+        return (Integer) settings.getOrDefault(EntitySetting.FEED_RATE, getDefaultFeedRate());
     }
 
     public void setFeedRate(Integer feedRate) {
         if (!valuesEquals(getFeedRate(), feedRate)) {
-            feedRate = Math.max(50, feedRate);
+            if (feedRate == 0) {
+                feedRate = getDefaultFeedRate();
+            }
             settings.put(EntitySetting.FEED_RATE, feedRate);
             notifyListeners(EntitySetting.FEED_RATE);
         }
+    }
+
+    private int getDefaultFeedRate() {
+        Controller controller = ControllerFactory.getController();
+        if (controller != null && controller.getSettings() != null) {
+            return controller.getSettings().getFeedSpeed();
+        }
+        return 50;
     }
 
     public String getFontFamily() {
@@ -261,7 +277,7 @@ public class SelectionSettingsModel implements Serializable {
     }
 
     public boolean getLockRatio() {
-        return  (Boolean) settings.getOrDefault(EntitySetting.LOCK_RATIO, true);
+        return (Boolean) settings.getOrDefault(EntitySetting.LOCK_RATIO, true);
     }
 
     public void setLockRatio(boolean lockRatio) {
@@ -272,7 +288,7 @@ public class SelectionSettingsModel implements Serializable {
     }
 
     public void updateFromEntity(Group selectionGroup) {
-        if(selectionGroup.getChildren().size() > 1) {
+        if (selectionGroup.getChildren().size() > 1) {
             return;
         }
         boolean isTextCuttable = selectionGroup.getChildren().get(0) instanceof Text;

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/path/GcodePath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/path/GcodePath.java
@@ -51,6 +51,10 @@ public class GcodePath implements PathGenerator {
         segments.add(new Segment(type, point, comment));
     }
 
+    public void addSegment(SegmentType type, PartialPosition point, int feedRate) {
+        segments.add(new Segment(type, point, null, null, feedRate));
+    }
+
     public void addSegment(Segment segment) {
         segments.add(segment);
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/path/Segment.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/path/Segment.java
@@ -43,13 +43,19 @@ public final class Segment {
     /**
      * The current spindle speed
      */
-    public final Integer spindleSpeed;
+    private final Integer spindleSpeed;
 
-    public Segment(SegmentType type, PartialPosition point, String label, Integer spindleSpeed) {
+    /**
+     * The current feed speed
+     */
+    private final Integer feedSpeed;
+
+    public Segment(SegmentType type, PartialPosition point, String label, Integer spindleSpeed, Integer feedSpeed) {
         this.type = type;
         this.point = point;
         this.label = label;
         this.spindleSpeed = spindleSpeed;
+        this.feedSpeed = feedSpeed;
     }
 
     public Segment(SegmentType type, PartialPosition point) {
@@ -60,7 +66,7 @@ public final class Segment {
         this(SegmentType.SEAM, null, label);
     }
     public Segment(SegmentType type, PartialPosition point, String label) {
-        this(type, point, label, null);
+        this(type, point, label, null, null);
     }
 
     /**
@@ -92,5 +98,13 @@ public final class Segment {
             throw new NullPointerException(type + " segment has no point!");
 
         return point;
+    }
+
+    public Integer getSpindleSpeed() {
+        return spindleSpeed;
+    }
+
+    public Integer getFeedSpeed() {
+        return feedSpeed;
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/AbstractToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/AbstractToolPath.java
@@ -18,8 +18,10 @@
  */
 package com.willwinder.ugs.nbp.designer.io.gcode.toolpaths;
 
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Cuttable;
 import com.willwinder.ugs.nbp.designer.io.gcode.path.GcodePath;
 import com.willwinder.ugs.nbp.designer.io.gcode.path.PathGenerator;
+import com.willwinder.ugs.nbp.designer.io.gcode.path.Segment;
 import com.willwinder.ugs.nbp.designer.io.gcode.path.SegmentType;
 import com.willwinder.ugs.nbp.designer.model.Settings;
 import com.willwinder.universalgcodesender.model.Axis;
@@ -77,21 +79,23 @@ public abstract class AbstractToolPath implements PathGenerator {
         return geometryFactory;
     }
 
-    protected GcodePath toGcodePath(List<List<PartialPosition>> coordinateList) {
-        GcodePath gcodePath = new GcodePath();
+    protected void addToGcodePath(GcodePath gcodePath, List<List<PartialPosition>> coordinateList, Cuttable source) {
         if (!coordinateList.isEmpty()) {
+            if (source.getSpindleSpeed() > 0) {
+                gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d)), null));
+            }
             coordinateList.forEach(cl -> {
                 if (!cl.isEmpty()) {
                     addSafeHeightSegmentTo(gcodePath, cl.get(0));
                     gcodePath.addSegment(SegmentType.POINT, cl.get(0));
-                    cl.forEach(c -> gcodePath.addSegment(SegmentType.LINE, c));
+                    cl.forEach(c -> gcodePath.addSegment(SegmentType.LINE, c, source.getFeedRate()));
                 }
             });
 
             addSafeHeightSegment(gcodePath);
         }
-        return gcodePath;
     }
+
 
     public GcodePath toGcodePath() {
         GcodePath gcodePath = new GcodePath();

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/LaserFillToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/LaserFillToolPath.java
@@ -34,7 +34,7 @@ public class LaserFillToolPath extends AbstractToolPath {
     }
 
     public void appendGcodePath(GcodePath gcodePath, Settings settings) {
-        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d))));
+        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d)), source.getFeedRate()));
 
         List<Geometry> geometries = getGeometries();
         geometries.forEach(g -> {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/LaserOutlineToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/LaserOutlineToolPath.java
@@ -20,7 +20,7 @@ public class LaserOutlineToolPath extends AbstractToolPath {
     }
 
     public void appendGcodePath(GcodePath gcodePath, Settings settings) {
-        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d))));
+        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d)), source.getFeedRate()));
 
         List<Geometry> geometries = getGeometries();
         geometries.forEach(g -> addGeometrySegments(g, gcodePath));

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPath.java
@@ -80,6 +80,6 @@ public class OutlineToolPath extends AbstractToolPath {
             }
         });
 
-        gcodePath.appendGcodePath(toGcodePath(coordinateList));
+        addToGcodePath(gcodePath, coordinateList, source);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/PocketToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/PocketToolPath.java
@@ -62,6 +62,6 @@ public class PocketToolPath extends AbstractToolPath {
             addGeometriesToCoordinatesList(shell, geometries, coordinateList, currentDepth);
         }
 
-        gcodePath.appendGcodePath(toGcodePath(coordinateList));
+        addToGcodePath(gcodePath, coordinateList, source);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/model/Settings.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/model/Settings.java
@@ -35,9 +35,9 @@ public class Settings {
     private UnitUtils.Units preferredUnits = UnitUtils.Units.MM;
     private double toolStepOver = 0.3;
     private double depthPerPass = 1;
-    private double spindleSpeed;
     private double laserDiameter = 0.2;
     private int maxSpindleSpeed = 255;
+    private boolean detectMaxSpindleSpeed = true;
 
     public Settings() {
     }
@@ -167,15 +167,6 @@ public class Settings {
         notifyListeners();
     }
 
-    public double getSpindleSpeed() {
-        return spindleSpeed;
-    }
-
-    public void setSpindleSpeed(double spindleSpeed) {
-        this.spindleSpeed = Math.abs(spindleSpeed);
-        notifyListeners();
-    }
-
     public void applySettings(Settings settings) {
         if (settings == null) {
             return;
@@ -189,9 +180,10 @@ public class Settings {
         setToolStepOver(settings.getToolStepOver());
         setPreferredUnits(settings.getPreferredUnits());
         setSafeHeight(settings.getSafeHeight());
-        setSpindleSpeed(settings.getSpindleSpeed());
         setLaserDiameter(settings.getLaserDiameter());
         setMaxSpindleSpeed(settings.getMaxSpindleSpeed());
+        setDetectMaxSpindleSpeed(settings.getDetectMaxSpindleSpeed());
+
     }
 
     public double getLaserDiameter() {
@@ -208,7 +200,19 @@ public class Settings {
     }
 
     public void setMaxSpindleSpeed(int maxSpindleSpeed) {
+        if (this.maxSpindleSpeed == Math.abs(maxSpindleSpeed)) {
+            return;
+        }
         this.maxSpindleSpeed = Math.abs(maxSpindleSpeed);
+        notifyListeners();
+    }
+
+    public boolean getDetectMaxSpindleSpeed() {
+        return detectMaxSpindleSpeed;
+    }
+
+    public void setDetectMaxSpindleSpeed(boolean detectMaxSpindleSpeed) {
+        this.detectMaxSpindleSpeed = detectMaxSpindleSpeed;
         notifyListeners();
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsAdapter.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsAdapter.java
@@ -29,6 +29,7 @@ import java.util.prefs.Preferences;
 public class SettingsAdapter {
     private static final Preferences preferences = NbPreferences.forModule(DesignerTopComponent.class);
     private static final String MAX_SPINDLE_SPEED = "maxSpindleSpeed";
+    private static final String DETECT_MAX_SPINDLE_SPEED = "detectMaxSpindleSpeed";
     private static final String LASER_DIAMETER = "laserDiameter";
     private static final String FEED_SPEED = "feedSpeed";
     private static final String PLUNGE_SPEED = "plungeSpeed";
@@ -36,7 +37,6 @@ public class SettingsAdapter {
     private static final String SAFE_HEIGHT = "safeHeight";
     private static final String TOOL_STEP_OVER = "toolStepOver";
     private static final String DEPTH_PER_PASS = "depthPerPass";
-    private static final String SPINDLE_SPEED = "spindleSpeed";
     private static final String STOCK_THICKNESS = "stockThickness";
 
     private SettingsAdapter() {}
@@ -44,6 +44,7 @@ public class SettingsAdapter {
     public static Settings loadSettings() {
         Settings settings = new Settings();
         settings.setMaxSpindleSpeed(preferences.getInt(MAX_SPINDLE_SPEED, 255));
+        settings.setDetectMaxSpindleSpeed(preferences.getBoolean(DETECT_MAX_SPINDLE_SPEED, true));
         settings.setLaserDiameter(preferences.getDouble(LASER_DIAMETER, 0.2d));
         settings.setDepthPerPass(preferences.getDouble(DEPTH_PER_PASS, 1d));
         settings.setFeedSpeed(preferences.getInt(FEED_SPEED, 1000));
@@ -51,13 +52,13 @@ public class SettingsAdapter {
         settings.setToolDiameter(preferences.getDouble(TOOL_DIAMETER, 3d));
         settings.setSafeHeight(preferences.getDouble(SAFE_HEIGHT, 5d));
         settings.setToolStepOver(preferences.getDouble(TOOL_STEP_OVER, 0.3));
-        settings.setSpindleSpeed(preferences.getDouble(SPINDLE_SPEED, 0.3));
         settings.setStockThickness(preferences.getDouble(STOCK_THICKNESS, 10));
         return settings;
     }
 
     public static void saveSettings(Settings settings) {
         preferences.putInt(MAX_SPINDLE_SPEED, settings.getMaxSpindleSpeed());
+        preferences.putBoolean(DETECT_MAX_SPINDLE_SPEED, settings.getDetectMaxSpindleSpeed());
         preferences.putDouble(LASER_DIAMETER, settings.getLaserDiameter());
         preferences.putDouble(DEPTH_PER_PASS, settings.getDepthPerPass());
         preferences.putInt(FEED_SPEED, settings.getFeedSpeed());
@@ -65,7 +66,6 @@ public class SettingsAdapter {
         preferences.putDouble(TOOL_DIAMETER, settings.getToolDiameter());
         preferences.putDouble(SAFE_HEIGHT, settings.getSafeHeight());
         preferences.putDouble(TOOL_STEP_OVER, settings.getToolStepOver());
-        preferences.putDouble(SPINDLE_SPEED, settings.getSpindleSpeed());
         preferences.putDouble(STOCK_THICKNESS, settings.getStockThickness());
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/LaserOutlinePathTest.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/LaserOutlinePathTest.java
@@ -1,11 +1,90 @@
 package com.willwinder.ugs.nbp.designer.io.gcode.toolpaths;
 
-import static org.junit.Assert.assertTrue;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Rectangle;
+import com.willwinder.ugs.nbp.designer.io.gcode.path.GcodePath;
+import com.willwinder.ugs.nbp.designer.io.gcode.path.Segment;
+import com.willwinder.ugs.nbp.designer.io.gcode.path.SegmentType;
+import com.willwinder.ugs.nbp.designer.model.Settings;
+import com.willwinder.ugs.nbp.designer.model.Size;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import org.junit.Test;
+
+import java.util.List;
 
 public class LaserOutlinePathTest {
     @Test
-    public void pocketOnRectangleWithHole() {
-       assertTrue(true);
+    public void outlineToolPathWithNoPassesShouldNotGenerateTheShape() {
+        Rectangle rectangle = new Rectangle(0,0);
+        rectangle.setFeedRate(100);
+        rectangle.setSpindleSpeed(100);
+        rectangle.setSize(new Size(10, 10));
+
+        Settings settings = new Settings();
+        settings.setMaxSpindleSpeed(10000);
+
+        LaserOutlineToolPath toolPath = new LaserOutlineToolPath(settings, rectangle);
+        toolPath.setStartDepth(-1);
+        toolPath.setTargetDepth(-1);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+
+        assertEquals(SegmentType.SEAM, segments.get(0).type);
+        assertNull(segments.get(0).point);
+        assertEquals(10000, segments.get(0).getSpindleSpeed(), 0.01);
+
+        assertEquals(1, segments.size());
+    }
+
+    @Test
+    public void outlineToolPathWithOnePass() {
+        Rectangle rectangle = new Rectangle(0,0);
+        rectangle.setFeedRate(500);
+        rectangle.setSpindleSpeed(50);
+        rectangle.setSize(new Size(10, 10));
+        rectangle.setPasses(1);
+
+        Settings settings = new Settings();
+        settings.setMaxSpindleSpeed(10000);
+
+        LaserOutlineToolPath toolPath = new LaserOutlineToolPath(settings, rectangle);
+        toolPath.setStartDepth(-1);
+        toolPath.setTargetDepth(-1);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+
+        // Start spindle
+        assertEquals(SegmentType.SEAM, segments.get(0).type);
+        assertNull(segments.get(0).point);
+        assertEquals(5000, segments.get(0).getSpindleSpeed(), 0.01);
+        assertEquals(500, segments.get(0).getFeedSpeed(), 0.01);
+
+        assertEquals(SegmentType.MOVE, segments.get(1).type);
+        assertEquals(0, segments.get(1).getPoint().getX(), 0.01);
+        assertEquals(0, segments.get(1).getPoint().getY(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(2).type);
+        assertEquals(0, segments.get(2).getPoint().getX(), 0.01);
+        assertEquals(0, segments.get(2).getPoint().getY(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(3).type);
+        assertEquals(0, segments.get(3).getPoint().getX(), 0.01);
+        assertEquals(10, segments.get(3).getPoint().getY(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(4).type);
+        assertEquals(10, segments.get(4).getPoint().getX(), 0.01);
+        assertEquals(10, segments.get(4).getPoint().getY(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(5).type);
+        assertEquals(10, segments.get(5).getPoint().getX(), 0.01);
+        assertEquals(0, segments.get(5).getPoint().getY(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(6).type);
+        assertEquals(0, segments.get(6).getPoint().getX(), 0.01);
+        assertEquals(0, segments.get(6).getPoint().getY(), 0.01);
+
+        assertEquals(7, segments.size());
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPathTest.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPathTest.java
@@ -97,4 +97,98 @@ public class OutlineToolPathTest {
 
         assertEquals(10, segments.size());
     }
+
+    @Test
+    public void toGcodePathShouldAddFeedRate() {
+        Rectangle rectangle = new Rectangle(0,0);
+        rectangle.setFeedRate(100);
+        rectangle.setSize(new Size(10, 10));
+        Settings settings = new Settings();
+        settings.setSafeHeight(10);
+
+        OutlineToolPath toolPath = new OutlineToolPath(settings, rectangle);
+        toolPath.setStartDepth(-1);
+        toolPath.setTargetDepth(-1);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(0).type);
+        assertFalse(segments.get(0).point.hasX());
+        assertFalse(segments.get(0).point.hasY());
+        assertEquals(10, segments.get(0).point.getZ(), 0.01);
+
+        // Move in XY-place
+        assertEquals(SegmentType.MOVE, segments.get(1).type);
+        assertEquals(0, segments.get(1).point.getX(), 0.01);
+        assertEquals(0, segments.get(1).point.getY(), 0.01);
+        assertFalse(segments.get(1).point.hasZ());
+
+        // Move to Z zero
+        assertEquals(SegmentType.MOVE, segments.get(2).type);
+        assertFalse(segments.get(2).point.hasX());
+        assertFalse(segments.get(2).point.hasY());
+        assertEquals(0, segments.get(2).point.getZ(), 0.01);
+
+        // Move into material
+        assertEquals(SegmentType.POINT, segments.get(3).type);
+        assertTrue(segments.get(3).point.hasX());
+        assertTrue(segments.get(3).point.hasY());
+        assertEquals(-1, segments.get(3).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(4).type);
+        assertEquals(0, segments.get(4).point.getX(), 0.01);
+        assertEquals(0, segments.get(4).point.getY(), 0.01);
+        assertEquals(-1, segments.get(4).point.getZ(), 0.01);
+        assertEquals(100, segments.get(4).getFeedSpeed(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(5).type);
+        assertEquals(0, segments.get(5).point.getX(), 0.01);
+        assertEquals(10, segments.get(5).point.getY(), 0.01);
+        assertEquals(-1, segments.get(5).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(7).type);
+        assertEquals(10, segments.get(7).point.getX(), 0.01);
+        assertEquals(0, segments.get(7).point.getY(), 0.01);
+        assertEquals(-1, segments.get(7).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(8).type);
+        assertEquals(0, segments.get(8).point.getX(), 0.01);
+        assertEquals(0, segments.get(8).point.getY(), 0.01);
+        assertEquals(-1, segments.get(8).point.getZ(), 0.01);
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(9).type);
+        assertFalse(segments.get(9).point.hasX());
+        assertFalse(segments.get(9).point.hasY());
+        assertEquals(10, segments.get(9).point.getZ(), 0.01);
+
+        assertEquals(10, segments.size());
+    }
+
+    @Test
+    public void toGcodePathShouldAddSpindleSpeed() {
+        Rectangle rectangle = new Rectangle(0,0);
+        rectangle.setFeedRate(100);
+        rectangle.setSpindleSpeed(100);
+        rectangle.setSize(new Size(10, 10));
+        Settings settings = new Settings();
+        settings.setSafeHeight(10);
+        settings.setMaxSpindleSpeed(10000);
+
+        OutlineToolPath toolPath = new OutlineToolPath(settings, rectangle);
+        toolPath.setStartDepth(-1);
+        toolPath.setTargetDepth(-1);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+
+        // Start spindle
+        assertEquals(SegmentType.SEAM, segments.get(0).type);
+        assertNull(segments.get(0).point);
+        assertEquals(10000, segments.get(0).getSpindleSpeed(), 0.01);
+
+        assertEquals(11, segments.size());
+    }
 }


### PR DESCRIPTION
The max spindle speed is now read from the controller and can be applied as a percentage on both milling and laser operations (it was previously stored on the project).

The feed rate can now also be set per shape.

![image](https://github.com/winder/Universal-G-Code-Sender/assets/8962024/80fc5d58-5e82-42fe-b602-53da65965353)


The max spindle speed will by default be read from the controller, but there is an option to set it manually by unchecking the "Detect max spindle speed":
![image](https://github.com/winder/Universal-G-Code-Sender/assets/8962024/5c3673aa-96fc-452f-9463-0815c3f806b7)
