### PR TITLE
Fix safe height when using start depths to make sure it clears the material

### DIFF
--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/AbstractToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/AbstractToolPath.java
@@ -65,7 +65,14 @@ public abstract class AbstractToolPath implements PathGenerator {
     }
 
     protected void addSafeHeightSegment(GcodePath gcodePath, PartialPosition coordinate, boolean isFirst) {
-        PartialPosition safeHeightCoordinate = PartialPosition.from(Axis.Z, -getStartDepth() + settings.getSafeHeight(), UnitUtils.Units.MM);
+        double safeHeight = settings.getSafeHeight();
+
+        // If the start depth is negative we need to add it to the safe height to clear the material
+        if (startDepth < 0) {
+            safeHeight = safeHeight - startDepth;
+        }
+
+        PartialPosition safeHeightCoordinate = PartialPosition.from(Axis.Z, safeHeight, UnitUtils.Units.MM);
         gcodePath.addSegment(SegmentType.MOVE, safeHeightCoordinate);
     }
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPath.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPath.java
@@ -53,22 +53,17 @@ public class OutlineToolPath extends AbstractToolPath {
     public void setOffset(double offset) {
         this.offset = offset;
     }
-    
-    private Double getSafeHeightToUse(Double currentZ, boolean isFirst) {
-        
-        double result = settings.getSafeHeight()+currentZ;
-        if (isFirst) {
-            result = -getStartDepth() + settings.getSafeHeight();
-        }
-        // Outline Paths always Start and end in the same spot so its worthwhile to only climb a smaller amount
-        return result;
-    }
 
     @Override
     protected void addSafeHeightSegment(GcodePath gcodePath, PartialPosition coordinate, boolean isFirst) {
-        double safeHeightToUse = (coordinate != null && coordinate.hasZ() ? coordinate.getZ() : -getStartDepth());
-        PartialPosition safeHeightCoordinate = PartialPosition.from(Axis.Z, getSafeHeightToUse(safeHeightToUse,isFirst), UnitUtils.Units.MM);
-        gcodePath.addSegment(SegmentType.MOVE, safeHeightCoordinate);
+        if (isFirst) {
+            super.addSafeHeightSegment(gcodePath, coordinate, true);
+        } else {
+            // Outline Paths always Start and end in the same spot so its worthwhile to only climb a smaller amount
+            double safeHeightToUse = settings.getSafeHeight() + (coordinate != null && coordinate.hasZ() ? coordinate.getZ() : -getStartDepth());
+            PartialPosition safeHeightCoordinate = PartialPosition.from(Axis.Z, safeHeightToUse, UnitUtils.Units.MM);
+            gcodePath.addSegment(SegmentType.MOVE, safeHeightCoordinate);
+        }
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/DrillCenterToolPathTest.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/DrillCenterToolPathTest.java
@@ -157,6 +157,66 @@ public class DrillCenterToolPathTest {
     }
 
     @Test
+    public void drillCenterShouldMoveToSafeHeight() {
+        Rectangle rectangle = new Rectangle();
+        rectangle.setSize(new Size(15, 15));
+        rectangle.setPosition(new Point2D.Double(10, 10));
+
+        Settings settings = new Settings();
+        settings.setSafeHeight(10);
+        settings.setDepthPerPass(10);
+
+        DrillCenterToolPath drillCenterToolPath = new DrillCenterToolPath(settings, rectangle);
+        drillCenterToolPath.setStartDepth(5);
+        drillCenterToolPath.setTargetDepth(10);
+        GcodePath gcodePath = drillCenterToolPath.toGcodePath();
+
+        assertEquals(7, gcodePath.getSegments().size());
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, gcodePath.getSegments().get(0).type);
+        assertFalse(gcodePath.getSegments().get(0).point.hasX());
+        assertFalse(gcodePath.getSegments().get(0).point.hasY());
+        assertEquals(10, gcodePath.getSegments().get(0).point.getZ(), 0.01);
+
+        // Move in XY-place
+        assertEquals(SegmentType.MOVE, gcodePath.getSegments().get(1).type);
+        assertEquals(17.5, gcodePath.getSegments().get(1).point.getX(), 0.01);
+        assertEquals(17.5, gcodePath.getSegments().get(1).point.getY(), 0.01);
+        assertFalse(gcodePath.getSegments().get(1).point.hasZ());
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, gcodePath.getSegments().get(2).type);
+        assertFalse(gcodePath.getSegments().get(2).point.hasX());
+        assertFalse(gcodePath.getSegments().get(2).point.hasY());
+        assertEquals(10, gcodePath.getSegments().get(2).point.getZ(), 0.01);
+
+        // First depth pass
+        assertEquals(SegmentType.POINT, gcodePath.getSegments().get(3).type);
+        assertFalse(gcodePath.getSegments().get(3).point.hasX());
+        assertFalse(gcodePath.getSegments().get(3).point.hasY());
+        assertEquals(-5, gcodePath.getSegments().get(3).point.getZ(), 0.01);
+
+        // Second depth pass
+        assertEquals(SegmentType.POINT, gcodePath.getSegments().get(4).type);
+        assertFalse(gcodePath.getSegments().get(4).point.hasX());
+        assertFalse(gcodePath.getSegments().get(4).point.hasY());
+        assertEquals(-10, gcodePath.getSegments().get(4).point.getZ(), 0.01);
+
+        // Clear material
+        assertEquals(SegmentType.MOVE, gcodePath.getSegments().get(5).type);
+        assertFalse(gcodePath.getSegments().get(5).point.hasX());
+        assertFalse(gcodePath.getSegments().get(5).point.hasY());
+        assertEquals(-5, gcodePath.getSegments().get(5).point.getZ(), 0.01);
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, gcodePath.getSegments().get(6).type);
+        assertFalse(gcodePath.getSegments().get(6).point.hasX());
+        assertFalse(gcodePath.getSegments().get(6).point.hasY());
+        assertEquals(10, gcodePath.getSegments().get(6).point.getZ(), 0.01);
+    }
+
+    @Test
     public void drillCenterWithSpindleSpeedShouldTurnOnSpindle() {
         Rectangle rectangle = new Rectangle();
         rectangle.setSize(new Size(15, 15));

--- a/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPathTest.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/OutlineToolPathTest.java
@@ -49,7 +49,7 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.MOVE, segments.get(0).type);
         assertFalse(segments.get(0).point.hasX());
         assertFalse(segments.get(0).point.hasY());
