### PR TITLE
Added ability to remove entity from generated g-code without loosing cut settings

### DIFF
--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntitySetting.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntitySetting.java
@@ -43,7 +43,8 @@ public enum EntitySetting {
     PASSES("Passes"),
     FEED_RATE("Feed rate"),
     LEAD_IN_PERCENT("Lead in percent"),
-    LEAD_OUT_PERCENT("Lead out percent");
+    LEAD_OUT_PERCENT("Lead out percent"),
+    INCLUDE_IN_EXPORT("Include in export");
 
     public static final List<EntitySetting> DEFAULT_ENDMILL_SETTINGS = List.of(
             EntitySetting.CUT_TYPE,
@@ -59,7 +60,8 @@ public enum EntitySetting {
             EntitySetting.TARGET_DEPTH,
             EntitySetting.SPINDLE_SPEED,
             EntitySetting.FEED_RATE,
-            EntitySetting.TEXT);
+            EntitySetting.TEXT,
+            EntitySetting.INCLUDE_IN_EXPORT);
 
     public static final List<EntitySetting> DEFAULT_SURFACE_SETTINGS = List.of(
             EntitySetting.CUT_TYPE,
@@ -77,7 +79,8 @@ public enum EntitySetting {
             EntitySetting.FEED_RATE,
             EntitySetting.TEXT,
             EntitySetting.LEAD_IN_PERCENT,
-            EntitySetting.LEAD_OUT_PERCENT);
+            EntitySetting.LEAD_OUT_PERCENT,
+            EntitySetting.INCLUDE_IN_EXPORT);
 
     public static final List<EntitySetting> DEFAULT_LASER_SETTINGS = List.of(
             EntitySetting.CUT_TYPE,
@@ -92,7 +95,8 @@ public enum EntitySetting {
             EntitySetting.SPINDLE_SPEED,
             EntitySetting.PASSES,
             EntitySetting.FEED_RATE,
-            EntitySetting.TEXT);
+            EntitySetting.TEXT,
+            EntitySetting.INCLUDE_IN_EXPORT);
 
     private final String label;
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/AbstractCuttable.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/AbstractCuttable.java
@@ -53,7 +53,8 @@ public abstract class AbstractCuttable extends AbstractEntity implements Cuttabl
     private int passes;
     private int feedRate;
     private boolean isHidden = false;
-
+    private boolean includeInExport = true;    
+    
     protected AbstractCuttable() {
         this(0, 0);
     }
@@ -259,7 +260,8 @@ public abstract class AbstractCuttable extends AbstractEntity implements Cuttabl
                 EntitySetting.PASSES,
                 EntitySetting.FEED_RATE,
                 EntitySetting.LEAD_IN_PERCENT,
-                EntitySetting.LEAD_OUT_PERCENT
+                EntitySetting.LEAD_OUT_PERCENT,
+                EntitySetting.INCLUDE_IN_EXPORT
         );
     }
 
@@ -295,6 +297,7 @@ public abstract class AbstractCuttable extends AbstractEntity implements Cuttabl
         copy.setSpindleSpeed(getSpindleSpeed());
         copy.setPasses(getPasses());
         copy.setHidden(isHidden());
+        copy.setIncludeInExport(getIncludeInExport());
     }
 
     @Override
@@ -305,5 +308,16 @@ public abstract class AbstractCuttable extends AbstractEntity implements Cuttabl
     @Override
     public void setEntitySetting(EntitySetting entitySetting, Object value) {
         entitySettings.setEntitySetting(entitySetting, value);
+    }
+    
+    @Override
+    public boolean getIncludeInExport() {
+        return includeInExport;
+    }
+
+    @Override
+    public void setIncludeInExport(boolean value) {
+        includeInExport = value;
+        notifyEvent(new EntityEvent(this, EventType.SETTINGS_CHANGED));
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Cuttable.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Cuttable.java
@@ -162,4 +162,17 @@ public interface Cuttable extends Entity {
      */
     int getLeadOutPercent();
 
+    /**
+     * If value is false then the cuttable will not be included in the exported g-code
+     *
+     * @param value the percentage value
+     */
+    void setIncludeInExport(boolean value);
+
+    /**
+     * Returns true if true then this cuttable will be included in the exported G-Code
+     *
+     * @return true if true then this cuttable will be included in the exported G-Code
+     */
+    boolean getIncludeInExport(); 
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/CuttableEntitySettings.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/CuttableEntitySettings.java
@@ -23,6 +23,7 @@ public class CuttableEntitySettings {
             case FEED_RATE -> Optional.of(cuttable.getFeedRate());
             case LEAD_IN_PERCENT -> Optional.of(cuttable.getLeadInPercent());
             case LEAD_OUT_PERCENT -> Optional.of(cuttable.getLeadOutPercent());
+            case INCLUDE_IN_EXPORT -> Optional.of(cuttable.getIncludeInExport());
             default -> Optional.empty();
         };
     }
@@ -37,6 +38,8 @@ public class CuttableEntitySettings {
             case FEED_RATE -> cuttable.setFeedRate(((Double) value).intValue());
             case LEAD_IN_PERCENT -> cuttable.setLeadInPercent((Integer) value);
             case LEAD_OUT_PERCENT -> cuttable.setLeadOutPercent((Integer) value);
+            case INCLUDE_IN_EXPORT -> cuttable.setIncludeInExport((Boolean) value);
+            
             default -> LOGGER.info("Do not know how to set " + entitySetting + " to " + value);
         }
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Group.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Group.java
@@ -184,7 +184,26 @@ public class Group extends EntityGroup implements Cuttable {
             }
         });
     }
