### PR TITLE
Restart controller when in DOOR-state

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/GrblUtils.java
@@ -696,7 +696,7 @@ public class GrblUtils {
         }
 
         // The controller is not up and running properly
-        if (statusCommand.getControllerStatus().getState() == ControllerState.HOLD || statusCommand.getControllerStatus().getState() == ControllerState.ALARM) {
+        if (statusCommand.getControllerStatus().getState() == ControllerState.DOOR || statusCommand.getControllerStatus().getState() == ControllerState.HOLD || statusCommand.getControllerStatus().getState() == ControllerState.ALARM) {
             try {
                 // Figure out if it is still responsive even if it is in HOLD or ALARM state
                 sendAndWaitForCompletion(controller, new GrblSystemCommand(""));

--- a/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/GrblUtilsTest.java
@@ -771,4 +771,21 @@ public class GrblUtilsTest {
 
         assertTrue(GrblUtils.isControllerResponsive(controller));
     }
+
+    @Test
+    public void isControllerResponsiveWhenControllerInStateDoor() throws Exception {
+        GrblController controller = mock(GrblController.class);
+        when(controller.isCommOpen()).thenReturn(true);
+        MessageService messageService = mock(MessageService.class);
+        when(controller.getMessageService()).thenReturn(messageService);
+
+        // Respond with status hold
+        doAnswer(answer -> {
+            GcodeCommand command = answer.getArgument(0, GcodeCommand.class);
+            command.appendResponse("<Door>");
+            return null;
+        }).when(controller).sendCommandImmediately(any(GcodeCommand.class));
+
+        assertFalse(GrblUtils.isControllerResponsive(controller));
+    }
 }


### PR DESCRIPTION
When connecting to a GRBL controller which is in DOOR state it will not accept any other commands which will prevent it from intializing. With older hardware it will always reset on connection, but newer 32-bit boards will not which will not make it possible to connect.

Added a reset upon connecting if the controller is in DOOR-state.

See discussion in #2737