-        assertEquals(9, segments.get(0).point.getZ(), 0.01);
+        assertEquals(10, segments.get(0).point.getZ(), 0.01);
 
         // Move in XY-place
         assertEquals(SegmentType.MOVE, segments.get(1).type);
@@ -61,7 +61,7 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.MOVE, segments.get(2).type);
         assertFalse(segments.get(2).point.hasX());
         assertFalse(segments.get(2).point.hasY());
-        assertEquals(9, segments.get(2).point.getZ(), 0.01);
+        assertEquals(10, segments.get(2).point.getZ(), 0.01);
 
         // Move into material
         assertEquals(SegmentType.POINT, segments.get(3).type);
@@ -93,11 +93,212 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.MOVE, segments.get(9).type);
         assertFalse(segments.get(9).point.hasX());
         assertFalse(segments.get(9).point.hasY());
-        assertEquals(9, segments.get(9).point.getZ(), 0.01);
+        assertEquals(10, segments.get(9).point.getZ(), 0.01);
 
         assertEquals(10, segments.size());
     }
 
+    @Test
+    public void toGcodePathShouldGenerateGcodeWithSafeHeightZero() {
+        Rectangle rectangle = new Rectangle(0,0);
+        rectangle.setSize(new Size(10, 10));
+        Settings settings = new Settings();
+        settings.setSafeHeight(0);
+
+        OutlineToolPath toolPath = new OutlineToolPath(settings, rectangle);
+        toolPath.setStartDepth(1);
+        toolPath.setTargetDepth(1);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(0).type);
+        assertFalse(segments.get(0).point.hasX());
+        assertFalse(segments.get(0).point.hasY());
+        assertEquals(0, segments.get(0).point.getZ(), 0.01);
+
+        // Move in XY-place
+        assertEquals(SegmentType.MOVE, segments.get(1).type);
+        assertEquals(0, segments.get(1).point.getX(), 0.01);
+        assertEquals(0, segments.get(1).point.getY(), 0.01);
+        assertFalse(segments.get(1).point.hasZ());
+
+        // Move to Z zero
+        assertEquals(SegmentType.MOVE, segments.get(2).type);
+        assertFalse(segments.get(2).point.hasX());
+        assertFalse(segments.get(2).point.hasY());
+        assertEquals(0, segments.get(2).point.getZ(), 0.01);
+
+        // Move into material
+        assertEquals(SegmentType.POINT, segments.get(3).type);
+        assertTrue(segments.get(3).point.hasX());
+        assertTrue(segments.get(3).point.hasY());
+        assertEquals(-1, segments.get(3).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(4).type);
+        assertEquals(0, segments.get(4).point.getX(), 0.01);
+        assertEquals(0, segments.get(4).point.getY(), 0.01);
+        assertEquals(-1, segments.get(4).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(5).type);
+        assertEquals(0, segments.get(5).point.getX(), 0.01);
+        assertEquals(10, segments.get(5).point.getY(), 0.01);
+        assertEquals(-1, segments.get(5).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(7).type);
+        assertEquals(10, segments.get(7).point.getX(), 0.01);
+        assertEquals(0, segments.get(7).point.getY(), 0.01);
+        assertEquals(-1, segments.get(7).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(8).type);
+        assertEquals(0, segments.get(8).point.getX(), 0.01);
+        assertEquals(0, segments.get(8).point.getY(), 0.01);
+        assertEquals(-1, segments.get(8).point.getZ(), 0.01);
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(9).type);
+        assertFalse(segments.get(9).point.hasX());
+        assertFalse(segments.get(9).point.hasY());
+        assertEquals(0, segments.get(9).point.getZ(), 0.01);
+
+        assertEquals(10, segments.size());
+    }
+
+
+    @Test
+    public void toGcodePathShouldGenerateGcodeWithSafeHeightForNegativeStartDepthAndSafeHeightZero() {
+        Rectangle rectangle = new Rectangle(0,0);
+        rectangle.setSize(new Size(10, 10));
+        Settings settings = new Settings();
+        settings.setSafeHeight(0);
+
+        OutlineToolPath toolPath = new OutlineToolPath(settings, rectangle);
+        toolPath.setStartDepth(-15);
+        toolPath.setTargetDepth(-15);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(0).type);
+        assertFalse(segments.get(0).point.hasX());
+        assertFalse(segments.get(0).point.hasY());
+        assertEquals(15, segments.get(0).point.getZ(), 0.01);
+
+        // Move in XY-place
+        assertEquals(SegmentType.MOVE, segments.get(1).type);
+        assertEquals(0, segments.get(1).point.getX(), 0.01);
+        assertEquals(0, segments.get(1).point.getY(), 0.01);
+        assertFalse(segments.get(1).point.hasZ());
+
+        // Move to Z zero
+        assertEquals(SegmentType.MOVE, segments.get(2).type);
+        assertFalse(segments.get(2).point.hasX());
+        assertFalse(segments.get(2).point.hasY());
+        assertEquals(15, segments.get(2).point.getZ(), 0.01);
+
+        // Move into material
+        assertEquals(SegmentType.POINT, segments.get(3).type);
+        assertTrue(segments.get(3).point.hasX());
+        assertTrue(segments.get(3).point.hasY());
+        assertEquals(15, segments.get(3).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(4).type);
+        assertEquals(0, segments.get(4).point.getX(), 0.01);
+        assertEquals(0, segments.get(4).point.getY(), 0.01);
+        assertEquals(15, segments.get(4).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(5).type);
+        assertEquals(0, segments.get(5).point.getX(), 0.01);
+        assertEquals(10, segments.get(5).point.getY(), 0.01);
+        assertEquals(15, segments.get(5).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(7).type);
+        assertEquals(10, segments.get(7).point.getX(), 0.01);
+        assertEquals(0, segments.get(7).point.getY(), 0.01);
+        assertEquals(15, segments.get(7).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(8).type);
+        assertEquals(0, segments.get(8).point.getX(), 0.01);
+        assertEquals(0, segments.get(8).point.getY(), 0.01);
+        assertEquals(15, segments.get(8).point.getZ(), 0.01);
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(9).type);
+        assertFalse(segments.get(9).point.hasX());
+        assertFalse(segments.get(9).point.hasY());
+        assertEquals(15, segments.get(9).point.getZ(), 0.01);
+
+        assertEquals(10, segments.size());
+    }
+
+    @Test
+    public void toGcodePathShouldGenerateGcodeWithSafeHeightForNegativeStartDepthAndSafeHeight() {
+        Rectangle rectangle = new Rectangle(0,0);
+        rectangle.setSize(new Size(10, 10));
+        Settings settings = new Settings();
+        settings.setSafeHeight(10);
+
+        OutlineToolPath toolPath = new OutlineToolPath(settings, rectangle);
+        toolPath.setStartDepth(-15);
+        toolPath.setTargetDepth(-15);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(0).type);
+        assertFalse(segments.get(0).point.hasX());
+        assertFalse(segments.get(0).point.hasY());
+        assertEquals(25, segments.get(0).point.getZ(), 0.01);
+
+        // Move in XY-place
+        assertEquals(SegmentType.MOVE, segments.get(1).type);
+        assertEquals(0, segments.get(1).point.getX(), 0.01);
+        assertEquals(0, segments.get(1).point.getY(), 0.01);
+        assertFalse(segments.get(1).point.hasZ());
+
+        // Move to Z zero
+        assertEquals(SegmentType.MOVE, segments.get(2).type);
+        assertFalse(segments.get(2).point.hasX());
+        assertFalse(segments.get(2).point.hasY());
+        assertEquals(25, segments.get(2).point.getZ(), 0.01);
+
+        // Move into material
+        assertEquals(SegmentType.POINT, segments.get(3).type);
+        assertTrue(segments.get(3).point.hasX());
+        assertTrue(segments.get(3).point.hasY());
+        assertEquals(15, segments.get(3).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(4).type);
+        assertEquals(0, segments.get(4).point.getX(), 0.01);
+        assertEquals(0, segments.get(4).point.getY(), 0.01);
+        assertEquals(15, segments.get(4).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(5).type);
+        assertEquals(0, segments.get(5).point.getX(), 0.01);
+        assertEquals(10, segments.get(5).point.getY(), 0.01);
+        assertEquals(15, segments.get(5).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(7).type);
+        assertEquals(10, segments.get(7).point.getX(), 0.01);
+        assertEquals(0, segments.get(7).point.getY(), 0.01);
+        assertEquals(15, segments.get(7).point.getZ(), 0.01);
+
+        assertEquals(SegmentType.LINE, segments.get(8).type);
+        assertEquals(0, segments.get(8).point.getX(), 0.01);
+        assertEquals(0, segments.get(8).point.getY(), 0.01);
+        assertEquals(15, segments.get(8).point.getZ(), 0.01);
+
+        // Move to safe height
+        assertEquals(SegmentType.MOVE, segments.get(9).type);
+        assertFalse(segments.get(9).point.hasX());
+        assertFalse(segments.get(9).point.hasY());
+        assertEquals(25, segments.get(9).point.getZ(), 0.01);
+
+        assertEquals(10, segments.size());
+    }
 
     @Test
     public void toGcodePathShouldGenerateGcodeFromNegativeStartDepth() {
@@ -235,7 +436,7 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.MOVE, segments.get(0).type);
         assertFalse(segments.get(0).point.hasX());
         assertFalse(segments.get(0).point.hasY());
