### PR TITLE
Issue 2942: parse 8E1 as string scalar and migrate to SnakeYAML Engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <ugs.commons-cli.version>1.4</ugs.commons-cli.version>
     <ugs.easymock.version>5.2.0</ugs.easymock.version>
     <ugs.maven-assembly-plugin.version>2.5.3</ugs.maven-assembly-plugin.version>
-    <ugs.snakeyaml.version>2.2</ugs.snakeyaml.version>
+    <ugs.snakeyaml.version>3.0.1</ugs.snakeyaml.version>
     <ugs.nashorn-core.version>15.4</ugs.nashorn-core.version>
     <ugs.jackson.version>2.15.3</ugs.jackson.version>
 

--- a/ugs-core/pom.xml
+++ b/ugs-core/pom.xml
@@ -40,8 +40,8 @@
             <version>${gson.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
             <version>${ugs.snakeyaml.version}</version>
         </dependency>
         <dependency>

--- a/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/commands/GetFirmwareSettingsCommand.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/firmware/fluidnc/commands/GetFirmwareSettingsCommand.java
@@ -19,8 +19,14 @@
 package com.willwinder.universalgcodesender.firmware.fluidnc.commands;
 
 import com.willwinder.universalgcodesender.types.CommandException;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.error.YAMLException;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
+import org.snakeyaml.engine.v2.nodes.Tag;
+import org.snakeyaml.engine.v2.resolver.JsonScalarResolver;
+import org.snakeyaml.engine.v2.resolver.ScalarResolver;
+import org.snakeyaml.engine.v2.schema.JsonSchema;
+
 
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -28,11 +34,27 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class GetFirmwareSettingsCommand extends SystemCommand {
 
+    static class InternalSchema extends JsonSchema {
+        @Override
+        public ScalarResolver getScalarResolver() {
+            return new InternalResolver();
+        }
+    }
+    static class InternalResolver extends JsonScalarResolver {
+        public static final Pattern SIMPLE_FLOAT =
+                Pattern.compile("^(-?(0|[1-9][0-9]*)(\\.[0-9]*)?)$");
+        @Override
+        protected void addImplicitResolvers() {
+            super.addImplicitResolvers();
+            addImplicitResolver(Tag.FLOAT, SIMPLE_FLOAT, "-0123456789.");
+        }
+    }
     public GetFirmwareSettingsCommand() {
         super("$Config/Dump");
     }
@@ -49,10 +71,17 @@ public class GetFirmwareSettingsCommand extends SystemCommand {
                 .collect(Collectors.joining("\n"));
 
         try {
-            Yaml yaml = new Yaml();
-            Map<String, Object> settingsTree = yaml.load(response);
+            Load load = new Load(LoadSettings.builder()
+                    .setAllowDuplicateKeys(false)
+                    .setAllowNonScalarKeys(false)
+                    .setAllowRecursiveKeys(false)
+                    .setCodePointLimit(1_000_000) // ~1 MB
+                    .setMaxAliasesForCollections(10)
+                    .setSchema(new InternalSchema())
+                    .build());
+            Map<String, Object> settingsTree = (Map<String, Object>) load.loadFromString(response);
             return flatten(settingsTree);
-        } catch (YAMLException e) {
+        } catch (YamlEngineException e) {
             throw new CommandException(e);
         }
     }


### PR DESCRIPTION
1. Migrate to SnakeYAML Engine
2. Parse 8E1 as string scalar

To fix [issue 2942](https://github.com/winder/Universal-G-Code-Sender/issues/2942)