### PR TITLE
Allow simple math expressions (e.g. 3/2, 7.2+1, 360/8) in the Designer's Transform panel position fields

### DIFF
--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/expression/ExpressionAwareTextFieldFormatter.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/expression/ExpressionAwareTextFieldFormatter.java
@@ -1,0 +1,79 @@
+/*
+    Copyright 2026 Damian Nikodem
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.gui.expression;
+
+import com.willwinder.universalgcodesender.model.Unit;
+import com.willwinder.universalgcodesender.uielements.TextFieldUnitFormatter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.text.ParseException;
+import java.util.OptionalDouble;
+
+/**
+ * {@link TextFieldUnitFormatter} that also accepts simple arithmetic expressions
+ * (e.g. {@code 3/2}, {@code 7.2+1}, {@code (5+1)*2}). Plain numeric input takes
+ * the normal path; only inputs the base formatter rejects are run through
+ * {@link MathExpressionParser}.
+ */
+public class ExpressionAwareTextFieldFormatter extends TextFieldUnitFormatter {
+
+    private static final Unit[] STRIPPABLE_UNITS = new Unit[]{
+            Unit.MM,
+            Unit.INCH,
+            Unit.INCHES_PER_MINUTE,
+            Unit.MM_PER_MINUTE,
+            Unit.REVOLUTIONS_PER_MINUTE,
+            Unit.PERCENT
+    };
+
+    public ExpressionAwareTextFieldFormatter(Unit unit, int numberOfDecimals) {
+        super(unit, numberOfDecimals);
+    }
+
+    public ExpressionAwareTextFieldFormatter(Unit unit, int numberOfDecimals, boolean showAbbreviation) {
+        super(unit, numberOfDecimals, showAbbreviation);
+    }
+
+    @Override
+    public Object stringToValue(String text) throws ParseException {
+        // Try the expression parser on a cleaned-up copy of the text. We can't
+        // rely on the base formatter throwing for inputs like "3/2", because
+        // DecimalFormat.parse stops at the first non-numeric character — it
+        // would happily return 3.
+        String stripped = stripTrailingUnitAbbreviation(text);
+        stripped = StringUtils.replace(stripped, ",", ".");
+        OptionalDouble evaluated = MathExpressionParser.tryEvaluate(stripped);
+        if (evaluated.isPresent()) {
+            // Re-enter the base formatter so rounding and PERCENT scaling stay
+            // in a single place.
+            return super.stringToValue(Double.toString(evaluated.getAsDouble()));
+        }
+        // Not an expression — let the base formatter handle plain numbers,
+        // locale quirks, and its existing error reporting.
+        return super.stringToValue(text);
+    }
+
+    private static String stripTrailingUnitAbbreviation(String text) {
+        String value = text == null ? "" : text;
+        for (Unit u : STRIPPABLE_UNITS) {
+            value = StringUtils.removeEnd(value, u.getAbbreviation());
+        }
+        return StringUtils.trim(value);
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/expression/MathExpressionParser.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/expression/MathExpressionParser.java
@@ -1,0 +1,196 @@
+/*
+    Copyright 2026 Damian Nikodem
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.gui.expression;
+
+import java.util.OptionalDouble;
+
+/**
+ * Tiny recursive-descent evaluator for arithmetic expressions a designer might
+ * type into a position field: {@code 3/2}, {@code 7.2+1}, {@code (5+1)*2},
+ * {@code -3+4}. Supports {@code + - * /} with standard precedence, unary minus,
+ * and parentheses. Decimal numbers only — no scientific notation, no identifiers.
+ *
+ * Any input outside the strict whitelist returns an empty {@link OptionalDouble}
+ * so callers can fall through to their own parsing without surprises.
+ */
+public final class MathExpressionParser {
+
+    private MathExpressionParser() {
+    }
+
+    public static OptionalDouble tryEvaluate(String text) {
+        if (text == null) {
+            return OptionalDouble.empty();
+        }
+        String trimmed = text.trim();
+        if (trimmed.isEmpty()) {
+            return OptionalDouble.empty();
+        }
+        for (int i = 0; i < trimmed.length(); i++) {
+            char c = trimmed.charAt(i);
+            boolean ok = (c >= '0' && c <= '9')
+                    || c == '.' || c == '+' || c == '-' || c == '*' || c == '/'
+                    || c == '(' || c == ')' || c == ' ';
+            if (!ok) {
+                return OptionalDouble.empty();
+            }
+        }
+        try {
+            Parser p = new Parser(trimmed);
+            double value = p.parseExpr();
+            p.skipWhitespace();
+            if (!p.atEnd()) {
+                return OptionalDouble.empty();
+            }
+            if (Double.isNaN(value) || Double.isInfinite(value)) {
+                return OptionalDouble.empty();
+            }
+            return OptionalDouble.of(value);
+        } catch (ParseFailure e) {
+            return OptionalDouble.empty();
+        }
+    }
+
+    private static final class ParseFailure extends RuntimeException {
+        ParseFailure() {
+            super(null, null, false, false);
+        }
+    }
+
+    private static final class Parser {
+        private final String src;
+        private int pos;
+
+        Parser(String src) {
+            this.src = src;
+        }
+
+        double parseExpr() {
+            double value = parseTerm();
+            while (true) {
+                skipWhitespace();
+                if (peek('+') || peek('-')) {
+                    char op = src.charAt(pos);
+                    pos++;
+                    skipWhitespace();
+                    // Disallow doubled additive operators (e.g. "5++3", "5+-3")
+                    // — these usually indicate a typo rather than intent.
+                    if (peek('+') || peek('-')) {
+                        throw new ParseFailure();
+                    }
+                    double rhs = parseTerm();
+                    value = (op == '+') ? value + rhs : value - rhs;
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        double parseTerm() {
+            double value = parseFactor();
+            while (true) {
+                skipWhitespace();
+                if (peek('*')) {
+                    pos++;
+                    value *= parseFactor();
+                } else if (peek('/')) {
+                    pos++;
+                    double divisor = parseFactor();
+                    if (divisor == 0.0) {
+                        throw new ParseFailure();
+                    }
+                    value /= divisor;
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        double parseFactor() {
+            skipWhitespace();
+            // Allow a single leading unary +/- before a primary. Stacking ("--5",
+            // "+-5") is rejected because it almost always indicates a typo.
+            if (peek('+')) {
+                pos++;
+                return parsePrimary();
+            }
+            if (peek('-')) {
+                pos++;
+                return -parsePrimary();
+            }
+            return parsePrimary();
+        }
+
+        double parsePrimary() {
+            skipWhitespace();
+            if (atEnd()) {
+                throw new ParseFailure();
+            }
+            if (peek('(')) {
+                pos++;
+                double value = parseExpr();
+                skipWhitespace();
+                if (!peek(')')) {
+                    throw new ParseFailure();
+                }
+                pos++;
+                return value;
+            }
+            return parseNumber();
+        }
+
+        double parseNumber() {
+            int start = pos;
+            boolean sawDigit = false;
+            while (!atEnd() && src.charAt(pos) >= '0' && src.charAt(pos) <= '9') {
+                pos++;
+                sawDigit = true;
+            }
+            if (!atEnd() && src.charAt(pos) == '.') {
+                pos++;
+                while (!atEnd() && src.charAt(pos) >= '0' && src.charAt(pos) <= '9') {
+                    pos++;
+                    sawDigit = true;
+                }
+            }
+            if (!sawDigit) {
+                throw new ParseFailure();
+            }
+            try {
+                return Double.parseDouble(src.substring(start, pos));
+            } catch (NumberFormatException e) {
+                throw new ParseFailure();
+            }
+        }
+
+        void skipWhitespace() {
+            while (!atEnd() && src.charAt(pos) == ' ') {
+                pos++;
+            }
+        }
+
+        boolean peek(char c) {
+            return !atEnd() && src.charAt(pos) == c;
+        }
+
+        boolean atEnd() {
+            return pos >= src.length();
+        }
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/selectionsettings/settingspanels/TransformationSettingsPanel.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/selectionsettings/settingspanels/TransformationSettingsPanel.java
@@ -25,6 +25,7 @@ import com.willwinder.ugs.designer.entities.entities.EntitySetting;
 import com.willwinder.ugs.designer.entities.entities.cuttable.Group;
 import com.willwinder.ugs.designer.entities.entities.settings.TransformationEntitySettingsManager;
 import com.willwinder.ugs.designer.gui.anchor.AnchorSelectorPanel;
+import com.willwinder.ugs.designer.gui.expression.ExpressionAwareTextFieldFormatter;
 import com.willwinder.ugs.designer.logic.Controller;
 import com.willwinder.ugs.designer.model.Size;
 import com.willwinder.universalgcodesender.i18n.Localization;
@@ -41,6 +42,7 @@ import javax.swing.JPanel;
 import javax.swing.JToggleButton;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.text.DefaultFormatterFactory;
 import java.awt.Component;
 import java.awt.geom.Point2D;
 import java.beans.PropertyChangeListener;
@@ -82,12 +84,22 @@ public class TransformationSettingsPanel extends JPanel implements EntitySetting
         lockRatioButton.setSelected(true);
     }
 
+    private static TextFieldWithUnit createExpressionField(Unit unit, int decimals, double initial) {
+        TextFieldWithUnit field = new TextFieldWithUnit(unit, decimals, initial);
+        field.setFormatterFactory(new DefaultFormatterFactory(
+                new ExpressionAwareTextFieldFormatter(unit, decimals),
+                new ExpressionAwareTextFieldFormatter(unit, decimals),
+                new ExpressionAwareTextFieldFormatter(unit, decimals, false)));
+        field.setValue(initial);
+        return field;
+    }
+
     private void initializeComponents() {
-        posXTextField = new TextFieldWithUnit(Unit.MM, 4, 0);
-        posYTextField = new TextFieldWithUnit(Unit.MM, 4, 0);
-        widthTextField = new TextFieldWithUnit(Unit.MM, 4, 0);
-        heightTextField = new TextFieldWithUnit(Unit.MM, 4, 0);
-        rotationTextField = new TextFieldWithUnit(Unit.DEGREE, 4, 0);
+        posXTextField = createExpressionField(Unit.MM, 4, 0);
+        posYTextField = createExpressionField(Unit.MM, 4, 0);
+        widthTextField = createExpressionField(Unit.MM, 4, 0);
+        heightTextField = createExpressionField(Unit.MM, 4, 0);
+        rotationTextField = createExpressionField(Unit.DEGREE, 4, 0);
         anchorSelector = new AnchorSelectorPanel();
 
         lockRatioButton = new JToggleButton(SvgIconLoader.loadImageIcon("img/link-off.svg", SvgIconLoader.SIZE_SMALL).orElse(null));

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/expression/ExpressionAwareTextFieldFormatterTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/expression/ExpressionAwareTextFieldFormatterTest.java
@@ -1,0 +1,135 @@
+/*
+    Copyright 2026 Damian Nikodem
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.gui.expression;
+
+import com.willwinder.universalgcodesender.model.Unit;
+import org.junit.Test;
+
+import java.text.ParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ExpressionAwareTextFieldFormatterTest {
+
+    private static double parseAsDouble(ExpressionAwareTextFieldFormatter f, String text) throws ParseException {
+        Object value = f.stringToValue(text);
+        return ((Number) value).doubleValue();
+    }
+
+    @Test
+    public void plainIntegerGoesThroughSuperPath() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        assertEquals(5.0, parseAsDouble(f, "5"), 1e-9);
+    }
+
+    @Test
+    public void plainNumberWithUnitSuffix() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        assertEquals(5.0, parseAsDouble(f, "5 mm"), 1e-9);
+    }
+
+    @Test
+    public void expressionEvaluates() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        assertEquals(1.5, parseAsDouble(f, "3/2"), 1e-9);
+    }
+
+    @Test
+    public void expressionWithTrailingUnit() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        assertEquals(1.5, parseAsDouble(f, "3/2 mm"), 1e-9);
+    }
+
+    @Test
+    public void expressionWithCommaDecimal() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        // Comma is the European decimal separator; the formatter normalises it.
+        assertEquals(8.2, parseAsDouble(f, "7,2+1"), 1e-9);
+    }
+
+    @Test
+    public void parenthesisedExpression() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        assertEquals(12.0, parseAsDouble(f, "(5+1)*2"), 1e-9);
+    }
+
+    @Test
+    public void roundingHonoursDecimals() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 2);
+        // 10/3 = 3.3333… should be rounded to 2 decimals by the super formatter
+        assertEquals(3.33, parseAsDouble(f, "10/3"), 1e-9);
+    }
+
+    @Test
+    public void garbageRejected() {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        try {
+            f.stringToValue("foo");
+            fail("expected ParseException");
+        } catch (ParseException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void identifierExpressionRejected() {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        try {
+            f.stringToValue("Math.sqrt(4)");
+            fail("expected ParseException");
+        } catch (ParseException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void valueToStringFormatsAsBeforeForMm() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.MM, 4);
+        String formatted = f.valueToString(1.5);
+        // The base formatter inserts " mm" by default
+        assertEquals("1.5 mm", formatted);
+    }
+
+    @Test
+    public void degreesPlainNumber() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.DEGREE, 4);
+        assertEquals(45.0, parseAsDouble(f, "45"), 1e-9);
+    }
+
+    @Test
+    public void degreesExpression() throws Exception {
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.DEGREE, 4);
+        assertEquals(45.0, parseAsDouble(f, "360/8"), 1e-9);
+    }
+
+    @Test
+    public void percentPlainNumberIsScaled() throws Exception {
+        // For PERCENT the base formatter divides by 100 — "50" should store 0.5.
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.PERCENT, 4);
+        assertEquals(0.5, parseAsDouble(f, "50"), 1e-9);
+    }
+
+    @Test
+    public void percentExpressionIsScaled() throws Exception {
+        // "50/2" = 25 % → stored as 0.25
+        ExpressionAwareTextFieldFormatter f = new ExpressionAwareTextFieldFormatter(Unit.PERCENT, 4);
+        assertEquals(0.25, parseAsDouble(f, "50/2"), 1e-9);
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/expression/MathExpressionParserTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/expression/MathExpressionParserTest.java
@@ -1,0 +1,167 @@
+/*
+    Copyright 2026 Damian Nikodem
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.gui.expression;
+
+import org.junit.Test;
+
+import java.util.OptionalDouble;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MathExpressionParserTest {
+
+    private static void assertEvaluates(String input, double expected) {
+        OptionalDouble result = MathExpressionParser.tryEvaluate(input);
+        assertTrue("expected " + input + " to evaluate", result.isPresent());
+        assertEquals(expected, result.getAsDouble(), 1e-9);
+    }
+
+    private static void assertRejects(String input) {
+        OptionalDouble result = MathExpressionParser.tryEvaluate(input);
+        assertFalse("expected " + input + " to be rejected", result.isPresent());
+    }
+
+    @Test
+    public void simpleDivision() {
+        assertEvaluates("3/2", 1.5);
+    }
+
+    @Test
+    public void addingDecimalAndInteger() {
+        assertEvaluates("7.2+1", 8.2);
+    }
+
+    @Test
+    public void parenthesisedExpression() {
+        assertEvaluates("(5+1)*2", 12.0);
+    }
+
+    @Test
+    public void unaryMinus() {
+        assertEvaluates("-3+4", 1.0);
+    }
+
+    @Test
+    public void whitespaceAndNegativeFactor() {
+        assertEvaluates("  10  *  -2 ", -20.0);
+    }
+
+    @Test
+    public void leadingDecimalPoint() {
+        assertEvaluates(".5+.5", 1.0);
+    }
+
+    @Test
+    public void plainNumberIsValid() {
+        assertEvaluates("5", 5.0);
+    }
+
+    @Test
+    public void plainNegativeDecimalIsValid() {
+        assertEvaluates("-3.7", -3.7);
+    }
+
+    @Test
+    public void emptyStringRejected() {
+        assertRejects("");
+    }
+
+    @Test
+    public void nullRejected() {
+        assertRejects(null);
+    }
+
+    @Test
+    public void identifierRejected() {
+        assertRejects("abc");
+    }
+
+    @Test
+    public void doubleOperatorRejected() {
+        assertRejects("5++3");
+    }
+
+    @Test
+    public void unmatchedOpeningParenRejected() {
+        assertRejects("(5+1");
+    }
+
+    @Test
+    public void unmatchedClosingParenRejected() {
+        assertRejects("5+1)");
+    }
+
+    @Test
+    public void divisionByZeroRejected() {
+        assertRejects("5/0");
+    }
+
+    @Test
+    public void semicolonRejected() {
+        assertRejects("5; System.exit(0)");
+    }
+
+    @Test
+    public void identifierWithDotRejected() {
+        assertRejects("Math.sqrt(4)");
+    }
+
+    @Test
+    public void scientificNotationRejected() {
+        assertRejects("1e3");
+    }
+
+    @Test
+    public void trailingOperatorRejected() {
+        assertRejects("5+");
+    }
+
+    @Test
+    public void leadingMultiplicationRejected() {
+        assertRejects("*5");
+    }
+
+    @Test
+    public void precedenceMixedOperators() {
+        assertEvaluates("2+3*4", 14.0);
+        assertEvaluates("2*3+4", 10.0);
+        assertEvaluates("8/4/2", 1.0);
+        assertEvaluates("8-4-2", 2.0);
+    }
+
+    @Test
+    public void parenthesisOverridesPrecedence() {
+        assertEvaluates("(2+3)*4", 20.0);
+    }
+
+    @Test
+    public void nestedParentheses() {
+        assertEvaluates("((1+2)*(3+4))", 21.0);
+    }
+
+    @Test
+    public void doubleNegationRejected() {
+        // Stacked unary operators almost always indicate a typo — keep the
+        // grammar strict and let the user re-type.
+        assertRejects("--5");
+        assertRejects("+-5");
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/selectionsettings/settingspanels/TransformationSettingsPanelTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/selectionsettings/settingspanels/TransformationSettingsPanelTest.java
@@ -1,0 +1,114 @@
+/*
+    Copyright 2026 Damian Nikodem
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.gui.selectionsettings.settingspanels;
+
+import com.willwinder.ugs.designer.gui.expression.ExpressionAwareTextFieldFormatter;
+import com.willwinder.universalgcodesender.uielements.TextFieldWithUnit;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.JFormattedTextField;
+import java.awt.GraphicsEnvironment;
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test that locks in the wiring between {@link TransformationSettingsPanel}
+ * and {@link ExpressionAwareTextFieldFormatter}. Without this, a future edit could
+ * silently swap the field constructor back to plain {@code TextFieldWithUnit} and
+ * the expression feature would regress without any unit test failing.
+ */
+public class TransformationSettingsPanelTest {
+
+    private static final String[] EXPRESSION_FIELD_NAMES = {
+            "posXTextField", "posYTextField", "widthTextField", "heightTextField", "rotationTextField"
+    };
+
+    private TransformationSettingsPanel panel;
+
+    @Before
+    public void setUp() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        panel = new TransformationSettingsPanel();
+    }
+
+    @Test
+    public void allTransformFieldsUseExpressionAwareFormatter() throws Exception {
+        for (String name : EXPRESSION_FIELD_NAMES) {
+            TextFieldWithUnit field = readField(name);
+            assertNotNull(name + " was not constructed", field);
+
+            JFormattedTextField.AbstractFormatterFactory factory = field.getFormatterFactory();
+            JFormattedTextField.AbstractFormatter formatter = factory.getFormatter(field);
+            assertTrue(name + " must use ExpressionAwareTextFieldFormatter, was " + formatter.getClass().getName(),
+                    formatter instanceof ExpressionAwareTextFieldFormatter);
+        }
+    }
+
+    @Test
+    public void typingAnExpressionIntoTheWidthFieldEvaluatesIt() throws Exception {
+        TextFieldWithUnit width = readField("widthTextField");
+
+        width.setText("3/2");
+        width.commitEdit();
+
+        assertEquals(1.5, ((Number) width.getValue()).doubleValue(), 1e-9);
+    }
+
+    @Test
+    public void typingAnExpressionWithUnitSuffixWorks() throws Exception {
+        TextFieldWithUnit height = readField("heightTextField");
+
+        height.setText("25.4 * 2 mm");
+        height.commitEdit();
+
+        assertEquals(50.8, ((Number) height.getValue()).doubleValue(), 1e-9);
+    }
+
+    @Test
+    public void rotationFieldAcceptsExpression() throws Exception {
+        TextFieldWithUnit rotation = readField("rotationTextField");
+
+        rotation.setText("360/8");
+        rotation.commitEdit();
+
+        assertEquals(45.0, ((Number) rotation.getValue()).doubleValue(), 1e-9);
+    }
+
+    @Test
+    public void plainNumericInputStillCommitsCleanly() throws Exception {
+        TextFieldWithUnit posX = readField("posXTextField");
+
+        posX.setText("42");
+        posX.commitEdit();
+
+        assertEquals(42.0, ((Number) posX.getValue()).doubleValue(), 1e-9);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T readField(String name) throws Exception {
+        Field field = TransformationSettingsPanel.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return (T) field.get(panel);
+    }
+}


### PR DESCRIPTION
  - New MathExpressionParser: ~150-line recursive-descent evaluator for + - * / and parens; strict whitelist, no ScriptEngine
  - New ExpressionAwareTextFieldFormatter: subclass of TextFieldUnitFormatter that runs the parser before falling back to super
  - TransformationSettingsPanel: X, Y, Width, Height, Rotation fields now build via createExpressionField helper using the new formatter
  - Tests: 38 unit + 5 integration cases covering grammar edges, unit/percent rounding, and field-wiring regression guard