-        assertEquals(9, segments.get(0).point.getZ(), 0.01);
+        assertEquals(10, segments.get(0).point.getZ(), 0.01);
 
         // Move in XY-place
         assertEquals(SegmentType.MOVE, segments.get(1).type);
@@ -247,7 +448,7 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.MOVE, segments.get(2).type);
         assertFalse(segments.get(2).point.hasX());
         assertFalse(segments.get(2).point.hasY());
-        assertEquals(9, segments.get(2).point.getZ(), 0.01);
+        assertEquals(10, segments.get(2).point.getZ(), 0.01);
 
         // Move into material
         assertEquals(SegmentType.POINT, segments.get(3).type);
@@ -280,7 +481,7 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.MOVE, segments.get(9).type);
         assertFalse(segments.get(9).point.hasX());
         assertFalse(segments.get(9).point.hasY());
-        assertEquals(9, segments.get(9).point.getZ(), 0.01);
+        assertEquals(10, segments.get(9).point.getZ(), 0.01);
 
         assertEquals(10, segments.size());
     }

--- a/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/PocketToolPathTest.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/PocketToolPathTest.java
@@ -161,6 +161,6 @@ public class PocketToolPathTest {
         }
 
         assertTrue("The tool path was " + Math.round(totalLength) + "mm long but should have been shorter", totalLength < 22144);
