### PR TITLE
Clear ABC axes when probing

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/model/PartialPosition.java
@@ -372,6 +372,13 @@ public class PartialPosition {
             }
             return this;
         }
+
+        public Builder clearABC() {
+            this.a = null;
+            this.b = null;
+            this.c = null;
+            return this;
+        }
     }
 
     public String getFormattedGCode() {

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/SurfaceScanner.java
@@ -199,13 +199,17 @@ public class SurfaceScanner {
             }
 
             // Move to the XY start position
-            PartialPosition startPos = PartialPosition.builder(minXYZ).clearZ().build();
+            PartialPosition startPos = PartialPosition.builder(minXYZ)
+                    .clearZ()
+                    .clearABC()
+                    .build();
+
             String cmd = GcodeUtils.generateMoveCommand(
                     "G90G0", getProbeScanFeedRate(), startPos);
             logger.log(Level.INFO, "Move to start position {0}", new Object[]{startPos});
             backend.sendGcodeCommand(true, cmd);
 
-            // Move to the Y start position
+            // Move to the Z start position
             PartialPosition startHeight = PartialPosition.builder(maxXYZ.getUnits()).setZ(maxXYZ.getZ()).build();
             cmd = GcodeUtils.generateMoveCommand(
                     "G90G0", getProbeScanFeedRate(), startHeight);
@@ -226,7 +230,11 @@ public class SurfaceScanner {
             Position p = this.pendingPositions.peek();
 
             // Position over next probe position
-            PartialPosition startPos = PartialPosition.builder(p).clearZ().build();
+            PartialPosition startPos = PartialPosition.builder(p)
+                    .clearZ()
+                    .clearABC()
+                    .build();
+
             String cmd = GcodeUtils.generateMoveCommand(
                     "G90G0", getProbeScanFeedRate(), startPos);
             logger.log(Level.INFO, "MoveTo {0} {1}", new Object[]{startPos, cmd});


### PR DESCRIPTION
Fixes the issue with default settings causing the probing to send ABC-axes
Discussed in #2679