### PR TITLE
Resets the controller when initializing in check state

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -690,6 +690,11 @@ public class GrblUtils {
             throw new IllegalStateException("Could not query the device status");
         }
 
+        // Some commands are not available in check mode
+        if (statusCommand.getControllerStatus().getState() == ControllerState.CHECK) {
+            return false;
+        }
+
         // The controller is not up and running properly
         if (statusCommand.getControllerStatus().getState() == ControllerState.HOLD || statusCommand.getControllerStatus().getState() == ControllerState.ALARM) {
             try {

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCUtils.java
@@ -175,6 +175,11 @@ public class FluidNCUtils {
             throw new IllegalStateException("Could not query the device status");
         }
 
+        // Some commands are not available in check mode
+        if (statusCommand.getControllerStatus().getState() == ControllerState.CHECK) {
+            return false;
+        }
+
         // The controller is not up and running properly
         if (statusCommand.getControllerStatus().getState() == ControllerState.HOLD || statusCommand.getControllerStatus().getState() == ControllerState.DOOR || statusCommand.getControllerStatus().getState() == ControllerState.ALARM) {
             try {

--- a/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/firmware/fluidnc/FluidNCUtilsTest.java
@@ -161,6 +161,22 @@ public class FluidNCUtilsTest {
     }
 
     @Test
+    public void isControllerResponsiveWhenControllerInStateCheck() throws Exception {
+        IController controller = mock(IController.class);
+        when(controller.isCommOpen()).thenReturn(true);
+        MessageService messageService = mock(MessageService.class);
+
+        // Respond with status hold
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("<Check>");
+            return null;
+        }).when(controller).sendCommandImmediately(any(GetStatusCommand.class));
+
+        assertFalse(FluidNCUtils.isControllerResponsive(controller, messageService));
+    }
+
+    @Test
     public void isControllerResponsiveWhenControllerInStateDoor() throws Exception {
         IController controller = mock(IController.class);
         when(controller.isCommOpen()).thenReturn(true);


### PR DESCRIPTION
When connecting to older 8-bit controllers with GRBL it will always reset it. This does not happen on some newer 32-bit ones. If the controller was left in "Check-mode" some commands will not work during initialization. 

This fix will reset the controller to exit the check mode if this happens.

Fixes #2696 