### PR TITLE
Fixed crash on macOS when opening designer

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/utils/SvgIconLoader.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/utils/SvgIconLoader.java
@@ -42,8 +42,7 @@ public class SvgIconLoader {
     }
 
     private static Optional<ImageIcon> loadIconImageIcon(String icon, int size) {
-        try (InputStream resourceAsStream =
-                     SvgIconLoader.class.getResourceAsStream("/" + icon)) {
+        try (InputStream resourceAsStream = openResource(icon)) {
 
             if (resourceAsStream == null) {
                 return Optional.empty();
@@ -150,12 +149,23 @@ public class SvgIconLoader {
             return Optional.empty();
         }
 
-        InputStream resourceAsStream = SvgIconLoader.class.getResourceAsStream("/" + icon);
+        InputStream resourceAsStream = openResource(icon);
         if (resourceAsStream == null) {
             return Optional.empty();
         }
 
         SVGLoader loader = new SVGLoader();
         return Optional.ofNullable(loader.load(resourceAsStream));
+    }
+
+    private static InputStream openResource(String icon) {
+        ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+        if (contextLoader != null) {
+            InputStream stream = contextLoader.getResourceAsStream(icon);
+            if (stream != null) {
+                return stream;
+            }
+        }
+        return SvgIconLoader.class.getResourceAsStream("/" + icon);
     }
 }

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/entities/entities/controls/ZoomControl.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/entities/entities/controls/ZoomControl.java
@@ -30,8 +30,15 @@ public class ZoomControl extends AbstractControl {
         super(controller.getSelectionManager());
         this.controller = controller;
 
-        zoomInCursor = Toolkit.getDefaultToolkit().createCustomCursor(SvgIconLoader.loadImageIcon("img/zoom-in.svg", SvgIconLoader.SIZE_SMALL).map(ImageIcon::getImage).orElse(null), new Point(8, 8), "zoom-in");
-        zoomOutCursor = Toolkit.getDefaultToolkit().createCustomCursor(SvgIconLoader.loadImageIcon("img/zoom-out.svg", SvgIconLoader.SIZE_SMALL).map(ImageIcon::getImage).orElse(null), new Point(8, 8), "zoom-out");
+        zoomInCursor = createCursor("img/zoom-in.svg", "zoom-in");
+        zoomOutCursor = createCursor("img/zoom-out.svg", "zoom-out");
+    }
+
+    private static Cursor createCursor(String iconPath, String name) {
+        return SvgIconLoader.loadImageIcon(iconPath, SvgIconLoader.SIZE_SMALL)
+                .map(ImageIcon::getImage)
+                .map(image -> Toolkit.getDefaultToolkit().createCustomCursor(image, new Point(8, 8), name))
+                .orElseGet(Cursor::getDefaultCursor);
     }
 
     @Override


### PR DESCRIPTION
Fixed crash where SvgIconLoader.class.getResourceAsStream("/img/zoom-in.svg") was doing a getResourceAsStream against ugs-core's classloader, but the icons actually live in ugs-designer (which sits in a downstream module classloader ugs-core can't see under the NetBeans Platform), so loadImageIcon came back empty, .orElse(null) handed a null to Toolkit.createCustomCursor, and mac's CCustomCursor NPE'd on File -> New Design