### PR TITLE
Fixed bug where "Mouse Jiggle" happens when controller is not connected

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/KeepAwakeUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/KeepAwakeUtils.java
@@ -62,7 +62,7 @@ public class KeepAwakeUtils {
             @Override
             public void run() {
                 // Move the mouse every 30 seconds to prevent sleeping.
-                if (backendAPI.isPaused() || !backendAPI.isIdle()) {
+                if (backendAPI.isConnected() && (backendAPI.isPaused() || !backendAPI.isIdle())) {
                     keepAwake();
                 }
             }


### PR DESCRIPTION
When no controller is connected IsIdle returns false which causes KeepAwake to fire and keep the computer awake 24/7