### PR TITLE
Pendant timeout class mismatch

### DIFF
--- a/ugs-pendant/src/main/webapp/src/store/socketMiddleware.ts
+++ b/ugs-pendant/src/main/webapp/src/store/socketMiddleware.ts
@@ -13,7 +13,7 @@ import { RootState } from "./store";
 import { getSettings } from "./settingsSlice";
 import { fetchFileStatus } from "./fileStatusSlice";
 
-let fetchStatusTimer: number;
+let fetchStatusTimer: NodeJS.Timeout;
 let debounceTime = 500;
 const fetchSettingsDebounce = (
   store: MiddlewareAPI<ThunkDispatch<RootState, void, Action>, RootState>

--- a/ugs-pendant/src/main/webapp/src/store/socketMiddleware.ts
+++ b/ugs-pendant/src/main/webapp/src/store/socketMiddleware.ts
@@ -13,7 +13,7 @@ import { RootState } from "./store";
 import { getSettings } from "./settingsSlice";
 import { fetchFileStatus } from "./fileStatusSlice";
 
-let fetchStatusTimer: NodeJS.Timeout;
+let fetchStatusTimer: number;
 let debounceTime = 500;
 const fetchSettingsDebounce = (
   store: MiddlewareAPI<ThunkDispatch<RootState, void, Action>, RootState>
@@ -22,7 +22,7 @@ const fetchSettingsDebounce = (
     clearTimeout(fetchStatusTimer);
   }
 
-  fetchStatusTimer = setTimeout(() => {
+  fetchStatusTimer = window.setTimeout(() => {
     console.log("Fetching settings");
     store.dispatch(getSettings());
   }, debounceTime);

--- a/ugs-platform/application/nb-configuration.xml
+++ b/ugs-platform/application/nb-configuration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
+    </properties>
+</project-shared-configuration>


### PR DESCRIPTION
`mvn install` gave an error for ugs-pendant.

```
[INFO] --- frontend-maven-plugin:1.12.0:npm (build prod) @ ugs-pendant ---
[INFO] Running 'npm run build' in /home/erhannis/clones/Universal-G-Code-Sender/ugs-pendant/src/main/webapp
[INFO] 
[INFO] > webapp2@0.0.0 build
[INFO] > tsc && vite build
[INFO] 
[INFO] src/store/socketMiddleware.ts(25,3): error TS2322: Type 'Timeout' is not assignable to type 'number'.
```

I don't know why nobody else has had this problem, but replacing type `number` with `NodeJS.Timeout` made the error go away.