### PR TITLE
Fixes for controller resets

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblController.java
@@ -169,11 +169,18 @@ public class GrblController extends AbstractController {
     }
 
     private void initialize() {
-        if (comm.areActiveCommands()) {
-            comm.cancelSend();
+        if (initializer.isInitializing()) {
+            logger.info("Already initializing, skipping");
+            return;
         }
-        setControllerState(ControllerState.CONNECTING);
 
+        if (comm.areActiveCommands()) {
+            messageService.dispatchMessage(MessageType.INFO, "*** Canceling current stream\n");
+            cancelCommands();
+            resetBuffers();
+        }
+
+        setControllerState(ControllerState.CONNECTING);
         ThreadHelper.invokeLater(() -> {
             positionPollTimer.stop();
             initializer.initialize();

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblControllerInitializer.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblControllerInitializer.java
@@ -6,13 +6,12 @@ import com.willwinder.universalgcodesender.firmware.grbl.commands.GetParserState
 import com.willwinder.universalgcodesender.firmware.grbl.commands.GetSettingsCommand;
 import com.willwinder.universalgcodesender.listeners.ControllerState;
 import com.willwinder.universalgcodesender.listeners.MessageType;
+import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndWaitForCompletion;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.willwinder.universalgcodesender.utils.ControllerUtils.sendAndWaitForCompletion;
 
 /**
  * A class that implements an initialization protocol for GRBL and keeps an internal state of the
@@ -50,6 +49,7 @@ public class GrblControllerInitializer implements IControllerInitializer {
         controller.setControllerState(ControllerState.CONNECTING);
         isInitializing.set(true);
         try {
+            // Some controllers need this wait before we can query its status
             Thread.sleep(2000);
             if (!GrblUtils.isControllerResponsive(controller)) {
                 isInitializing.set(false);
@@ -58,6 +58,8 @@ public class GrblControllerInitializer implements IControllerInitializer {
                 return false;
             }
 
+            // Some controllers need this wait before we can query the rest of its information
+            Thread.sleep(2000);
             fetchControllerVersion();
             fetchControllerState();
 
@@ -108,6 +110,10 @@ public class GrblControllerInitializer implements IControllerInitializer {
     @Override
     public boolean isInitialized() {
         return isInitialized.get();
+    }
+
+    public boolean isInitializing() {
+        return isInitializing.get();
     }
 
     public GrblVersion getVersion() {

--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblControllerInitializer.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblControllerInitializer.java
@@ -83,13 +83,15 @@ public class GrblControllerInitializer implements IControllerInitializer {
         }
     }
 
-    private void fetchControllerState() throws Exception {
+    private void fetchControllerState() throws InterruptedException {
+        controller.getMessageService().dispatchMessage(MessageType.INFO, "*** Fetching device settings\n");
         sendAndWaitForCompletion(controller, new GetSettingsCommand());
+        controller.getMessageService().dispatchMessage(MessageType.INFO, "*** Fetching device state\n");
         sendAndWaitForCompletion(controller, new GetParserStateCommand());
     }
 
-    private void fetchControllerVersion() throws Exception {
-        // Send commands to get the state of the controller
+    private void fetchControllerVersion() throws InterruptedException {
+        controller.getMessageService().dispatchMessage(MessageType.INFO, "*** Fetching device version\n");
         GetBuildInfoCommand getBuildInfoCommand = sendAndWaitForCompletion(controller, new GetBuildInfoCommand());
         Optional<GrblVersion> optionalVersion = getBuildInfoCommand.getVersion();
         if (optionalVersion.isEmpty()) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -1392,7 +1392,6 @@ public class GrblControllerTest {
         instance.openCommPort(getSettings().getConnectionDriver(), "/dev/port", 1234);
         Thread.sleep(50);
 
-        instance.rawResponseHandler(grblVersionString);
         return instance;
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblControllerTest.java
@@ -1167,7 +1167,27 @@ public class GrblControllerTest {
     }
 
     @Test
-    public void rawResponseHandlerOnVersionStringShouldResetStatus() throws Exception {
+    public void rawResponseHandlerOnVersionStringWhenSendingFileShouldCancelStream() throws Exception {
+        // Given
+        GrblController instance = initializeAndConnectController(VERSION_GRBL_1_1F);
+        instance.rawResponseHandler("<Run|MPos:0.000,0.000,0.000|FS:0,0|Pn:XYZ>");
+        assertEquals("We should be in sending mode", COMM_SENDING, instance.getCommunicatorState());
+        assertEquals(ControllerState.RUN, instance.getControllerStatus().getState());
+
+        // Simulate that there is an ongoing stream
+        mgc.areActiveCommands = true;
+
+        // When
+        instance.rawResponseHandler("Grbl " + VERSION_GRBL_1_1F);
+
+        // Then
+        assertEquals(1, mgc.numCancelSendCalls);
+        assertEquals(1, mgc.numResetBuffersCalls);
+        assertEquals(COMM_IDLE, instance.getCommunicatorState());
+    }
+
+    @Test
+    public void rawResponseHandlerOnVersionStringWhenNotSendingFileShouldNotCancelStream() throws Exception {
         // Given
         GrblController instance = initializeAndConnectController(VERSION_GRBL_1_1F);
         instance.rawResponseHandler("<Run|MPos:0.000,0.000,0.000|FS:0,0|Pn:XYZ>");
@@ -1178,8 +1198,10 @@ public class GrblControllerTest {
         instance.rawResponseHandler("Grbl " + VERSION_GRBL_1_1F);
 
         // Then
+        assertEquals(0, mgc.numCancelSendCalls);
+        assertEquals(0, mgc.numResetBuffersCalls);
         assertEquals(COMM_IDLE, instance.getCommunicatorState());
-        assertEquals(ControllerState.CONNECTING, instance.getControllerStatus().getState());
+
     }
 
     /**
@@ -1383,7 +1405,8 @@ public class GrblControllerTest {
      */
     private GrblController initializeAndConnectController(String grblVersionString) throws Exception {
         GrblControllerInitializer initializer = mock(GrblControllerInitializer.class);
-        when(initializer.isInitialized()).thenReturn(true);
+        when(initializer.isInitialized()).thenReturn(false);
+        when(initializer.isInitializing()).thenReturn(false);
 
         GrblVersion version = new GrblVersion("[VER:" + grblVersionString + "]");
         when(initializer.getVersion()).thenReturn(version);
@@ -1391,6 +1414,9 @@ public class GrblControllerTest {
         GrblController instance = new GrblController(mgc, initializer);
         instance.openCommPort(getSettings().getConnectionDriver(), "/dev/port", 1234);
         Thread.sleep(50);
+
+        when(initializer.isInitialized()).thenReturn(true);
+        when(initializer.isInitializing()).thenReturn(false);
 
         return instance;
     }

--- a/ugs-core/test/com/willwinder/universalgcodesender/mockobjects/MockGrblCommunicator.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/mockobjects/MockGrblCommunicator.java
@@ -56,6 +56,7 @@ public class MockGrblCommunicator extends GrblCommunicator {
     public int numPauseSendCalls;
     public int numResumeSendCalls;
     public int numCancelSendCalls;
+    public int numResetBuffersCalls;
     private IGcodeStreamReader gcodeStreamReader;
 
     public void resetInputsAndFunctionCalls() {
@@ -74,6 +75,7 @@ public class MockGrblCommunicator extends GrblCommunicator {
         this.numPauseSendCalls = 0;
         this.numResumeSendCalls = 0;
         this.numCancelSendCalls = 0;
+        this.numResetBuffersCalls = 0;
     }
     
     public MockGrblCommunicator() {
@@ -152,5 +154,10 @@ public class MockGrblCommunicator extends GrblCommunicator {
     @Override
     public void cancelSend() {
         this.numCancelSendCalls++;
+    }
+
+    @Override
+    public void resetBuffers() {
+        this.numResetBuffersCalls++;
     }
 }


### PR DESCRIPTION
Cancels the current stream if the controller is reset and prevent the initialization to trigger twice if already started.