### PR TITLE
Add G-code text input field to jog screen in web pendant

### DIFF
--- a/ugs-pendant/src/main/webapp/src/services/machine.ts
+++ b/ugs-pendant/src/main/webapp/src/services/machine.ts
@@ -101,3 +101,16 @@ export const send = (): Promise<void> => {
 
   return fetch(url, request).then();
 };
+
+export const sendGcode = (commands: string): Promise<void> => {
+  const url = "api/v1/machine/sendGcode";
+  const request = {
+    method: "POST",
+    headers: {
+      'Content-Type': "application/json"
+    },
+    body: JSON.stringify({ commands })
+  };
+
+  return fetch(url, request).then();
+};


### PR DESCRIPTION
I find it handy to be able to input gcode on the web pendant as it may be faster and more accurate than jogging by steps

<img width="502" height="942" alt="gcode" src="https://github.com/user-attachments/assets/30b660bc-ec62-4837-826e-e15f4682f541" />