-        assertTrue("The tool path rapids was " + Math.round(totalRapidLength) + "mm long but should have been shorter", totalRapidLength < 721);
+        assertTrue("The tool path rapids was " + Math.round(totalRapidLength) + "mm long but should have been shorter", totalRapidLength < 730);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/SurfaceToolPathTest.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gcode/toolpaths/SurfaceToolPathTest.java
@@ -95,7 +95,7 @@ public class SurfaceToolPathTest {
 
         // Move to safe height
         assertEquals(SegmentType.MOVE, segments.get(9).type);
-        assertZPoint(segments.get(9).point, 9);
+        assertZPoint(segments.get(9).point, 10);
     }
 
     @Test
@@ -159,7 +159,7 @@ public class SurfaceToolPathTest {
 
         // Move to safe height
         assertEquals(SegmentType.MOVE, segments.get(9).type);
-        assertZPoint(segments.get(9).point, 9);
+        assertZPoint(segments.get(9).point, 10);
     }
 
     @Test
@@ -293,7 +293,7 @@ public class SurfaceToolPathTest {
 
         // Move to safe height
         assertEquals(SegmentType.MOVE, segments.get(9).type);
-        assertZPoint(segments.get(9).point, 9);
+        assertZPoint(segments.get(9).point, 10);
     }
 
     @Test
@@ -358,7 +358,7 @@ public class SurfaceToolPathTest {
 
         // Move to safe height
         assertEquals(SegmentType.MOVE, segments.get(9).type);
-        assertZPoint(segments.get(9).point, 9);
+        assertZPoint(segments.get(9).point, 10);
     }
 
     @Test
@@ -422,7 +422,7 @@ public class SurfaceToolPathTest {
 
         // Move to safe height
         assertEquals(SegmentType.MOVE, segments.get(9).type);
-        assertZPoint(segments.get(9).point, 9);
+        assertZPoint(segments.get(9).point, 10);
     }
 
     private static void assertXYPoint(PartialPosition point, double expectedX, double expectedY) {


### PR DESCRIPTION
In version 2.1.16 it only applied the safe height to the top of the work path not taking the start depth into account:

<img width="812" height="829" alt="image" src="https://github.com/user-attachments/assets/404c8f62-79de-4825-a41f-bdfb4ad7868d" />

When using a start depth it will now be applied to the safe height:
<img width="751" height="802" alt="image" src="https://github.com/user-attachments/assets/fb3e5259-d0b5-4f6e-bdf5-5de7b520347f" />

Should fix #2875
