### PR TITLE
Add reader for gerber files

### DIFF
--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/OpenAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/OpenAction.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2022 Will Winder
+    Copyright 2022-2026 Joacim Breiler
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -21,6 +21,7 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.nbp.designer.io.DesignReader;
 import com.willwinder.ugs.nbp.designer.io.c2d.C2dReader;
+import com.willwinder.ugs.nbp.designer.io.gerber.GerberReader;
 import com.willwinder.ugs.nbp.designer.io.svg.SvgReader;
 import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignReader;
 import com.willwinder.ugs.nbp.designer.logic.Controller;
@@ -42,6 +43,7 @@ public class OpenAction extends AbstractDesignAction {
     private static final String ICON_LARGE_PATH = "img/open24.svg";
     private static final FileFilter SVG_FILE_FILTER = new FileNameExtensionFilter("Scalable Vector Graphics (svg)", "svg");
     private static final FileFilter C2D_FILE_FILTER = new FileNameExtensionFilter("Carbide Create (c2d)", "c2d");
+    private static final FileFilter GERBER_FILE_FILTER = new FileNameExtensionFilter("Gerber (gbr)", "gbr");
     private final JFileChooser fileChooser;
 
     public OpenAction() {
@@ -56,6 +58,7 @@ public class OpenAction extends AbstractDesignAction {
         fileChooser.addChoosableFileFilter(DESIGN_FILE_FILTER);
         fileChooser.addChoosableFileFilter(SVG_FILE_FILTER);
         fileChooser.addChoosableFileFilter(C2D_FILE_FILTER);
+        fileChooser.addChoosableFileFilter(GERBER_FILE_FILTER);
         fileChooser.setFileFilter(DESIGN_FILE_FILTER);
     }
 
@@ -76,6 +79,8 @@ public class OpenAction extends AbstractDesignAction {
                 designReader = new SvgReader();
             } else if (fileChooser.getFileFilter() == C2D_FILE_FILTER) {
                 designReader = new C2dReader();
+            } else if (fileChooser.getFileFilter() == GERBER_FILE_FILTER) {
+                designReader = new GerberReader();
             }
 
             File selectedFile = fileChooser.getSelectedFile();

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolImportAction.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/actions/ToolImportAction.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2022 Will Winder
+    Copyright 2022-2026 Joacim Breiler
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -21,6 +21,7 @@ package com.willwinder.ugs.nbp.designer.actions;
 import com.willwinder.ugs.nbp.designer.io.c2d.C2dReader;
 import com.willwinder.ugs.nbp.designer.io.dxf.DxfReader;
 import com.willwinder.ugs.nbp.designer.io.eagle.EaglePnpReader;
+import com.willwinder.ugs.nbp.designer.io.gerber.GerberReader;
 import com.willwinder.ugs.nbp.designer.io.kicad.KiCadPosReader;
 import com.willwinder.ugs.nbp.designer.io.svg.SvgReader;
 import com.willwinder.ugs.nbp.designer.io.ugsd.UgsDesignReader;
@@ -66,6 +67,7 @@ public final class ToolImportAction extends AbstractDesignAction {
             new FileNameExtensionFilter("Carbide Create (.c2d)", "c2d"),
             new FileNameExtensionFilter("Eagle (.mnt, .mnb)", "mnt", "mnb"),
             new FileNameExtensionFilter("KiCad (.pos)", "pos"),
+            new FileNameExtensionFilter("Gerber (.gbr)", "gbr"),
             new FileNameExtensionFilter("UGS design (.ugsd)", "ugsd")
     };
 
@@ -102,6 +104,13 @@ public final class ToolImportAction extends AbstractDesignAction {
             optionalDesign = reader.read(f);
         } else if (StringUtils.endsWithIgnoreCase(f.getName(), ".ugsd")) {
             UgsDesignReader reader = new UgsDesignReader();
+            optionalDesign = reader.read(f);
+        } else if (StringUtils.endsWithIgnoreCase(f.getName(), "-drl.gbr")) {
+            // Treat as a KiCad drill file
+            GerberReader reader = new GerberReader(true);
+            optionalDesign = reader.read(f);
+        } else if (StringUtils.endsWithIgnoreCase(f.getName(), ".gbr")) {
+            GerberReader reader = new GerberReader();
             optionalDesign = reader.read(f);
         }
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntityGroup.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/EntityGroup.java
@@ -27,6 +27,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -135,7 +136,7 @@ public class EntityGroup extends AbstractEntity implements EntityListener {
         cachedBounds = null;
     }
 
-    public void addAll(List<Entity> entities) {
+    public void addAll(Collection<? extends Entity> entities) {
         entities.forEach(entity -> {
             if (!containsChild(entity)) {
                 children.add(entity);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Ellipse.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Ellipse.java
@@ -19,6 +19,8 @@
 package com.willwinder.ugs.nbp.designer.entities.cuttable;
 
 import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.model.Size;
+import static com.willwinder.universalgcodesender.utils.MathUtils.isEqual;
 
 import java.awt.Shape;
 import java.awt.geom.Ellipse2D;
@@ -30,14 +32,19 @@ public class Ellipse extends AbstractCuttable {
 
     private final Ellipse2D.Double shape;
 
-    public Ellipse(double relativeX, double relativeY) {
-        super(relativeX, relativeY);
+    public Ellipse(double x, double y) {
+        super(x, y);
         setName("Ellipse");
         this.shape = new Ellipse2D.Double(0, 0, 10, 10);
     }
 
     public Ellipse() {
         this(0,0);
+    }
+
+    public Ellipse(double x, double y, double w, double h) {
+        this(x, y);
+        setSize(new Size(w, h));
     }
 
     @Override
@@ -50,5 +57,9 @@ public class Ellipse extends AbstractCuttable {
         Ellipse ellipse = new Ellipse();
         copyPropertiesTo(ellipse);
         return ellipse;
+    }
+
+    public boolean isCircle() {
+        return isEqual(getSize().getHeight(), getSize().getWidth(), 0.01);
     }
 }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Group.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Group.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021-2025 Will Winder
+    Copyright 2021-2026 Joacim Breiler
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -276,7 +276,7 @@ public class Group extends EntityGroup implements Cuttable {
             return List.of();
         }
 
-        List<EntitySetting> result = list.get(0);
+        List<EntitySetting> result = new ArrayList<>(list.get(0));
         for (List<EntitySetting> settings : list) {
             result.retainAll(settings);
         }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Path.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Path.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021-2026 Will Winder
+    Copyright 2021-2026 Joacim Breiler
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -44,6 +44,11 @@ public class Path extends AbstractCuttable {
         super();
         setName("Path");
         this.shape = shape;
+    }
+
+    public Path(Shape shape) {
+        this(new Path2D.Double());
+        this.shape.append(shape, false);
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Rectangle.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/entities/cuttable/Rectangle.java
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Will Winder
+    Copyright 2021-2026 Joacim Breiler
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -19,6 +19,7 @@
 package com.willwinder.ugs.nbp.designer.entities.cuttable;
 
 import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.model.Size;
 
 import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
@@ -44,6 +45,11 @@ public class Rectangle extends AbstractCuttable {
         super(x, y);
         this.shape = new Rectangle2D.Double(0, 0, 1, 1);
         setName("Rectangle");
+    }
+
+    public Rectangle(double x, double y, double w, double h) {
+        this(x, y);
+        setSize(new Size(w, h));
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsPanel.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/gui/selectionsettings/SelectionSettingsPanel.java
@@ -39,6 +39,7 @@ import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.awt.Container;
 import java.beans.PropertyChangeListener;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -78,7 +79,7 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
     }
 
     private void setEnabledRecursive(Container container, boolean enabled) {
-        for (Component c : container.getComponents()) {
+        for (Component c : Arrays.stream(container.getComponents()).filter(Objects::nonNull).toList()) {
             c.setEnabled(enabled);
             if (c instanceof Container child) {
                 setEnabledRecursive(child, enabled);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Aperture.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Aperture.java
@@ -1,0 +1,49 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+import java.util.Arrays;
+
+public record Aperture(String name, Code code, double[] params, Macro macro) {
+
+    public Aperture {
+        params = params == null ? new double[0] : Arrays.copyOf(params, params.length);
+
+        if (macro != null) {
+            code = Code.MACRO;
+        }
+    }
+
+    public Aperture(String name, Code code, double[] params) {
+        this(name, code, params, null);
+    }
+
+    public Aperture(String name, Macro macro, double[] params) {
+        this(name, Code.MACRO, params, macro);
+    }
+
+    @Override
+    public double[] params() {
+        return Arrays.copyOf(params, params.length);
+    }
+
+    boolean isMacro() {
+        return macro != null;
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/CenterLinePrimitive.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/CenterLinePrimitive.java
@@ -1,0 +1,26 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+public record CenterLinePrimitive(double width,
+                                  double height,
+                                  double cx,
+                                  double cy,
+                                  double rotation) implements Primitive {
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Code.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Code.java
@@ -1,0 +1,48 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+public enum Code {
+    CIRCLE('C'),
+    RECTANGLE('R'),
+    OBROUND('O'),
+    POLYGON('P'),
+    UNKNOWN('?'),
+    MACRO('M');
+
+    private final char code;
+
+    Code(char code) {
+        this.code = code;
+    }
+
+    public static Code fromCode(char code) {
+        for (Code shape : Code.values()) {
+            if (shape.code == code) {
+                return shape;
+            }
+        }
+        return Code.UNKNOWN;
+    }
+
+    public char getCode() {
+        return code;
+    }
+
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/GerberEntity.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/GerberEntity.java
@@ -1,0 +1,25 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+
+public record GerberEntity(Polarity polarity, Entity entity) {
+
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/GerberReader.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/GerberReader.java
@@ -1,0 +1,480 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.CutType;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Ellipse;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Group;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Path;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Rectangle;
+import com.willwinder.ugs.nbp.designer.io.DesignReader;
+import com.willwinder.ugs.nbp.designer.io.DesignReaderException;
+import com.willwinder.ugs.nbp.designer.model.Design;
+import com.willwinder.ugs.nbp.designer.utils.StitchPathUtils;
+import com.willwinder.universalgcodesender.model.UnitUtils;
+import com.willwinder.universalgcodesender.utils.MathUtils;
+
+import java.awt.BasicStroke;
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Arc2D;
+import java.awt.geom.Area;
+import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class GerberReader implements DesignReader {
+    private static final Logger LOGGER = Logger.getLogger(GerberReader.class.getName());
+
+    /**
+     * A threshold for when a line should be considered to be one line or should be padded
+     */
+    private static final double CENTER_LINE_THRESHOLD_MM = 0.1;
+
+    private final State state = new State();
+    private final boolean importDrillHoles;
+
+
+    public GerberReader() {
+        this(false);
+    }
+
+    /**
+     * @param importDrillHoles import as gerber drill holes
+     */
+    public GerberReader(boolean importDrillHoles) {
+        this.importDrillHoles = importDrillHoles;
+    }
+
+    @Override
+    public Optional<Design> read(File file) {
+        try (InputStream in = new FileInputStream(file)) {
+            return read(in);
+        } catch (IOException e) {
+            throw new DesignReaderException("Failed to read Gerber file", e);
+        }
+    }
+
+    @Override
+    public Optional<Design> read(InputStream inputStream) {
+        state.reset();
+        parseInputStream(inputStream);
+
+        List<Entity> entities = new ArrayList<>();
+        if (importDrillHoles) {
+            Group group = new Group();
+            group.setName("Holes");
+            group.addAll(getDrillHoles());
+            entities.add(group);
+        } else {
+            entities.add(createCopperShape());
+            Group group = createLinesGroup();
+            if (!group.getChildren().isEmpty()) {
+                entities.add(group);
+            }
+        }
+
+        Design design = new Design();
+        design.setEntities(entities);
+        return Optional.of(design);
+    }
+
+    private Collection<? extends Entity> getDrillHoles() {
+        List<Ellipse> holes = state.getShapes().stream()
+                .map(GerberEntity::entity)
+                .filter(s -> s instanceof Ellipse)
+                .map(s -> (Ellipse) s)
+                .filter(Ellipse::isCircle)
+                .toList();
+
+        Map<String, Group> holeGroups = new HashMap<>();
+
+        for (Ellipse s : holes) {
+            String key = String.valueOf(MathUtils.round(s.getSize().getWidth(), 3));
+            Group group = holeGroups.getOrDefault(key, new Group());
+            group.setName(key + " mm");
+            group.addChild(s);
+            holeGroups.put(key, group);
+        }
+        return holeGroups.values();
+    }
+
+    private Group createLinesGroup() {
+        Group group = new Group();
+        group.addAll(StitchPathUtils.stitchEntities(state.getCenterLines().stream().map(s -> (Entity) new Path(s)).toList()));
+        group.setName("Lines");
+        group.setStartDepth(0.1);
+        group.setTargetDepth(0.1);
+        group.setCutType(CutType.ON_PATH);
+        return group;
+    }
+
+    private Path createCopperShape() {
+        Area copper = new Area();
+        for (GerberEntity s : state.getShapes()) {
+            if (s.polarity() == Polarity.DARK) {
+                copper.add(new Area(s.entity().getShape()));
+            } else {
+                copper.subtract(new Area(s.entity().getShape()));
+            }
+        }
+
+        Path path = new Path();
+        path.append(copper);
+        path.setName("Copper");
+        path.setCutType(CutType.OUTSIDE_PATH);
+        path.setStartDepth(0.1);
+        path.setTargetDepth(0.1);
+        return path;
+    }
+
+    private void parseInputStream(InputStream stream) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(stream))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty()) continue;
+
+                if (line.startsWith("%")) {
+                    parseExtended(line);
+                } else {
+                    parseStandard(line);
+                }
+            }
+        } catch (IOException e) {
+            throw new DesignReaderException("Gerber parse error", e);
+        }
+    }
+
+    private void parseExtended(String line) {
+
+        if (line.startsWith("%MO")) {
+            state.setUnits(line.contains("IN") ? UnitUtils.Units.INCH : UnitUtils.Units.MM);
+        } else if (line.startsWith("%FS")) {
+            Matcher m = Pattern.compile("X(\\d)(\\d)Y(\\d)(\\d)").matcher(line);
+            if (m.find()) {
+                state.setIntDigits(Integer.parseInt(m.group(1)));
+                state.setDecDigits(Integer.parseInt(m.group(2)));
+            }
+        } else if (line.startsWith("%ADD")) {
+            parseAperature(line);
+        } else if (line.startsWith("%TO.N,")) {
+            state.setCurrentNet(extractNetName(line));
+        } else if (line.startsWith("%LPD")) {
+            state.setPolarity(Polarity.DARK);
+        } else if (line.startsWith("%LPC")) {
+            state.setPolarity(Polarity.CLEAR);
+        } else if (line.startsWith("%AM")) {
+            parseMacro(line);
+        }
+    }
+
+    private void parseAperature(String line) {
+        // 1️⃣ Standard apertures: C, R, O, P
+        Matcher std = Pattern.compile("%ADD(\\d+)([CROP]),(.+)\\*%").matcher(line);
+        if (std.matches()) {
+            String code = "D" + std.group(1);
+            Code shape = Code.fromCode(std.group(2).charAt(0));
+            double[] params = Arrays.stream(std.group(3).split("X")).mapToDouble(Double::parseDouble).map(this::scaleToMM).toArray();
+
+            state.getApertures().put(code, new Aperture(code, shape, params));
+            return;
+        }
+
+        // 2️⃣ Macro apertures
+        Matcher macro = Pattern.compile("%ADD(\\d+)([A-Z0-9_]+),(.+)\\*%").matcher(line);
+
+        if (macro.matches()) {
+            String code = "D" + macro.group(1);
+            String macroName = macro.group(2);
+            double[] params = Arrays.stream(macro.group(3).split("X")).mapToDouble(Double::parseDouble).map(this::scaleToMM).toArray();
+
+            Macro am = state.getMacros().get(macroName);
+            if (am == null) {
+                LOGGER.warning("Unknown aperture macro: " + macroName);
+                return;
+            }
+
+            state.getApertures().put(code, new Aperture(code, am, params));
+        }
+    }
+
+    private void parseMacro(String line) {
+        // %AMMACRO1*21,1,$1,$2,0,0,$3*%
+        String body = line.substring(3, line.length() - 2);
+        String[] parts = body.split("\\*", 2);
+
+        String name = parts[0];
+        String content = parts[1];
+        List<Primitive> primitives = new ArrayList<>();
+
+        for (String prim : content.split("\\*")) {
+            String[] p = prim.split(",");
+
+            int code = Integer.parseInt(p[0]);
+            if (code == 21) {
+                primitives.add(new CenterLinePrimitive(
+                        parseMacroValue(p[2]),
+                        parseMacroValue(p[3]),
+                        parseMacroValue(p[4]),
+                        parseMacroValue(p[5]),
+                        parseMacroValue(p[6])));
+            }
+        }
+
+        state.getMacros().put(name, new Macro(name, primitives));
+    }
+
+    private double parseMacroValue(String s) {
+        if (s.startsWith("$")) {
+            return Double.NaN; // resolved later
+        }
+        return Double.parseDouble(s);
+    }
+
+    private String extractNetName(String line) {
+        Pattern NET_ATTR_PATTERN = Pattern.compile("%TO\\.N,([^*]+)\\*%");
+        Matcher m = NET_ATTR_PATTERN.matcher(line);
+        if (!m.matches()) {
+            return null;
+        }
+
+        String raw = m.group(1);
+        return decodeUnicodeEscapes(raw);
+    }
+
+    private String decodeUnicodeEscapes(String s) {
+        StringBuilder out = new StringBuilder(s.length());
+        int i = 0;
+
+        while (i < s.length()) {
+            char c = s.charAt(i);
+
+            if (c == '\\' && i + 5 < s.length() && s.charAt(i + 1) == 'u') {
+                String hex = s.substring(i + 2, i + 6);
+                try {
+                    int code = Integer.parseInt(hex, 16);
+                    out.append((char) code);
+                    i += 6;
+                    continue;
+                } catch (NumberFormatException ignored) {
+                    // fall through
+                }
+            }
+
+            out.append(c);
+            i++;
+        }
+
+        return out.toString();
+    }
+
+    private void parseStandard(String block) {
+        if (block.contains("G36")) {
+            state.setInRegion(true);
+            state.getRegionPoints().clear();
+        }
+
+        if (block.contains("G37")) {
+            finalizeRegion();
+            state.setInRegion(false);
+        }
+
+        if (block.contains("G01")) state.setInterpolation(Interpolation.LINEAR);
+        if (block.contains("G02")) state.setInterpolation(Interpolation.CW_ARC);
+        if (block.contains("G03")) state.setInterpolation(Interpolation.CCW_ARC);
+
+        Matcher dSel = Pattern.compile("D(\\d{2,})").matcher(block);
+        if (dSel.find()) {
+            String code = "D" + dSel.group(1);
+            if (state.getApertures().containsKey(code)) {
+                state.setCurrentAperture(state.getApertures().get(code));
+            }
+        }
+
+        Double nx = extractCoord(block, 'X');
+        Double ny = extractCoord(block, 'Y');
+        Double ni = extractCoord(block, 'I');
+        Double nj = extractCoord(block, 'J');
+
+        double px = state.getX();
+        double py = state.getY();
+
+        if (nx != null) state.setX(nx);
+        if (ny != null) state.setY(ny);
+
+        if (block.contains("D02")) {
+            if (state.isInRegion() && state.getRegionPoints().isEmpty()) {
+                state.getRegionPoints().add(new Point2D.Double(state.getX(), state.getY()));
+            }
+            return;
+        }
+
+        if (block.contains("D01")) {
+            if (state.isInRegion()) {
+                state.getRegionPoints().add(new Point2D.Double(state.getX(), state.getY()));
+            } else {
+                draw(px, py, state.getX(), state.getY(), ni, nj);
+            }
+        }
+
+        if (block.contains("D03")) {
+            flash(state.getX(), state.getY());
+        }
+    }
+
+    private boolean isCenterLineAperture() {
+        return state.getCurrentAperture() != null && state.getCurrentAperture().params()[0] <= CENTER_LINE_THRESHOLD_MM;
+    }
+
+    private void draw(double x1, double y1, double x2, double y2, Double i, Double j) {
+        if (state.getCurrentAperture() == null) return;
+
+        Shape shape;
+
+        if (state.getInterpolation() == Interpolation.LINEAR || i == null || j == null) {
+            shape = new Line2D.Double(x1, y1, x2, y2);
+        } else {
+            double cx = x1 + i;
+            double cy = y1 + j;
+
+            double r = Point2D.distance(cx, cy, x1, y1);
+            double a1 = Math.atan2(y1 - cy, x1 - cx);
+            double a2 = Math.atan2(y2 - cy, x2 - cx);
+
+            double extent = Math.toDegrees(a2 - a1);
+            if (state.getInterpolation() == Interpolation.CW_ARC && extent > 0) extent -= 360;
+            if (state.getInterpolation() == Interpolation.CCW_ARC && extent < 0) extent += 360;
+            shape = new Arc2D.Double(cx - r, cy - r, r * 2, r * 2, Math.toDegrees(a1), extent, Arc2D.OPEN);
+        }
+
+        if (isCenterLineAperture()) {
+            Path2D p = new Path2D.Double();
+
+            if (shape instanceof Line2D l) {
+                p.moveTo(l.getX1(), l.getY1());
+                p.lineTo(l.getX2(), l.getY2());
+            } else if (shape instanceof Arc2D a) {
+                p.append(a, true);
+            }
+
+            state.getCenterLines().add(p);
+        } else {
+            BasicStroke stroke = new BasicStroke((float) state.getCurrentAperture().params()[0], BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
+            addEntity(new Path(new Path2D.Double(stroke.createStrokedShape(shape))));
+        }
+    }
+
+    private void addEntity(Entity entity) {
+        state.getShapes().add(new GerberEntity(state.getPolarity(), entity));
+    }
+
+    private void flash(double x, double y) {
+        if (state.getCurrentAperture() == null) return;
+
+        if (state.getCurrentAperture().code() == Code.CIRCLE) {
+            double r = state.getCurrentAperture().params()[0] / 2;
+            addEntity(new Ellipse(x - r, y - r, r * 2, r * 2));
+        } else if (state.getCurrentAperture().code() == Code.RECTANGLE) {
+            double w = state.getCurrentAperture().params()[0];
+            double h = state.getCurrentAperture().params()[1];
+            addEntity(new Rectangle(x - (w / 2), y - (h / 2), w, h));
+        } else if (state.getCurrentAperture().code() == Code.OBROUND) {
+            double w = state.getCurrentAperture().params()[0];
+            double h = state.getCurrentAperture().params()[1];
+            addEntity(new Ellipse(x - (w / 2), y - (h / 2), w, h));
+        } else if (state.getCurrentAperture().isMacro()) {
+            flashMacro(x, y, state.getCurrentAperture());
+        }
+    }
+
+    private void flashMacro(double x, double y, Aperture aperture) {
+        if (aperture.macro() == null) {
+            return;
+        }
+
+        for (Primitive prim : aperture.macro().primitives()) {
+            if (prim instanceof CenterLinePrimitive cl) {
+                double[] params = aperture.params();
+                double w = resolve(cl.width(), params, 0);
+                double h = resolve(cl.height(), params, 1);
+                double rot = resolve(cl.rotation(), params, 2);
+
+                Shape rect = new Rectangle2D.Double(-w / 2, -h / 2, w, h);
+
+                AffineTransform tx = new AffineTransform();
+                tx.translate(x, y);
+                tx.rotate(Math.toRadians(rot));
+                addEntity(new Path(tx.createTransformedShape(rect)));
+            }
+        }
+    }
+
+    private double resolve(double v, double[] params, int index) {
+        if (!Double.isNaN(v)) return v;
+        return params[index];
+    }
+
+    private void finalizeRegion() {
+        if (state.getRegionPoints().size() < 3) return;
+
+        Path2D p = new Path2D.Double();
+        Point2D first = state.getRegionPoints().get(0);
+        p.moveTo(first.getX(), first.getY());
+
+        for (int i = 1; i < state.getRegionPoints().size(); i++) {
+            Point2D pt = state.getRegionPoints().get(i);
+            p.lineTo(pt.getX(), pt.getY());
+        }
+        p.closePath();
+        addEntity(new Path(p));
+    }
+
+    private Double extractCoord(String text, char axis) {
+        Matcher m = Pattern.compile(axis + "([+-]?\\d+)").matcher(text);
+        if (!m.find()) return null;
+        return scaleToMM(parseFixed(m.group(1)));
+    }
+
+    private double parseFixed(String s) {
+        return Integer.parseInt(s) / Math.pow(10, state.getDecDigits());
+    }
+
+    private double scaleToMM(double value) {
+        return UnitUtils.scaleUnits(state.getUnits(), UnitUtils.Units.MM) * value;
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Interpolation.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Interpolation.java
@@ -1,0 +1,21 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+public enum Interpolation { LINEAR, CW_ARC, CCW_ARC }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Macro.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Macro.java
@@ -1,0 +1,24 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+import java.util.List;
+
+public record Macro(String name, List<Primitive> primitives) {
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Polarity.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Polarity.java
@@ -1,0 +1,21 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+public enum Polarity { DARK, CLEAR }

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Primitive.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/Primitive.java
@@ -1,0 +1,21 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+interface Primitive {}

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/State.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/io/gerber/State.java
@@ -1,0 +1,166 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+import com.willwinder.universalgcodesender.model.UnitUtils;
+
+import java.awt.geom.Path2D;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class State {
+    private Aperture currentAperture;
+    private UnitUtils.Units units;
+    private int intDigits;
+    private int decDigits;
+    private Interpolation interpolation;
+    private Map<String, Aperture> apertures;
+    private double x;
+    private double y;
+    private boolean inRegion;
+    private List<Point2D.Double> regionPoints;
+    private String currentNet;
+    private List<GerberEntity> shapes;
+    private Polarity polarity;
+    private final Map<String, Macro> macros = new HashMap<>();
+    private List<Path2D> centerLines;
+
+    public Map<String, Macro> getMacros() {
+        return macros;
+    }
+
+    public State() {
+        reset();
+    }
+
+    public void reset() {
+        currentAperture = null;
+        units = UnitUtils.Units.MM;
+        intDigits = 2;
+        decDigits = 4;
+        interpolation = Interpolation.LINEAR;
+        apertures = new HashMap<>();
+        x = 0;
+        y = 0;
+        inRegion = false;
+        regionPoints = new ArrayList<>();
+        shapes = new ArrayList<>();
+        polarity = Polarity.DARK;
+        centerLines = new ArrayList<>();
+    }
+
+    public Aperture getCurrentAperture() {
+        return currentAperture;
+    }
+
+    public void setCurrentAperture(Aperture currentAperture) {
+        this.currentAperture = currentAperture;
+    }
+
+    public UnitUtils.Units getUnits() {
+        return units;
+    }
+
+    public void setUnits(UnitUtils.Units units) {
+        this.units = units;
+    }
+
+    public int getIntDigits() {
+        return intDigits;
+    }
+
+    public void setIntDigits(int intDigits) {
+        this.intDigits = intDigits;
+    }
+
+    public int getDecDigits() {
+        return decDigits;
+    }
+
+    public void setDecDigits(int decDigits) {
+        this.decDigits = decDigits;
+    }
+
+    public Interpolation getInterpolation() {
+        return interpolation;
+    }
+
+    public void setInterpolation(Interpolation interpolation) {
+        this.interpolation = interpolation;
+    }
+
+    public Map<String, Aperture> getApertures() {
+        return apertures;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public boolean isInRegion() {
+        return inRegion;
+    }
+
+    public void setInRegion(boolean inRegion) {
+        this.inRegion = inRegion;
+    }
+
+    public List<Point2D.Double> getRegionPoints() {
+        return regionPoints;
+    }
+
+    public void setCurrentNet(String currentNet) {
+        this.currentNet = currentNet;
+    }
+
+    public Polarity getPolarity() {
+        return polarity;
+    }
+
+    public void setPolarity(Polarity polarity) {
+        this.polarity = polarity;
+    }
+
+    public List<GerberEntity> getShapes() {
+        return shapes;
+    }
+
+    public List<Path2D> getCenterLines() {
+        return centerLines;
+    }
+
+    public String getCurrentNet() {
+        return currentNet;
+    }
+}

--- a/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gerber/GerberReaderTest.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/test/java/com/willwinder/ugs/nbp/designer/io/gerber/GerberReaderTest.java
@@ -1,0 +1,245 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.nbp.designer.io.gerber;
+
+import com.willwinder.ugs.nbp.designer.entities.Entity;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Ellipse;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Group;
+import com.willwinder.ugs.nbp.designer.entities.cuttable.Path;
+import com.willwinder.ugs.nbp.designer.model.Design;
+import org.apache.commons.io.IOUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import java.awt.Shape;
+import java.awt.geom.PathIterator;
+import java.awt.geom.Point2D;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GerberReaderTest {
+
+    public static final double POINT_EQUAL_TOLERANCE = 1.0E-4;
+
+    @Test
+    public void readCenterLine() {
+        // Use a very small aperture (0.05mm) which is <= CENTER_LINE_THRESHOLD_MM
+        String data = """
+                %LPD*%
+                %ADD10C,0.05000*%
+                %FSLAX46Y46*%
+                D10*
+                X000000Y000000D02*
+                X1000000Y1000000D01*
+                """;
+        GerberReader reader = new GerberReader();
+        Design design = reader.read(IOUtils.toInputStream(data, StandardCharsets.UTF_8)).orElseThrow();
+
+        // One entity for "Copper" (empty) and one "Lines" group
+        assertEquals(2, design.getEntities().size());
+        
+        Entity linesGroup = design.getEntities().stream()
+                .filter(e -> "Lines".equals(e.getName()))
+                .findFirst()
+                .orElseThrow();
+        
+        assertTrue(linesGroup instanceof Group);
+        Group group = (Group) linesGroup;
+        
+        // Should contain one path representing the center line
+        assertEquals(1, group.getChildren().size());
+        Entity path = group.getChildren().get(0);
+        assertTrue(path instanceof Path);
+        
+        // Verify bounds of the line from (0,0) to (1,1)
+        assertEquals(1.0, path.getBounds().getWidth(), 0.001);
+        assertEquals(1.0, path.getBounds().getHeight(), 0.001);
+    }
+
+    @Test
+    public void readLine() {
+        String data = """
+                %LPD*%
+                %ADD10C,1.00000*%
+                %FSLAX46Y46*%
+                D10*
+                X5080000Y3810000D02*
+                X8890000Y3810000D01*
+                """;
+        GerberReader reader = new GerberReader();
+        Design design = reader.read(IOUtils.toInputStream(data, StandardCharsets.UTF_8)).orElseThrow();
+        assertEquals(1, design.getEntities().size());
+
+        // Should create a single line with the width 1mm
+        Entity entity = design.getEntities().get(0);
+        assertEquals(3.81d - 0.5, entity.getBounds().getY(), 0.001);
+        assertEquals(5.08d - 0.5, entity.getBounds().getX(), 0.001);
+        assertEquals(4.81, entity.getBounds().getWidth(), 0.001);
+        assertEquals(1, entity.getBounds().getHeight(), 0.001);
+    }
+
+    @Test
+    public void readCircleAsDrillHole() {
+        String data = """
+                %LPD*%
+                %ADD10C,2.00000*%
+                %FSLAX46Y46*%
+                D10*
+                X5080000Y3810000D03*
+                """;
+        GerberReader reader = new GerberReader(true);
+        Design design = reader.read(IOUtils.toInputStream(data, StandardCharsets.UTF_8)).orElseThrow();
+        assertEquals(1, design.getEntities().size());
+
+        Entity entity = design.getEntities().get(0);
+        assertTrue(entity instanceof Group);
+        Group group = (Group) entity;
+        assertEquals("Holes", group.getName());
+        assertEquals(1, group.getChildren().size());
+
+        entity = group.getChildren().get(0);
+        assertTrue(entity instanceof Group);
+        Group subGroup = (Group) entity;
+        assertEquals("2.0 mm", subGroup.getName());
+        assertEquals(1, group.getChildren().size());
+
+        entity = subGroup.getChildren().get(0);
+        assertTrue(entity instanceof Ellipse);
+        assertEquals(2.0, group.getBounds().getWidth(), 0.001);
+        assertEquals(2.0, group.getBounds().getHeight(), 0.001);
+    }
+
+    @Test
+    public void readFilledPolygonRegion() {
+        String data = """
+                %LPD*%
+                %FSLAX46Y46*%
+                G36*
+                X000000Y000000D02*
+                X100000Y000000D01*
+                X100000Y100000D01*
+                X000000Y100000D01*
+                G37*
+                """;
+        GerberReader reader = new GerberReader();
+        Design design = reader.read(IOUtils.toInputStream(data, StandardCharsets.UTF_8)).orElseThrow();
+
+        assertEquals(1, design.getEntities().size());
+        Entity entity = design.getEntities().get(0);
+
+        List<Point2D> vertices = new ArrayList<>();
+        Shape shape = entity.getShape();
+        PathIterator iterator = shape.getPathIterator(null);
+        double[] coords = new double[6];
+        while (!iterator.isDone()) {
+            int type = iterator.currentSegment(coords);
+            if (type == PathIterator.SEG_MOVETO || type == PathIterator.SEG_LINETO) {
+                vertices.add(new Point2D.Double(coords[0], coords[1]));
+            }
+            iterator.next();
+        }
+
+        assertEquals(4, vertices.size());
+        assertTrue(hasPoint(vertices, 0.0, 0.0));
+        assertTrue(hasPoint(vertices, 0.1, 0.0));
+        assertTrue(hasPoint(vertices, 0.1, 0.1));
+        assertTrue(hasPoint(vertices, 0.0, 0.1));
+    }
+
+    private static boolean hasPoint(List<Point2D> points, double x, double y) {
+        return points.stream().anyMatch(p ->
+                Math.abs(p.getX() - x) <= 1.0E-4 && Math.abs(p.getY() - y) <= POINT_EQUAL_TOLERANCE
+        );
+    }
+
+    @Test
+    public void readRectangle() {
+        String data = """
+                %LPD*%
+                %ADD10R,2.5X1.5*%
+                %FSLAX46Y46*%
+                D10*
+                X5000000Y3000000D03*
+                """;
+        GerberReader reader = new GerberReader();
+        Design design = reader.read(IOUtils.toInputStream(data, StandardCharsets.UTF_8)).orElseThrow();
+
+        assertEquals(1, design.getEntities().size());
+        Entity entity = design.getEntities().get(0);
+
+        assertEquals(2.5, entity.getBounds().getWidth(), 0.001);
+        assertEquals(1.5, entity.getBounds().getHeight(), 0.001);
+
+        assertEquals(3.75, entity.getBounds().getX(), 0.001);
+        assertEquals(2.25, entity.getBounds().getY(), 0.001);
+    }
+    
+    @Test
+    public void readObroundAperture() {
+        String data = """
+                %LPD*%
+                %ADD10O,3.0X1.0*%
+                %FSLAX46Y46*%
+                D10*
+                X2000000Y2000000D03*
+                """;
+        GerberReader reader = new GerberReader();
+        Design design = reader.read(IOUtils.toInputStream(data, StandardCharsets.UTF_8)).orElseThrow();
+
+        assertEquals(1, design.getEntities().size());
+        Entity entity = design.getEntities().get(0);
+
+        assertEquals(3.0, entity.getBounds().getWidth(), 0.001);
+        assertEquals(1.0, entity.getBounds().getHeight(), 0.001);
+
+        assertEquals(0.5, entity.getBounds().getX(), 0.001);
+        assertEquals(1.5, entity.getBounds().getY(), 0.001);
+    }
+    
+    @Test
+    public void readRotatedMacroRectangle() {
+        // Macro 'ROTRECT': primitive 21 (Center Line/Rectangle)
+        // Parameters: exposure(1), width(2), height(3), center_x(4), center_y(5), rotation(6)
+        String data = """
+                %LPD*%
+                %AMMACRO1*21,1,$1,$2,0,0,$3*%
+                %ADD10MACRO1,2X1X90*%
+                %FSLAX46Y46*%
+                D10*
+                X000000Y000000D03*
+                """;
+        GerberReader reader = new GerberReader();
+        Design design = reader.read(IOUtils.toInputStream(data, StandardCharsets.UTF_8)).orElseThrow();
+
+        assertEquals(1, design.getEntities().size());
+        Entity entity = design.getEntities().get(0);
+
+        // A 10x2 rectangle rotated 45 degrees around (0,0)
+        // The bounding box for a rotated rectangle is larger than the original dimensions.
+        // Width/Height will be approx: 10*cos(45) + 2*sin(45) = 7.071 + 1.414 = 8.485
+        assertEquals(1, entity.getBounds().getWidth(), 0.001);
+        assertEquals(2, entity.getBounds().getHeight(), 0.001);
+
+        // Centered at 0,0, so minX should be approx -4.242
+        assertEquals(-0.5, entity.getBounds().getX(), 0.001);
+        assertEquals(-1, entity.getBounds().getY(), 0.001);
+    }
+}


### PR DESCRIPTION
Added support for reading Gerber files. Here is an example of an export from KiCad:
<img width="2032" height="968" alt="image" src="https://github.com/user-attachments/assets/2d41a8d0-c532-4f7c-8eaa-7c17c106ca6d" />

It can import the copper traces. For best results don't use copper fills.
It can also import gerber drill files assuming the file ends with `-drl.gbr`