### PR TITLE
Autoleveler fixes

### DIFF
--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/Utils.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/Utils.java
@@ -39,10 +39,31 @@ public class Utils {
 
     public static final JFileChooser fileChooser = new JFileChooser();
 
-    public static boolean shouldEraseProbedData() {
+    /**
+     * Checks if there is probed data present and if so asks the user if it is ok to delete.
+     * If it is ok to delete, the data will be removed
+     *
+     * @param surfaceScanner the current surface scanner
+     * @return true if there is no probe data
+     */
+    public static boolean removeProbeData(SurfaceScanner surfaceScanner) {
+        if (!surfaceScanner.isValid()) {
+            return true;
+        }
+
+        if (!shouldEraseProbedData()) {
+            return false;
+        }
+
+        // Reset the scanner
+        surfaceScanner.reset();
+        return true;
+    }
+
+    private static boolean shouldEraseProbedData() {
         int result = JOptionPane.showConfirmDialog(new Frame(),
                 Localization.getString("autoleveler.panel.overwrite"),
-                Localization.getString("AutoLevelerTitle"),
+                Localization.getString("platform.window.autoleveler"),
                 JOptionPane.YES_NO_OPTION);
         return result == JOptionPane.YES_OPTION;
     }

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/GenerateTestDataAction.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/GenerateTestDataAction.java
@@ -20,6 +20,7 @@ package com.willwinder.ugs.platform.surfacescanner.actions;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.platform.surfacescanner.SurfaceScanner;
+import com.willwinder.ugs.platform.surfacescanner.Utils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -27,10 +28,10 @@ import com.willwinder.universalgcodesender.model.UGSEvent;
 import com.willwinder.universalgcodesender.model.events.ControllerStatusEvent;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 import java.awt.event.ActionEvent;
 
-import static com.willwinder.ugs.platform.surfacescanner.Utils.shouldEraseProbedData;
 
 /**
  * An action for generating test data and add it to the surface scanner
@@ -64,7 +65,7 @@ public class GenerateTestDataAction extends AbstractAction implements UGSEventLi
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (surfaceScanner.isValid() && !shouldEraseProbedData()) {
+        if (!Utils.removeProbeData(surfaceScanner)) {
             return;
         }
 

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/OpenScannedSurfaceAction.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/OpenScannedSurfaceAction.java
@@ -20,9 +20,9 @@ package com.willwinder.ugs.platform.surfacescanner.actions;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.platform.surfacescanner.SurfaceScanner;
+import com.willwinder.ugs.platform.surfacescanner.Utils;
 import static com.willwinder.ugs.platform.surfacescanner.Utils.getMaxPosition;
 import static com.willwinder.ugs.platform.surfacescanner.Utils.getMinPosition;
-import static com.willwinder.ugs.platform.surfacescanner.Utils.shouldEraseProbedData;
 import com.willwinder.ugs.platform.surfacescanner.io.XyzFileFilter;
 import com.willwinder.ugs.platform.surfacescanner.io.XyzSurfaceReader;
 import com.willwinder.universalgcodesender.i18n.Localization;
@@ -77,7 +77,7 @@ public class OpenScannedSurfaceAction extends AbstractAction implements UGSEvent
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (surfaceScanner.isValid() && !shouldEraseProbedData()) {
+        if (!Utils.removeProbeData(surfaceScanner)) {
             return;
         }
 

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/ScanSurfaceAction.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/ScanSurfaceAction.java
@@ -20,6 +20,7 @@ package com.willwinder.ugs.platform.surfacescanner.actions;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.platform.surfacescanner.SurfaceScanner;
+import com.willwinder.ugs.platform.surfacescanner.Utils;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -27,10 +28,9 @@ import com.willwinder.universalgcodesender.model.UGSEvent;
 import com.willwinder.universalgcodesender.model.events.ControllerStatusEvent;
 import org.openide.util.ImageUtilities;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 import java.awt.event.ActionEvent;
-
-import static com.willwinder.ugs.platform.surfacescanner.Utils.shouldEraseProbedData;
 
 public class ScanSurfaceAction extends AbstractAction implements UGSEventListener {
 
@@ -60,10 +60,9 @@ public class ScanSurfaceAction extends AbstractAction implements UGSEventListene
     @Override
     public void actionPerformed(ActionEvent e) {
         // Exit early if we have probed data and it is not ok to erase
-        if (surfaceScanner.isValid() && !shouldEraseProbedData()) {
+        if (!Utils.removeProbeData(surfaceScanner)) {
             return;
         }
-        surfaceScanner.reset();
         surfaceScanner.scan();
     }
 

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/TogglePreviewAction.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/TogglePreviewAction.java
@@ -38,19 +38,20 @@ public class TogglePreviewAction extends AbstractAction {
     }
 
     private void updateState() {
-        String title = Localization.getString("autoleveler.panel.visible");
-        String icon = renderable.isEnabled() ? ICON_BASE_ENABLED : ICON_BASE_DISABLED;
-        putValue(NAME, title);
-        putValue("menuText", title);
-        putValue(Action.SHORT_DESCRIPTION, title);
-        putValue("iconBase", icon);
-        putValue(SMALL_ICON, ImageUtilities.loadImageIcon(icon, false));
-        putValue(Action.SELECTED_KEY, !renderable.isEnabled());
+        SwingUtilities.invokeLater(() -> {
+            String title = Localization.getString("autoleveler.panel.visible");
+            String icon = renderable.isEnabled() ? ICON_BASE_ENABLED : ICON_BASE_DISABLED;
+            putValue(NAME, title);
+            putValue("menuText", title);
+            putValue(Action.SHORT_DESCRIPTION, title);
+            putValue("iconBase", icon);
+            putValue(SMALL_ICON, ImageUtilities.loadImageIcon(icon, false));
+            putValue(Action.SELECTED_KEY, renderable.isEnabled());
+        });
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        renderable.setEnabled(!renderable.isEnabled());
-        updateState();
+        SwingUtilities.invokeLater(() -> renderable.setEnabled(!renderable.isEnabled()));
     }
 }

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/UpdateMinMaxFromGcode.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/actions/UpdateMinMaxFromGcode.java
@@ -20,6 +20,8 @@ package com.willwinder.ugs.platform.surfacescanner.actions;
 
 import com.willwinder.ugs.nbp.lib.lookup.CentralLookup;
 import com.willwinder.ugs.platform.surfacescanner.SurfaceScanner;
+import static com.willwinder.ugs.platform.surfacescanner.Utils.getRoundPosition;
+import static com.willwinder.ugs.platform.surfacescanner.Utils.removeProbeData;
 import com.willwinder.universalgcodesender.i18n.Localization;
 import com.willwinder.universalgcodesender.listeners.UGSEventListener;
 import com.willwinder.universalgcodesender.model.BackendAPI;
@@ -29,11 +31,9 @@ import com.willwinder.universalgcodesender.model.events.ControllerStatusEvent;
 import com.willwinder.universalgcodesender.model.events.FileStateEvent;
 import com.willwinder.universalgcodesender.utils.Settings;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 import java.awt.event.ActionEvent;
-
-import static com.willwinder.ugs.platform.surfacescanner.Utils.getRoundPosition;
-import static com.willwinder.ugs.platform.surfacescanner.Utils.shouldEraseProbedData;
 
 public class UpdateMinMaxFromGcode extends AbstractAction implements UGSEventListener {
 
@@ -61,7 +61,8 @@ public class UpdateMinMaxFromGcode extends AbstractAction implements UGSEventLis
         if (!isEnabled() ) {
             return;
         }
-        if (surfaceScanner.isValid() && !shouldEraseProbedData()) {
+
+        if (!removeProbeData(surfaceScanner)) {
             return;
         }
 

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/renderable/AutoLevelPreview.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/renderable/AutoLevelPreview.java
@@ -237,12 +237,4 @@ public class AutoLevelPreview extends Renderable {
                 .mapToDouble(CNCPoint::getZ)
                 .filter(z -> !Double.isNaN(z));
     }
-
-    @Override
-    public void setEnabled(boolean enabled) {
-        if (VisualizerOptions.getBooleanOption(VISUALIZER_OPTION_AUTOLEVEL_PREVIEW, true) != enabled) {
-            VisualizerOptions.setBooleanOption(VISUALIZER_OPTION_AUTOLEVEL_PREVIEW, enabled);
-            notifyListeners();
-        }
-    }
 }

--- a/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/ui/AutoLevelerPanel.java
+++ b/ugs-platform/ugs-platform-surfacescanner/src/main/java/com/willwinder/ugs/platform/surfacescanner/ui/AutoLevelerPanel.java
@@ -154,7 +154,7 @@ public class AutoLevelerPanel extends JPanel {
     }
 
     private void syncControlsToSettings() {
-        if (surfaceScanner.isValid() && !Utils.shouldEraseProbedData()) {
+        if (!Utils.removeProbeData(surfaceScanner)) {
             return;
         }
 

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/shared/Renderable.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/shared/Renderable.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 Will Winder
+    Copyright 2016-2025 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -31,9 +31,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author wwinder
  */
 public abstract class Renderable implements Comparable<Renderable> {
-    Integer priority;
-    String title;
-    boolean isEnabled;
+    private final Integer priority;
+    private final String title;
+
+    /**
+     * A locally cached setting for if the renderable is enabled.
+     * This is needed to make the rendering fast enough to not slow down the rendering thread.
+     */
+    private boolean isEnabled;
 
     private final Set<RenderableListener> listeners = ConcurrentHashMap.newKeySet();
     private final String enabledOptionKey;
@@ -45,7 +50,7 @@ public abstract class Renderable implements Comparable<Renderable> {
     protected Renderable(int priority, String title, String enabledOptionKey) {
         this.title = title;
         this.priority = priority;
-        this.isEnabled = true;
+        this.isEnabled = VisualizerOptions.getBooleanOption(enabledOptionKey, true);
         this.enabledOptionKey = enabledOptionKey;
     }
 
@@ -76,7 +81,9 @@ public abstract class Renderable implements Comparable<Renderable> {
      * @param enabled set to true for enabling it in the configuration
      */
     public void setEnabled(boolean enabled) {
+        isEnabled = enabled;
         VisualizerOptions.setBooleanOption(enabledOptionKey, enabled);
+        notifyListeners();
     }
 
     /**
@@ -110,6 +117,7 @@ public abstract class Renderable implements Comparable<Renderable> {
     public abstract boolean center();
 
     public abstract void init(GLAutoDrawable drawable);
+
     public void reloadPreferences(VisualizerOptions vo) {
         isEnabled = VisualizerOptions.getBooleanOption(enabledOptionKey, true);
     }


### PR DESCRIPTION
Prevent more than one dialog for replacing probe data to be shown and fix the enable preview checkbox getting out of sync.

Discussed in https://github.com/winder/Universal-G-Code-Sender/discussions/2860