+    @Override
+    public boolean getIncludeInExport() {
+        for (Entity child : getChildren()) {
+            if (child instanceof Cuttable cuttable) {
+                if (cuttable.getIncludeInExport()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
+    @Override
+    public void setIncludeInExport(boolean value) {
+        getChildren().forEach(child -> {
+            if (child instanceof Cuttable cuttable) {
+                cuttable.setIncludeInExport(value);
+            }
+        });
+    }
     @Override
     public boolean isHidden() {
         return getCuttableStream()
@@ -274,7 +293,12 @@ public class Group extends EntityGroup implements Cuttable {
             result = new ArrayList<>(result);
             result.remove(EntitySetting.LEAD_OUT_PERCENT);
         }
-
+        
+        if (getCuttableStream().map(Cuttable::getIncludeInExport).distinct().toList().size() > 1) {
+            result = new ArrayList<>(result);
+            result.remove(EntitySetting.INCLUDE_IN_EXPORT);
+        }
+        
         return result;
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/FieldEventDispatcher.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/FieldEventDispatcher.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.JCheckBox;
 
 
 /**
@@ -140,7 +141,14 @@ public class FieldEventDispatcher {
         componentsMap.put(entitySetting, component);
         component.addItemListener(l -> updateValue(entitySetting, l.getItem()));
     }
-
+    
+    public void registerListener(EntitySetting entitySetting, JCheckBox component) {
+        componentsMap.put(entitySetting, component);
+        component.addActionListener((e) -> {
+            updateValue(entitySetting, component.isSelected());
+        });
+    }
+    
     private void valueUpdated(PropertyChangeEvent propertyChangeEvent) {
         Object source = propertyChangeEvent.getSource();
         componentsMap.entrySet()

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsModel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsModel.java
@@ -61,6 +61,7 @@ public class SelectionSettingsModel implements Serializable {
             case FEED_RATE -> getFeedRate();
             case LEAD_IN_PERCENT -> getLeadInPercent();
             case LEAD_OUT_PERCENT -> getLeadOutPercent();
+            case INCLUDE_IN_EXPORT -> getIncludeInExport();
             default -> throw new SelectionSettingsModelException("Unknown setting " + key);
         };
     }
@@ -145,7 +146,16 @@ public class SelectionSettingsModel implements Serializable {
             notifyListeners(EntitySetting.LEAD_OUT_PERCENT);
         }
     }
+    public boolean getIncludeInExport() {
+        return (Boolean) settings.getOrDefault(EntitySetting.INCLUDE_IN_EXPORT, true);
+    }
 
+    public void setIncludeInExport(boolean aValue) {
+        if (getIncludeInExport() != aValue) {
+            settings.put(EntitySetting.INCLUDE_IN_EXPORT, aValue);
+            notifyListeners(EntitySetting.INCLUDE_IN_EXPORT);
+        }
+    }
     private void notifyListeners(EntitySetting setting) {
         listeners.forEach(l -> l.onModelUpdate(setting));
     }
@@ -163,6 +173,7 @@ public class SelectionSettingsModel implements Serializable {
         setFeedRate(0);
         setLeadInPercent(0);
         setText("");
+        setIncludeInExport(true);        
         setFontFamily(Font.SANS_SERIF);
     }
 
@@ -374,6 +385,9 @@ public class SelectionSettingsModel implements Serializable {
 
         if (settings.contains(EntitySetting.LEAD_OUT_PERCENT)) {
             setLeadOutPercent(selectionGroup.getLeadOutPercent());
+        }
+        if (settings.contains(EntitySetting.INCLUDE_IN_EXPORT)) {
+            setIncludeInExport(selectionGroup.getIncludeInExport());
         }
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsPanel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsPanel.java
@@ -47,6 +47,7 @@ import javax.swing.JToggleButton;
 import javax.swing.SwingConstants;
 import java.awt.geom.Point2D;
 import java.util.Arrays;
+import javax.swing.JCheckBox;
 
 /**
  * @author Joacim Breiler
@@ -213,8 +214,23 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
         fieldEventDispatcher.registerListener(EntitySetting.TARGET_DEPTH, targetDepthSpinner);
         add(targetDepthSpinner, FIELD_CONSTRAINTS + ", spanx");
         setEnabled(false);
+        
+        targetDepthSpinner.setPreferredSize(targetDepthSpinner.getPreferredSize());
+        fieldEventDispatcher.registerListener(EntitySetting.TARGET_DEPTH, targetDepthSpinner);
+        add(targetDepthSpinner, FIELD_CONSTRAINTS + ", spanx");
+        setEnabled(false);
+        
+        includeInExport = new JCheckBox();
+        includeInExport.setSelected(true);
+        fieldEventDispatcher.registerListener(EntitySetting.INCLUDE_IN_EXPORT, includeInExport);
+        includeInExportLabel = createAndAddLabel(EntitySetting.INCLUDE_IN_EXPORT);
+        add(includeInExport, FIELD_CONSTRAINTS + ", spanx");
+        
     }
-
+    private JLabel includeInExportLabel;
+    
+    private JCheckBox includeInExport;
+    
     private void setController(Controller controller) {
         this.controller = controller;
         this.controller.getSelectionManager().addSelectionListener(this);
@@ -343,7 +359,11 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
         } else if (entitySetting == EntitySetting.LEAD_OUT_PERCENT) {
             leadOutPercentSlider.setValue(model.getLeadOutPercent());
             selectionGroup.setLeadOutPercent(model.getLeadOutPercent());
+        } else if (entitySetting == EntitySetting.INCLUDE_IN_EXPORT) {
+            includeInExport.setSelected(model.getIncludeInExport());
+            selectionGroup.setIncludeInExport(model.getIncludeInExport());
         }
+
 
 
         handleComponentVisibility(selectionGroup);
@@ -361,7 +381,9 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
         startDepthLabel.setEnabled(hasCutTypeSelection);
         targetDepthSpinner.setEnabled(hasCutTypeSelection);
         targetDepthLabel.setEnabled(hasCutTypeSelection);
-
+        includeInExport.setVisible(hasCutType);
+        includeInExportLabel.setVisible(hasCutType);
+        
         boolean isTextCuttable = selectionHasSetting(selectionGroup, EntitySetting.TEXT);
         textTextField.setVisible(isTextCuttable);
         textLabel.setVisible(isTextCuttable);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/SimpleGcodeRouter.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/SimpleGcodeRouter.java
@@ -87,57 +87,61 @@ public class SimpleGcodeRouter {
     private GcodePath getGcodePathFromCuttables(List<Cuttable> cuttables) {
         GcodePath gcodePath = new GcodePath();
         int index = 0;
+        
         for (Cuttable cuttable : cuttables) {
+            
             index++;
             gcodePath.addSegment(new Segment(" " + cuttable.getName() + " - " + cuttable.getCutType().getName() + " (" + index + "/" + cuttables.size() + ")" ));
-            switch (cuttable.getCutType()) {
-                case POCKET:
-                    PocketToolPath simplePocket = new PocketToolPath(settings, cuttable);
-                    simplePocket.setStartDepth(cuttable.getStartDepth());
-                    simplePocket.setTargetDepth(cuttable.getTargetDepth());
-                    simplePocket.appendGcodePath(gcodePath, settings);
-                    break;
-                case SURFACE:
-                    SurfaceToolPath surfaceToolPath = new SurfaceToolPath(settings, cuttable);
-                    surfaceToolPath.setStartDepth(cuttable.getStartDepth());
-                    surfaceToolPath.setTargetDepth(cuttable.getTargetDepth());
-                    surfaceToolPath.appendGcodePath(gcodePath, settings);
-                    break;
-                case OUTSIDE_PATH:
-                    OutlineToolPath simpleOutsidePath = new OutlineToolPath(settings, cuttable);
-                    simpleOutsidePath.setOffset(settings.getToolDiameter() / 2d);
-                    simpleOutsidePath.setStartDepth(cuttable.getStartDepth());
-                    simpleOutsidePath.setTargetDepth(cuttable.getTargetDepth());
-                    simpleOutsidePath.appendGcodePath(gcodePath, settings);
-                    break;
-                case INSIDE_PATH:
-                    OutlineToolPath simpleInsidePath = new OutlineToolPath(settings, cuttable);
-                    simpleInsidePath.setOffset(-settings.getToolDiameter() / 2d);
-                    simpleInsidePath.setStartDepth(cuttable.getStartDepth());
-                    simpleInsidePath.setTargetDepth(cuttable.getTargetDepth());
-                    simpleInsidePath.appendGcodePath(gcodePath, settings);
-                    break;
-                case ON_PATH:
-                    OutlineToolPath simpleOnPath = new OutlineToolPath(settings, cuttable);
-                    simpleOnPath.setStartDepth(cuttable.getStartDepth());
-                    simpleOnPath.setTargetDepth(cuttable.getTargetDepth());
-                    simpleOnPath.appendGcodePath(gcodePath, settings);
-                    break;
-                case CENTER_DRILL:
-                    DrillCenterToolPath drillToolPath = new DrillCenterToolPath(settings, cuttable);
-                    drillToolPath.setStartDepth(cuttable.getStartDepth());
-                    drillToolPath.setTargetDepth(cuttable.getTargetDepth());
-                    drillToolPath.appendGcodePath(gcodePath, settings);
-                    break;
-                case LASER_ON_PATH:
-                    LaserOutlineToolPath laserOutlineToolPath = new LaserOutlineToolPath(settings, cuttable);
-                    laserOutlineToolPath.appendGcodePath(gcodePath, settings);
-                    break;
-                case LASER_FILL:
-                    LaserFillToolPath laserFillToolPath = new LaserFillToolPath(settings, cuttable);
-                    laserFillToolPath.appendGcodePath(gcodePath, settings);
-                    break;
-                default:
+            if (cuttable.getIncludeInExport()) {                            
+                switch (cuttable.getCutType()) {
+                    case POCKET:
+                        PocketToolPath simplePocket = new PocketToolPath(settings, cuttable);
+                        simplePocket.setStartDepth(cuttable.getStartDepth());
+                        simplePocket.setTargetDepth(cuttable.getTargetDepth());
+                        simplePocket.appendGcodePath(gcodePath, settings);
+                        break;
+                    case SURFACE:
+                        SurfaceToolPath surfaceToolPath = new SurfaceToolPath(settings, cuttable);
+                        surfaceToolPath.setStartDepth(cuttable.getStartDepth());
+                        surfaceToolPath.setTargetDepth(cuttable.getTargetDepth());
+                        surfaceToolPath.appendGcodePath(gcodePath, settings);
+                        break;
+                    case OUTSIDE_PATH:
+                        OutlineToolPath simpleOutsidePath = new OutlineToolPath(settings, cuttable);
+                        simpleOutsidePath.setOffset(settings.getToolDiameter() / 2d);
+                        simpleOutsidePath.setStartDepth(cuttable.getStartDepth());
+                        simpleOutsidePath.setTargetDepth(cuttable.getTargetDepth());
+                        simpleOutsidePath.appendGcodePath(gcodePath, settings);
+                        break;
+                    case INSIDE_PATH:
+                        OutlineToolPath simpleInsidePath = new OutlineToolPath(settings, cuttable);
+                        simpleInsidePath.setOffset(-settings.getToolDiameter() / 2d);
+                        simpleInsidePath.setStartDepth(cuttable.getStartDepth());
+                        simpleInsidePath.setTargetDepth(cuttable.getTargetDepth());
+                        simpleInsidePath.appendGcodePath(gcodePath, settings);
+                        break;
+                    case ON_PATH:
+                        OutlineToolPath simpleOnPath = new OutlineToolPath(settings, cuttable);
+                        simpleOnPath.setStartDepth(cuttable.getStartDepth());
+                        simpleOnPath.setTargetDepth(cuttable.getTargetDepth());
+                        simpleOnPath.appendGcodePath(gcodePath, settings);
+                        break;
+                    case CENTER_DRILL:
+                        DrillCenterToolPath drillToolPath = new DrillCenterToolPath(settings, cuttable);
+                        drillToolPath.setStartDepth(cuttable.getStartDepth());
+                        drillToolPath.setTargetDepth(cuttable.getTargetDepth());
+                        drillToolPath.appendGcodePath(gcodePath, settings);
+                        break;
+                    case LASER_ON_PATH:
+                        LaserOutlineToolPath laserOutlineToolPath = new LaserOutlineToolPath(settings, cuttable);
+                        laserOutlineToolPath.appendGcodePath(gcodePath, settings);
+                        break;
+                    case LASER_FILL:
+                        LaserFillToolPath laserFillToolPath = new LaserFillToolPath(settings, cuttable);
+                        laserFillToolPath.appendGcodePath(gcodePath, settings);
+                        break;
+                    default:
+                }
             }
         }
         return gcodePath;


### PR DESCRIPTION
- Added a new Checkbox to designers Selection Settings Panel to allow user to include / exclude a shape from being exported to gcode.


This should fix: https://github.com/winder/Universal-G-Code-Sender/issues/2824