### PR TITLE
Force calls which will update the UI to execute in the swing thread.

### DIFF
--- a/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
+++ b/ugs-platform/ugs-platform-gcode-editor/src/main/java/com/willwinder/ugs/nbp/editor/SourceMultiviewElement.java
@@ -117,11 +117,13 @@ public class SourceMultiviewElement extends MultiViewEditorElement implements UG
 
     @Override
     public void UGSEvent(UGSEvent ugsEvent) {
-        if (ugsEvent instanceof ControllerStateEvent) {
-            setEditable();
-        } else if (ugsEvent instanceof CommandEvent && ((CommandEvent) ugsEvent).getCommandEventType() == CommandEventType.COMMAND_COMPLETE) {
-            followLineUpdater.updateCurrentLine(obj, ((CommandEvent) ugsEvent).getCommand().getCommandNumber());
-        }
+        SwingUtilities.invokeLater(() -> {
+            if (ugsEvent instanceof ControllerStateEvent) {
+                setEditable();
+            } else if (ugsEvent instanceof CommandEvent && ((CommandEvent) ugsEvent).getCommandEventType() == CommandEventType.COMMAND_COMPLETE) {
+                followLineUpdater.updateCurrentLine(obj, ((CommandEvent) ugsEvent).getCommand().getCommandNumber());             
+            }
+        });
     }
 
     private void setEditable() {

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/DesignerTopComponent.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.Serial;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.SwingUtilities;
 
 /**
  * A designer component for editing vector graphics that will be converted to gcode.
@@ -179,15 +180,19 @@ public class DesignerTopComponent extends TopComponent implements UndoManagerLis
 
     @Override
     public void onChanged() {
-        dataObject.setModified(true);
+        SwingUtilities.invokeLater(() -> {        
+            dataObject.setModified(true);
+        });
     }
 
     @Override
     public void onSelectionEvent(SelectionEvent selectionEvent) {
-        controller.getDrawing().repaint();
-        PlatformUtils.openSettings(controller);
-        PlatformUtils.openEntitesTree(controller);
-        requestActive();
+        SwingUtilities.invokeLater(() -> {
+            controller.getDrawing().repaint();
+            PlatformUtils.openSettings(controller);
+            PlatformUtils.openEntitesTree(controller);            
+            requestActive();
+        });
     }
 
     @Override


### PR DESCRIPTION
- Wrapped calls to unsafe methods with SwingUtilities.invokeLater
- Fixed issues causing:  https://github.com/winder/Universal-G-Code-Sender/issues/2746#issue-2988180880