### PR TITLE
Fix mobile scroll issue on web pendant jog panel

### DIFF
--- a/ugs-pendant/src/main/webapp/src/App.scss
+++ b/ugs-pendant/src/main/webapp/src/App.scss
@@ -10,6 +10,6 @@ body {
 .app {
     .appContainer {
         padding-top: 54px;
-        height: calc(100vh);
+        min-height: calc(100vh);
     }
 }

--- a/ugs-pendant/src/main/webapp/src/pages/MainPage.scss
+++ b/ugs-pendant/src/main/webapp/src/pages/MainPage.scss
@@ -24,3 +24,10 @@
   padding-left: 10px;
   padding-right: 10px;
 }
+
+@media (max-width: 575.98px) {
+  .mainPageRow {
+    height: auto !important;
+    padding-bottom: 100px;
+  }
+}

--- a/ugs-pendant/src/main/webapp/src/pages/MainPage.tsx
+++ b/ugs-pendant/src/main/webapp/src/pages/MainPage.tsx
@@ -64,7 +64,7 @@ const MainPage = () => {
   const state = useAppSelector((state) => state.status.state);
 
   return (
-    <Row style={{ margin: 0, height: "100%" }}>
+    <Row style={{ margin: 0, height: "100%" }} className="mainPageRow">
       <Col xs={'auto'} className="d-none d-sm-block sideMenu">
         <Navbar bg="dark" data-bs-theme="dark">
           <Menu className="flex-column" />


### PR DESCRIPTION
On mobile devices, the jog panel controls (X/Y Step, Z step, Feed rate) were partially covered by the bottom tab navigation bar, and attempting to scroll would cause the page to bounce back.

Changes:
- Changed appContainer height to min-height to allow content overflow
- Override row height to auto on mobile screens
- Added bottom padding on mobile to account for fixed bottom navbar

#2962
