### PR TITLE
adding a text field for the spindle speed in the 'Cut settings' dialog

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/uielements/TextFieldUnit.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/uielements/TextFieldUnit.java
@@ -28,6 +28,7 @@ public enum TextFieldUnit {
     INCHES_PER_MINUTE("inch/min"),
     ROTATIONS_PER_MINUTE("rpm"),
     PERCENT("%"),
+    PERCENT1("%"),
     DEGREE("°"),
     TIMES("times"),
     SECONDS("s");

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/CuttableEntitySettings.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/CuttableEntitySettings.java
@@ -33,7 +33,7 @@ public class CuttableEntitySettings {
             case CUT_TYPE -> cuttable.setCutType((CutType) value);
             case START_DEPTH -> cuttable.setStartDepth((Double) value);
             case TARGET_DEPTH -> cuttable.setTargetDepth((Double) value);
-            case SPINDLE_SPEED -> cuttable.setSpindleSpeed((Integer) value);
+            case SPINDLE_SPEED -> cuttable.setSpindleSpeed((Integer) (value instanceof Double ? (int) Math.round((Double)value) : value));
             case PASSES -> cuttable.setPasses(Integer.parseInt(value.toString()));
             case FEED_RATE -> cuttable.setFeedRate(((Double) value).intValue());
             case LEAD_IN_PERCENT -> cuttable.setLeadInPercent((Integer) value);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsPanel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsPanel.java
@@ -65,6 +65,7 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
     private TextFieldWithUnit posXTextField;
     private TextFieldWithUnit posYTextField;
     private JSlider spindleSpeedSlider;
+    private UnitSpinner spindleSpeed2Spinner;
     private JLabel startDepthLabel;
     private JLabel targetDepthLabel;
     private CutTypeCombo cutTypeComboBox;
@@ -81,6 +82,7 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
     private JLabel heightLabel;
     private JToggleButton lockRatioButton;
     private JLabel spindleSpeedLabel;
+    private JLabel spindleSpeed2Label;
     private JLabel laserPassesLabel;
     private JSlider passesSlider;
     private JLabel feedRateLabel;
@@ -190,6 +192,11 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
 
         add(spindleSpeedSlider, SLIDER_FIELD_CONSTRAINTS + ", spanx");
         fieldEventDispatcher.registerListener(EntitySetting.SPINDLE_SPEED, spindleSpeedSlider);
+
+        spindleSpeed2Label = createAndAddLabel(EntitySetting.SPINDLE_SPEED);
+        spindleSpeed2Spinner = new UnitSpinner(50d, TextFieldUnit.PERCENT1, 0d, 100d, 1d);
+        add(spindleSpeed2Spinner, FIELD_CONSTRAINTS + ", spanx");
+        fieldEventDispatcher.registerListener(EntitySetting.SPINDLE_SPEED, spindleSpeed2Spinner);
 
         laserPassesLabel = createAndAddLabel(EntitySetting.PASSES);
         passesSlider = new JSlider(0, 10, 1);
@@ -346,6 +353,7 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
             lockRatioButton.setSelected(!model.getLockRatio());
         } else if (entitySetting == EntitySetting.SPINDLE_SPEED) {
             spindleSpeedSlider.setValue(model.getSpindleSpeed());
+            spindleSpeed2Spinner.setValue(model.getSpindleSpeed());
             selectionGroup.setSpindleSpeed(model.getSpindleSpeed());
         } else if (entitySetting == EntitySetting.PASSES) {
             passesSlider.setValue(model.getPasses());
@@ -417,6 +425,9 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
         spindleSpeedLabel.setText(cutType == CutType.LASER_FILL || cutType == CutType.LASER_ON_PATH ? "Power" : EntitySetting.SPINDLE_SPEED.getLabel());
         spindleSpeedLabel.setVisible(hasLaserPower);
         spindleSpeedSlider.setVisible(hasLaserPower);
+        spindleSpeed2Label.setText(cutType == CutType.LASER_FILL || cutType == CutType.LASER_ON_PATH ? "Power" : EntitySetting.SPINDLE_SPEED.getLabel());
+        spindleSpeed2Label.setVisible(hasLaserPower);
+        spindleSpeed2Spinner.setVisible(hasLaserPower);
 
         boolean hasLaserPasses = selectionHasSetting(selectionGroup, EntitySetting.PASSES) &&
                 cutType.getSettings().contains(EntitySetting.PASSES);


### PR DESCRIPTION
Hi, I would suggest adding add a text field for the laser power (spindle speed) to allow entering low values (e.g. 4%) for laser engraving: 

https://github.com/user-attachments/assets/0f8e2966-854d-4c9d-be49-2652b581796e

To show this, I made a PoC but you may want to do this differently.
As far as I understood, there are two "issues"
1. the `SPINDLE_SPEED` entity property seems to be an Integer `{1..100}` while the `UnitSpinner` outputs a Double
    - my workaround was to add code in `setEntitySetting` to round this Double to an Integer
2. the `PERCENT` type in the `TextFieldUnit` is additionally muliplied and divided by 100
    - my workaround was to add a `PERCENT1` unit which circuments these code pathes

I haven't tested this yet on my cnc but what do you think - would it be possible to include such text field in an upcoming release?