### PR TITLE
Forced settingsChanged to run in the EDT preventing threading issues

### DIFF
--- a/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacrosTopComponent.java
+++ b/ugs-platform/ugs-platform-ugscore/src/main/java/com/willwinder/ugs/nbp/core/control/MacrosTopComponent.java
@@ -37,6 +37,7 @@ import javax.swing.JButton;
 import javax.swing.JPopupMenu;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.util.concurrent.Future;
 
 /**
  * Top component which displays something.
@@ -52,8 +53,8 @@ import java.awt.Dimension;
         preferredID = "MacrosTopComponent"
 )
 public final class MacrosTopComponent extends TopComponent implements UGSEventListener {
-    private final Object settingsLock = new Object();
     private final ButtonGridPanel buttonGridPanel;
+    private Future<?> settingsChangedFuture;
 
     public MacrosTopComponent() {
         super.setLayout(new BorderLayout());
@@ -77,6 +78,7 @@ public final class MacrosTopComponent extends TopComponent implements UGSEventLi
         SwingHelpers.traverse(this, comp -> comp.setComponentPopupMenu(popupMenu));
 
         revalidate();
+        settingsChangedFuture = null;
     }
 
     @Override
@@ -102,10 +104,8 @@ public final class MacrosTopComponent extends TopComponent implements UGSEventLi
 
     @Override
     public void UGSEvent(UGSEvent evt) {
-        if (!(evt instanceof SettingChangedEvent)) return;
-
-        synchronized (settingsLock) {
-            ThreadHelper.invokeLater(this::settingsChanged, 2000);
+        if (evt instanceof SettingChangedEvent && settingsChangedFuture == null) {
+            settingsChangedFuture = ThreadHelper.invokeLater(this::settingsChanged, 2000);
         }
     }
 


### PR DESCRIPTION
 Before 60a684c1, the handler held a Future<?> settingsChangedFuture guard so only one rebuild was ever scheduled at a time; subsequent events while a rebuild was pending were dropped, and the guard was cleared at the end of settingsChanged().

 The synchronized(settingsLock) block is a no-op (it guards nothing that is actually shared). Every SettingChangedEvent now schedules a new rebuild task.

 The user's keyboard shortcuts fire actions that produce SettingChangedEvents in rapid succession. After the 2-second delay, N queued rebuilds all run concurrently on the 10-thread pool, each calling removeAll() and then add(...) on the same buttonGridPanel. Interleaved execution on two+ worker threads races on Swing's (non-thread-safe) container list