### PR TITLE
Fixed issue where selection did not update after clicking on shape

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/services/LookupService.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/services/LookupService.java
@@ -25,6 +25,7 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
 
 import java.lang.reflect.Constructor;
+import java.net.URL;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -68,9 +69,32 @@ public class LookupService {
         }
     }
 
-    public static synchronized void discoverProviders(String... packageRoots) {
-        try (ScanResult scanResult = new ClassGraph().enableClassInfo().enableAnnotationInfo().acceptPackages(packageRoots).scan()) {
-            scanResult.getClassesWithAnnotation(LookupServiceProvider.class.getName()).loadClasses().stream().sorted(Comparator.comparingInt(LookupService::positionOf)).forEach(LookupService::createAndRegister);
+    public static synchronized void discoverProviders(Class<?> reference) {
+        // ClassGraph cannot enumerate classes through NetBeans' ProxyClassLoader,
+        // so scan the JAR/directory backing the reference class directly. Loading
+        // must still go through the module's own classloader, otherwise dependent
+        // classes (e.g. MigLayout) won't resolve.
+        URL codeSource = reference.getProtectionDomain().getCodeSource().getLocation();
+        ClassLoader classLoader = reference.getClassLoader();
+        try (ScanResult scanResult = new ClassGraph()
+                .enableClassInfo().enableAnnotationInfo()
+                .overrideClasspath(codeSource)
+                .acceptPackages(reference.getPackageName())
+                .scan()) {
+            List<String> classNames = scanResult.getClassesWithAnnotation(LookupServiceProvider.class.getName()).getNames();
+            LOGGER.info("discoverProviders registered " + classNames.size() + " @LookupServiceProvider classes from " + reference.getPackageName());
+            classNames.stream()
+                    .map(name -> loadClass(name, classLoader))
+                    .sorted(Comparator.comparingInt(LookupService::positionOf))
+                    .forEach(LookupService::createAndRegister);
+        }
+    }
+
+    private static Class<?> loadClass(String name, ClassLoader classLoader) {
+        try {
+            return Class.forName(name, true, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to load lookup service: " + name, e);
         }
     }
 

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/DesignerMain.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/DesignerMain.java
@@ -46,7 +46,7 @@ public class DesignerMain extends JFrame {
 
         Controller controller = ControllerFactory.getController();
         LookupService.register(controller);
-        LookupService.discoverProviders(DesignerMain.class.getPackageName());
+        LookupService.discoverProviders(DesignerMain.class);
 
         UndoManager undoManager = ControllerFactory.getUndoManager();
         LookupService.register(undoManager);

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/selectionsettings/SelectionSettingsPanel.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/selectionsettings/SelectionSettingsPanel.java
@@ -66,6 +66,11 @@ public class SelectionSettingsPanel extends JPanel implements SelectionListener,
 
         setController(controller);
         setEnabled(false);
+
+        // DesignerTopComponent re-opens this pane via invokeLater on selection,
+        // so the SelectionEvent has already fired by the time we're constructed.
+        // Seed from the current selection so the panel reflects an already-selected shape.
+        onEvent(new EntityEvent(controller.getSelectionManager(), EventType.SELECTED));
     }
 
     @Override

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/Startup.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/Startup.java
@@ -47,8 +47,11 @@ public class Startup implements Runnable {
         LookupService.register(controller.getSelectionManager());
         LookupService.register(new PlatformFileContext());
 
-        // Register all lookup providers
-        LookupService.discoverProviders(DesignerMain.class.getPackageName());
+        // Register all lookup providers. Pass the class so ClassGraph uses the
+        // ugs-designer module's classloader — under the NetBeans Platform module
+        // isolation, the context classloader does not see the designer JAR.
+        LookupService.discoverProviders(DesignerMain.class);
+        LookupService.discoverProviders(Startup.class);
 
         // Registers the file types that can be opened in UGSs
         FileFilterService fileFilterService = Lookup.getDefault().lookup(FileFilterService.class);


### PR DESCRIPTION
Selection is only populated itself from SelectionListener events. But DesignerTopComponent.onSelectionEvent opens the settings pane via SwingUtilities.invokeLater, so SettingsTopComponent.componentOpened runs after the SelectionEvent has already been dispatched. A fresh SelectionSettingsPanel then  registers as a listener with no way to learn about the just-selected shape, leaving the pane empty and disabled