### PR TITLE
Fix problem with arcs with negative radius

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserException.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/util/GcodeParserException.java
@@ -7,7 +7,11 @@ package com.willwinder.universalgcodesender.gcode.util;
  * @author wwinder
  */
 public class GcodeParserException extends Exception {
-    public GcodeParserException(String s) {
-        super(s);
+    public GcodeParserException(String message) {
+        super(message);
+    }
+
+    public GcodeParserException(String message, Throwable throwable) {
+        super(message, throwable);
     }
 }

--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/MathUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/MathUtils.java
@@ -39,7 +39,7 @@ public class MathUtils {
 
     /**
      * To find orientation of ordered triplet (p1, p2, p3).
-     * https://www.geeksforgeeks.org/orientation-3-ordered-points/
+     * <a href="https://www.geeksforgeeks.org/orientation-3-ordered-points/">orientation-3-ordered-points</a>
      *
      * @param p1 a point in a polygon
      * @param p2 a point in a polygon
@@ -142,6 +142,21 @@ public class MathUtils {
         }
 
         return Math.abs(d1 - d2) <= delta;
+    }
+
+    /**
+     * Normalizes an angle given in radians to make sure it is in the interval [0,2π]
+     *
+     * @param angle an angle in radians
+     * @return the normalized angle
+     */
+    public static double normalizeAngle(double angle) {
+        double twoPi = 2 * Math.PI;
+        angle = angle % twoPi;
+        if (angle < 0) {
+            angle += twoPi;
+        }
+        return angle;
     }
 
     /**

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/GcodeViewParse.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/GcodeViewParse.java
@@ -132,7 +132,6 @@ public class GcodeViewParse {
 
         // Save the state
         Position start = new Position(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, gp.getCurrentState().getUnits());
-        double spindleSpeed = 0;
 
         while (reader.getNumRowsRemaining() > 0) {
             GcodeCommand commandObject = reader.getNextCommand();
@@ -141,9 +140,8 @@ public class GcodeViewParse {
                 List<GcodeMeta> points = gp.addCommand(command, commandObject.getCommandNumber());
                 for (GcodeMeta meta : points) {
                     if (meta.point != null) {
-                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, lines, spindleSpeed);
+                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, lines);
                         start = meta.point.point();
-                        spindleSpeed = meta.point.getSpindleSpeed();
                     }
                 }
             }
@@ -176,7 +174,6 @@ public class GcodeViewParse {
 
         // Save the state
         Position start = new Position(Double.NaN, Double.NaN, Double.NaN, gp.getCurrentState().getUnits());
-        double spindleSpeed = 0;
 
         for (String s : gcode) {
             List<String> commands = gp.preprocessCommand(s, gp.getCurrentState());
@@ -184,8 +181,7 @@ public class GcodeViewParse {
                 List<GcodeMeta> points = gp.addCommand(command);
                 for (GcodeMeta meta : points) {
                     if (meta.point != null) {
-                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, lines, spindleSpeed);
-                        spindleSpeed = meta.point.getSpindleSpeed();
+                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, lines);
 
                         // if the last set point is in a different or unknown unit, crate a new point-instance with the correct unit set
                         if (start.getUnits() != UnitUtils.Units.MM && gp.getCurrentState().isMetric) {

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtilsTest.java
@@ -78,12 +78,12 @@ public class GcodePreprocessorUtilsTest {
         String expResult;
         String result;
 
-        command   = "some command ;comment";
+        command = "some command ;comment";
         expResult = "comment";
         result = GcodePreprocessorUtils.parseComment(command);
         assertEquals(expResult, result);
 
-        command   = "some (comment here) command ;comment";
+        command = "some (comment here) command ;comment";
         expResult = "comment here";
         result = GcodePreprocessorUtils.parseComment(command);
         assertEquals(expResult, result);
@@ -171,7 +171,7 @@ public class GcodePreprocessorUtilsTest {
     }
 
     @Test
-    public void parseCoord() throws Exception {
+    public void parseCoord() {
         List<String> args = ImmutableList.of("G10", "G3", "X100", "y-.5", "Z0.25");
         assertThat(GcodePreprocessorUtils.parseCoord(args, 'x')).isEqualTo(100);
         assertThat(GcodePreprocessorUtils.parseCoord(args, 'y')).isEqualTo(-0.5);
@@ -183,7 +183,7 @@ public class GcodePreprocessorUtilsTest {
     }
 
     @Test
-    public void extractWord() throws Exception {
+    public void extractWord() {
         List<String> args = ImmutableList.of("G10", "G3", "X100", "y-.5", "Z0.25");
         assertThat(GcodePreprocessorUtils.extractWord(args, 'x')).isEqualTo("X100");
         assertThat(GcodePreprocessorUtils.extractWord(args, 'y')).isEqualTo("y-.5");
@@ -195,14 +195,14 @@ public class GcodePreprocessorUtilsTest {
     }
 
     @Test
-    public void testGetGcodes() throws Exception {
+    public void testGetGcodes() {
         List<String> args = ImmutableList.of("F100", "M30", "G1", "G2", "F100", "G3", "G92.1", "G38.2", "S1300");
         Set<Code> codes = GcodePreprocessorUtils.getGCodes(args);
         assertThat(codes).containsExactly(G1, G2, G3, G92_1, G38_2);
     }
 
     @Test
-    public void testExtractMotion() throws Exception {
+    public void testExtractMotion() {
         assertThat(GcodePreprocessorUtils.extractMotion(G3, "G17 G03 X0 Y12 I0.25 J-0.25 K1.99 F100"))
                 .hasFieldOrPropertyWithValue("extracted", "G03X0Y12I0.25J-0.25K1.99")
                 .hasFieldOrPropertyWithValue("remainder", "G17F100");
@@ -274,7 +274,7 @@ public class GcodePreprocessorUtilsTest {
     }
 
     @Test
-    public void processCommandWithBlockComments() throws Exception {
+    public void processCommandWithBlockComments() {
         List<String> splitted = GcodePreprocessorUtils.splitCommand("(hello world)G3");
         assertThat(splitted.size()).isEqualTo(2);
 
@@ -312,6 +312,79 @@ public class GcodePreprocessorUtilsTest {
     }
 
     @Test
+    public void generatePointsAlongArcBDringShouldHandleNegativeRadius() {
+        double radius = -10;
+        Position start = new Position(10, 10, 0, MM);
+        Position end = new Position(20, 0, 0, MM);
+        Position center = GcodePreprocessorUtils.convertRToCenter(start, end, radius, false, true, new PlaneFormatter(Plane.XY));
+
+        List<Position> points = GcodePreprocessorUtils.generatePointsAlongArcBDring(start, end, center, true, radius, 10, 10, new PlaneFormatter(Plane.XY));
+        assertPosition(points.get(0), 10, 10, 0);
+        assertPosition(points.get(1), 14.122, 18.090, 0);
+        assertPosition(points.get(2), 23.090, 19.510, 0);
+        assertPosition(points.get(3), 29.510, 13.090, 0);
+        assertPosition(points.get(4), 28.090, 4.122, 0);
+        assertPosition(points.get(5), 20, 0, 0);
+        assertEquals(6, points.size());
+        assertTrue("Coordinates are generated in wrong units", points.stream().allMatch(p -> p.getUnits() == MM));
+    }
+
+    static void assertPosition(Position position, double x, double y, double z) {
+        assertEquals(position.x, x, 0.001);
+        assertEquals(position.y, y, 0.001);
+        assertEquals(position.z, z, 0.001);
+    }
+
+    @Test
+    public void getAngle() {
+        Position center = new Position(0, 0, 0, MM);
+        assertEquals(0, GcodePreprocessorUtils.getAngle(new Position(-10, 0, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+        assertEquals(Math.PI / 2, GcodePreprocessorUtils.getAngle(new Position(0, -10, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+        assertEquals(Math.PI, GcodePreprocessorUtils.getAngle(new Position(10, 0, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+        assertEquals(Math.PI / 2 + Math.PI, GcodePreprocessorUtils.getAngle(new Position(0, 10, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+    }
+
+    @Test
+    public void getAngleWithCenterOffset() {
+        Position center = new Position(10, 10, 0, MM);
+        assertEquals(0, GcodePreprocessorUtils.getAngle(new Position(0, 10, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+        assertEquals(Math.PI / 2, GcodePreprocessorUtils.getAngle(new Position(10, 0, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+        assertEquals(Math.PI, GcodePreprocessorUtils.getAngle(new Position(20, 10, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+        assertEquals(Math.PI / 2 + Math.PI, GcodePreprocessorUtils.getAngle(new Position(10, 20, 0, MM), center, new PlaneFormatter(Plane.XY)), 0.01);
+    }
+
+
+    @Test
+    public void convertRToCenterShouldFindCenterOnArc() {
+        Position start = new Position(10, 10, 0, MM);
+        Position end = new Position(20, 0, 0, MM);
+        double radius = 10;
+        Position center = GcodePreprocessorUtils.convertRToCenter(start, end, radius, false, true, new PlaneFormatter(Plane.XY));
+        assertThat(center).isEqualTo(new Position(10, 0, 0, 0, 0, 0, MM));
+    }
+
+    @Test
+    public void convertRToCenterShouldFindCenterWithNegativeRadius() {
+        Position start = new Position(10, 10, 0, MM);
+        Position end = new Position(20, 0, 0, MM);
+        double radius = -10;
+        Position center = GcodePreprocessorUtils.convertRToCenter(start, end, radius, false, true, new PlaneFormatter(Plane.XY));
+        assertThat(center).isEqualTo(new Position(20, 10, 0, 0, 0, 0, MM));
+    }
+
+    @Test
+    public void calculateNumberOfPointsToExpandShouldCalculate() {
+        int numberOfPoints = GcodePreprocessorUtils.calculateNumberOfPointsToExpand(5, MM, 1, 1, Math.PI);
+        assertEquals(16, numberOfPoints);
+    }
+
+    @Test
+    public void calculateNumberOfPointsToExpandShouldHandleNegativeRadius() {
+        int numberOfPoints = GcodePreprocessorUtils.calculateNumberOfPointsToExpand(-5, MM, 1, 1, Math.PI);
+        assertEquals(16, numberOfPoints);
+    }
+
+    @Test
     public void generatePointsAlongArcBDringShouldGenerateAnArcWhenPositionsAreInInches() {
         Position start = new Position(0, 0, 0, UnitUtils.Units.INCH);
         Position end = new Position(10 * UnitUtils.scaleUnits(MM, INCH), 0, 0, UnitUtils.Units.INCH);
@@ -341,7 +414,7 @@ public class GcodePreprocessorUtilsTest {
     @Test
     public void updatePointWithCommandShouldSetPositionIfOriginalIsNaN() {
         Position position = new Position(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, MM);
-        Position newPosition = GcodePreprocessorUtils.updatePointWithCommand(position, 1, 2, 3, 4, 5,6, false);
+        Position newPosition = GcodePreprocessorUtils.updatePointWithCommand(position, 1, 2, 3, 4, 5, 6, false);
         assertEquals(1, newPosition.getX(), 0.01);
         assertEquals(2, newPosition.getY(), 0.01);
         assertEquals(3, newPosition.getZ(), 0.01);
@@ -354,7 +427,7 @@ public class GcodePreprocessorUtilsTest {
     @Test
     public void updatePointWithCommandShouldAddToPosition() {
         Position position = new Position(1, 2, 3, 4, 5, 6, MM);
-        Position newPosition = GcodePreprocessorUtils.updatePointWithCommand(position, 1, 2, 3, 4, 5,6, false);
+        Position newPosition = GcodePreprocessorUtils.updatePointWithCommand(position, 1, 2, 3, 4, 5, 6, false);
         assertEquals(2, newPosition.getX(), 0.01);
         assertEquals(4, newPosition.getY(), 0.01);
         assertEquals(6, newPosition.getZ(), 0.01);

--- a/ugs-core/test/com/willwinder/universalgcodesender/utils/MathUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/utils/MathUtilsTest.java
@@ -20,13 +20,14 @@ package com.willwinder.universalgcodesender.utils;
 
 import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.UnitUtils;
+import static com.willwinder.universalgcodesender.utils.MathUtils.isEqual;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static com.willwinder.universalgcodesender.utils.MathUtils.isEqual;
-import static org.junit.Assert.*;
 
 /**
  * @author Joacim Breiler
@@ -99,5 +100,13 @@ public class MathUtilsTest {
         assertTrue(isEqual(0.9999, 1.0, 0.0001));
         assertFalse(isEqual(0.9999, 1.0, 0.00001));
 
+    }
+
+    @Test
+    public void normalizeAngle() {
+        assertEquals(Math.PI, MathUtils.normalizeAngle(Math.PI), 0.001);
+        assertEquals(Math.PI, MathUtils.normalizeAngle(Math.PI * 3), 0.001);
+        assertEquals(Math.PI, MathUtils.normalizeAngle(-Math.PI), 0.001);
+        assertEquals(0, MathUtils.normalizeAngle(0), 0.001);
     }
 }

--- a/ugs-core/test/com/willwinder/universalgcodesender/visualizer/VisualizerUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/visualizer/VisualizerUtilsTest.java
@@ -80,7 +80,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result, 0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(1, result.size());
         assertPosition(0, 0, 10, Double.NaN, Double.NaN, Double.NaN, result.get(0).getEnd());
@@ -93,7 +93,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result, 0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(1, result.size());
         assertPosition(0, 0, 10, Double.NaN, Double.NaN, Double.NaN, result.get(0).getEnd());
@@ -106,7 +106,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(1, result.size());
         assertPosition(0, 0, 10, 0.0, Double.NaN, Double.NaN, result.get(0).getEnd());
@@ -119,7 +119,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(3, result.size());
         assertPosition(0, 0, 10, 0, Double.NaN, Double.NaN, result.get(0).getEnd());
@@ -134,7 +134,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
         assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
@@ -150,7 +150,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
         assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
@@ -166,7 +166,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
         assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
@@ -182,7 +182,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
         assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
@@ -198,7 +198,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(19, result.size());
         assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());
@@ -214,7 +214,7 @@ public class VisualizerUtilsTest {
         PointSegment endSegment = new PointSegment(endPosition, 0);
 
         List<LineSegment> result = new ArrayList<>();
-        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result,0);
+        VisualizerUtils.expandRotationalLineSegment(startPosition, endSegment, result);
 
         assertEquals(7, result.size());
         assertPosition(0, 0, 10, 0, 0, 0, result.get(0).getEnd());

--- a/ugs-core/test/com/willwinder/universalgcodesender/visualizer/VisualizerUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/visualizer/VisualizerUtilsTest.java
@@ -3,12 +3,11 @@ package com.willwinder.universalgcodesender.visualizer;
 import com.willwinder.universalgcodesender.model.Position;
 import com.willwinder.universalgcodesender.model.UnitUtils;
 import com.willwinder.universalgcodesender.types.PointSegment;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class VisualizerUtilsTest {
 


### PR DESCRIPTION
Fixes a problem where a program like this could not be loaded:
```
G17 G21 G90 G94 G54 M0 M5 M9
G0 X10  Y10.0   F8.0
G02 X20 Y0      R-10
```
NCViewer displays it like this:
![image](https://github.com/user-attachments/assets/c36bce3b-e241-4709-98f4-f137c55a5539)

There were two problems. A check was in place to prevent negative radius values which was removed. But we also needed to handle the special case to invert the angle when there is a negative radius. Of there these fixes it now displays correctly with:

![image](https://github.com/user-attachments/assets/d612ceda-c363-4b29-ab19-7550ea34a68c)

Also prevent spamming error dialogs when loading gcode with multiple errors. Removed unused parameter for spindle speed.

Relates to #2710