### PR TITLE
Visualizer arc tolerance

### DIFF
--- a/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtils.java
@@ -522,6 +522,93 @@ public class GcodePreprocessorUtils {
     }
 
     /**
+     * Generates the points along an arc using a chord tolerance instead of a fixed segment length.
+     * <p>
+     * The number of segments is derived from the maximum allowed deviation (sagitta) between the
+     * generated chord and the true arc. This keeps the visual error bounded regardless of the arc
+     * size: large gentle arcs get few segments while small tight arcs stay smooth. It avoids the
+     * huge geometry generated when expanding large arcs with a fixed segment length.
+     *
+     * @param start            start position XYZ and rotations
+     * @param end              end position XYZ and rotations
+     * @param center           center of rotation
+     * @param clockwise        flag indicating clockwise or counter-clockwise
+     * @param radius           radius of the arc in the same units as the given start, end and center position
+     * @param chordToleranceMM the maximum allowed deviation between the chord and the arc, in millimeters
+     * @param plane            helper to select values for arcs across different planes
+     */
+    static public List<Position> generatePointsAlongArcWithTolerance(
+            final Position start,
+            final Position end,
+            final Position center,
+            boolean clockwise,
+            double radius,
+            double chordToleranceMM,
+            PlaneFormatter plane) {
+
+        // Calculate radius if necessary.
+        double r = radius;
+        if (r == 0) {
+            r = Math.sqrt(Math.pow(plane.axis0(start) - plane.axis0(center), 2.0) + Math.pow(plane.axis1(end) - plane.axis1(center), 2.0));
+        }
+
+        double startAngle = GcodePreprocessorUtils.getAngle(center, start, plane);
+        double endAngle = GcodePreprocessorUtils.getAngle(center, end, plane);
+        double sweep = GcodePreprocessorUtils.calculateSweep(startAngle, endAngle, clockwise);
+
+        // If the radius is negative we need invert the angle
+        if (radius < 0) {
+            startAngle = normalizeAngle(startAngle - Math.PI);
+        }
+
+        int numPoints = calculateNumberOfPointsToExpandWithTolerance(r, start.getUnits(), chordToleranceMM, sweep);
+        if (numPoints == 0) {
+            return Collections.emptyList();
+        }
+
+        return GcodePreprocessorUtils.generatePointsAlongArcBDring(start, end, center, clockwise, r, startAngle, sweep, numPoints, plane);
+    }
+
+    /**
+     * Calculates the number of segments an arc should be expanded into so that the chord never
+     * deviates from the arc by more than the given tolerance.
+     * <p>
+     * For a segment spanning an angle of {@code theta} the maximum deviation (sagitta) is
+     * {@code r * (1 - cos(theta / 2))}. Solving for the largest {@code theta} that keeps the
+     * deviation within {@code chordToleranceMM} gives {@code theta = 2 * acos(1 - tolerance / r)},
+     * and the number of segments is {@code ceil(sweep / theta)}.
+     *
+     * @param radius           the radius of the arc
+     * @param radiusUnits      the radius units
+     * @param chordToleranceMM the maximum allowed deviation between the chord and the arc, in millimeters
+     * @param sweep            the angle of the arc in radians
+     * @return the number of segments to split the arc into to stay within the given tolerance
+     */
+    public static int calculateNumberOfPointsToExpandWithTolerance(double radius, UnitUtils.Units radiusUnits, double chordToleranceMM, double sweep) {
+        double radiusMM = Math.abs(radius * UnitUtils.scaleUnits(radiusUnits, UnitUtils.Units.MM));
+        double absSweep = Math.abs(sweep);
+
+        // A degenerate arc (no radius or no sweep) is just a single segment.
+        if (radiusMM == 0 || absSweep == 0) {
+            return 1;
+        }
+
+        // Without a usable tolerance we can't derive a chord based count, just keep the arc as a single segment.
+        if (chordToleranceMM <= 0) {
+            return 1;
+        }
+
+        // The chord deviation can never be larger than the radius, so a single segment is enough.
+        if (chordToleranceMM >= radiusMM) {
+            return 1;
+        }
+
+        // Largest angle per segment that keeps the chord deviation (sagitta) within the tolerance.
+        double maxAnglePerSegment = 2.0 * Math.acos(1.0 - (chordToleranceMM / radiusMM));
+        return Math.max(1, (int) Math.ceil(absSweep / maxAnglePerSegment));
+    }
+
+    /**
      * Calculates the number of points to expand an arc into
      *
      * @param radius             the radius of the arc

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/GcodeViewParse.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/GcodeViewParse.java
@@ -129,6 +129,26 @@ public class GcodeViewParse {
      */
     public List<LineSegment> toObjFromReader(IGcodeStreamReader reader,
                                              double arcSegmentLength, double minSegmentLength) throws IOException, GcodeParserException {
+        return toObjFromReader(reader, arcSegmentLength, 0, minSegmentLength);
+    }
+
+    /**
+     * Same as {@link #toObjFromReader(IGcodeStreamReader, double, double)} but expands arcs using a
+     * chord tolerance instead of a fixed segment length. The number of segments is derived from the
+     * maximum allowed deviation between the chord and the arc, which avoids generating huge amounts
+     * of geometry for large arcs while keeping tight arcs smooth.
+     *
+     * @param reader           a stream with commands to parse.
+     * @param arcToleranceMM   the maximum allowed deviation between the chord and the arc, in millimeters.
+     * @param minSegmentLength the minimum length before a line is split up.
+     */
+    public List<LineSegment> toObjFromReaderWithArcTolerance(IGcodeStreamReader reader,
+                                                             double arcToleranceMM, double minSegmentLength) throws IOException, GcodeParserException {
+        return toObjFromReader(reader, 0, arcToleranceMM, minSegmentLength);
+    }
+
+    private List<LineSegment> toObjFromReader(IGcodeStreamReader reader,
+                                              double arcSegmentLength, double arcToleranceMM, double minSegmentLength) throws IOException, GcodeParserException {
         lines.clear();
         GcodeParser gp = getParser(minSegmentLength);
 
@@ -142,7 +162,7 @@ public class GcodeViewParse {
                 List<GcodeMeta> points = gp.addCommand(command, commandObject.getCommandNumber());
                 for (GcodeMeta meta : points) {
                     if (meta.point != null) {
-                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, lines);
+                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, arcToleranceMM, lines);
                         start = meta.point.point();
                     }
                 }
@@ -170,6 +190,24 @@ public class GcodeViewParse {
      * @param arcSegmentLength length of line segments when expanding an arc.
      */
     public List<LineSegment> toObjRedux(List<String> gcode, double arcSegmentLength, double minSegmentLength) throws GcodeParserException {
+        return toObjRedux(gcode, arcSegmentLength, 0, minSegmentLength);
+    }
+
+    /**
+     * Same as {@link #toObjRedux(List, double, double)} but expands arcs using a chord tolerance
+     * instead of a fixed segment length. The number of segments is derived from the maximum allowed
+     * deviation between the chord and the arc, which avoids generating huge amounts of geometry for
+     * large arcs while keeping tight arcs smooth.
+     *
+     * @param gcode            commands to visualize.
+     * @param arcToleranceMM   the maximum allowed deviation between the chord and the arc, in millimeters.
+     * @param minSegmentLength the minimum length before a line is split up.
+     */
+    public List<LineSegment> toObjReduxWithArcTolerance(List<String> gcode, double arcToleranceMM, double minSegmentLength) throws GcodeParserException {
+        return toObjRedux(gcode, 0, arcToleranceMM, minSegmentLength);
+    }
+
+    private List<LineSegment> toObjRedux(List<String> gcode, double arcSegmentLength, double arcToleranceMM, double minSegmentLength) throws GcodeParserException {
         GcodeParser gp = getParser(minSegmentLength);
 
         lines.clear();
@@ -183,7 +221,7 @@ public class GcodeViewParse {
                 List<GcodeMeta> points = gp.addCommand(command);
                 for (GcodeMeta meta : points) {
                     if (meta.point != null) {
-                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, lines);
+                        VisualizerUtils.addLinesFromPointSegment(start, meta.point, arcSegmentLength, arcToleranceMM, lines);
 
                         // if the last set point is in a different or unknown unit, crate a new point-instance with the correct unit set
                         if (start.getUnits() != UnitUtils.Units.MM && gp.getCurrentState().isMetric) {

--- a/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerUtils.java
+++ b/ugs-core/src/com/willwinder/universalgcodesender/visualizer/VisualizerUtils.java
@@ -131,11 +131,16 @@ public class VisualizerUtils {
     }
 
     /**
-     * Turns a point segment into one or more LineSegment. Arcs and rotations around axes are expanded
+     * Turns a point segment into one or more LineSegment. Arcs and rotations around axes are expanded.
+     * <p>
+     * If {@code arcToleranceMM} is greater than zero arcs are expanded using a chord tolerance, where
+     * the number of segments is derived from the maximum allowed deviation between the chord and the
+     * true arc. This avoids generating huge amounts of geometry for large arcs while keeping tight
+     * arcs smooth. Otherwise the fixed {@code arcSegmentLength} is used.
      *
      * @throws GcodeParserException if the lines could not be expanded
      */
-    public static void addLinesFromPointSegment(final Position start, final PointSegment endSegment, double arcSegmentLength, List<LineSegment> ret) throws GcodeParserException {
+    public static void addLinesFromPointSegment(final Position start, final PointSegment endSegment, double arcSegmentLength, double arcToleranceMM, List<LineSegment> ret) throws GcodeParserException {
         // For a line segment list ALL arcs must be converted to lines.
         double minArcLength = 0;
         endSegment.convertToMetric();
@@ -145,7 +150,7 @@ public class VisualizerUtils {
             if (start != null) {
                 // Expand arc for graphics.
                 if (endSegment.isArc()) {
-                    expandArc(start, endSegment, arcSegmentLength, ret, minArcLength);
+                    expandArc(start, endSegment, arcSegmentLength, arcToleranceMM, ret, minArcLength);
                 } else if (endSegment.isRotation()) {
                     expandRotationalLineSegment(start, endSegment, ret);
                 } else {
@@ -159,11 +164,18 @@ public class VisualizerUtils {
         }
     }
 
-    private static void expandArc(Position start, PointSegment endSegment, double arcSegmentLength, List<LineSegment> ret, double minArcLength) {
-        List<Position> points =
-                GcodePreprocessorUtils.generatePointsAlongArcBDring(
-                        start, endSegment.point(), endSegment.center(), endSegment.isClockwise(),
-                        endSegment.getRadius(), minArcLength, arcSegmentLength, new PlaneFormatter(endSegment.getPlaneState()));
+    private static void expandArc(Position start, PointSegment endSegment, double arcSegmentLength, double arcToleranceMM, List<LineSegment> ret, double minArcLength) {
+        PlaneFormatter plane = new PlaneFormatter(endSegment.getPlaneState());
+        List<Position> points;
+        if (arcToleranceMM > 0) {
+            points = GcodePreprocessorUtils.generatePointsAlongArcWithTolerance(
+                    start, endSegment.point(), endSegment.center(), endSegment.isClockwise(),
+                    endSegment.getRadius(), arcToleranceMM, plane);
+        } else {
+            points = GcodePreprocessorUtils.generatePointsAlongArcBDring(
+                    start, endSegment.point(), endSegment.center(), endSegment.isClockwise(),
+                    endSegment.getRadius(), minArcLength, arcSegmentLength, plane);
+        }
         // Create line segments from points.
         if (!points.isEmpty()) {
             Position startPoint = start;

--- a/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtilsTest.java
+++ b/ugs-core/test/com/willwinder/universalgcodesender/gcode/GcodePreprocessorUtilsTest.java
@@ -391,6 +391,71 @@ public class GcodePreprocessorUtilsTest {
     }
 
     @Test
+    public void calculateNumberOfPointsToExpandWithToleranceShouldDeriveCountFromCurvature() {
+        // A half circle with radius 5 mm and a 1 mm chord tolerance only needs a few segments...
+        assertEquals(3, GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(5, MM, 1, Math.PI));
+
+        // ...a tighter tolerance produces more segments.
+        assertEquals(8, GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(5, MM, 0.1, Math.PI));
+    }
+
+    @Test
+    public void calculateNumberOfPointsToExpandWithToleranceShouldNotExplodeForLargeArcs() {
+        // A large gentle arc (radius 1000 mm, 90 degrees) needs very few segments to stay within
+        // a 0.01 mm tolerance...
+        int withTolerance = GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(1000, MM, 0.01, Math.PI / 2);
+        assertEquals(176, withTolerance);
+
+        // ...where a fixed 0.01 mm segment length would generate a huge number of segments.
+        int withFixedSegmentLength = GcodePreprocessorUtils.calculateNumberOfPointsToExpand(1000, MM, 0, 0.01, Math.PI / 2);
+        assertEquals(157080, withFixedSegmentLength);
+        assertTrue("Tolerance based expansion should generate far fewer segments", withTolerance < withFixedSegmentLength);
+    }
+
+    @Test
+    public void calculateNumberOfPointsToExpandWithToleranceShouldHandleEdgeCases() {
+        // Tolerance larger than the radius can be satisfied with a single segment.
+        assertEquals(1, GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(5, MM, 10, Math.PI));
+        // No radius or no sweep is a single segment.
+        assertEquals(1, GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(0, MM, 0.1, Math.PI));
+        assertEquals(1, GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(5, MM, 0.1, 0));
+        // A non-positive tolerance falls back to a single segment instead of dividing by zero.
+        assertEquals(1, GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(5, MM, 0, Math.PI));
+        // A negative radius is handled like its absolute value.
+        assertEquals(3, GcodePreprocessorUtils.calculateNumberOfPointsToExpandWithTolerance(-5, MM, 1, Math.PI));
+    }
+
+    @Test
+    public void generatePointsAlongArcWithToleranceShouldGenerateAnArcWithinTolerance() {
+        Position start = new Position(0, 0, 0, MM);
+        Position end = new Position(10, 0, 0, MM);
+        Position center = new Position(5, 0, 0, MM);
+        double radius = 5;
+        double tolerance = 0.1;
+
+        List<Position> points = GcodePreprocessorUtils.generatePointsAlongArcWithTolerance(start, end, center, true, radius, tolerance, new PlaneFormatter(Plane.XY));
+
+        // 8 segments for a half circle plus the explicit end point.
+        assertEquals(9, points.size());
+        assertThatPointsAreWithinBoundary(start, end, radius, points);
+        assertTrue("Coordinates are generated in wrong units", points.stream().allMatch(p -> p.getUnits() == MM));
+
+        // Every generated point lies on the arc.
+        assertTrue("All points should lie on the arc", points.stream()
+                .allMatch(p -> Math.abs(Math.hypot(p.x - center.x, p.y - center.y) - radius) < 0.001));
+
+        // The deviation of each chord from the arc must stay within the requested tolerance.
+        for (int i = 1; i < points.size(); i++) {
+            Position a = points.get(i - 1);
+            Position b = points.get(i);
+            double midX = (a.x + b.x) / 2.0;
+            double midY = (a.y + b.y) / 2.0;
+            double deviation = radius - Math.hypot(midX - center.x, midY - center.y);
+            assertTrue("Chord deviation " + deviation + " should be within tolerance", deviation <= tolerance + 0.001);
+        }
+    }
+
+    @Test
     public void generatePointsAlongArcBDringShouldGenerateAnArcWhenPositionsAreInInches() {
         Position start = new Position(0, 0, 0, UnitUtils.Units.INCH);
         Position end = new Position(10 * UnitUtils.scaleUnits(MM, INCH), 0, 0, UnitUtils.Units.INCH);

--- a/ugs-fx/src/main/java/com/willwinder/universalgcodesender/fx/component/visualizer/models/GcodeModel.java
+++ b/ugs-fx/src/main/java/com/willwinder/universalgcodesender/fx/component/visualizer/models/GcodeModel.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
 
 public class GcodeModel extends Model {
     private static final Logger LOGGER = Logger.getLogger(GcodeModel.class.getName());
-    public static final double ARC_SEGMENT_LENGTH = 0.8;
+    public static final double ARC_TOLERANCE = 0.02;
     private final GcodeViewParse gcvp;
     private final MeshView meshView;
     private final BackendAPI backendAPI;
@@ -73,11 +73,11 @@ public class GcodeModel extends Model {
 
     private List<LineSegment> loadModel(GcodeViewParse gcvp, String gcodeFile) throws IOException, GcodeParserException {
         try (IGcodeStreamReader gsr = new GcodeStreamReader(new File(gcodeFile), new DefaultCommandCreator())) {
-            return gcvp.toObjFromReader(gsr, ARC_SEGMENT_LENGTH, 0);
+            return gcvp.toObjFromReaderWithArcTolerance(gsr, ARC_TOLERANCE, 0);
         } catch (GcodeStreamReader.NotGcodeStreamFile e) {
             List<String> linesInFile;
             linesInFile = VisualizerUtils.readFiletoArrayList(gcodeFile);
-            return gcvp.toObjRedux(linesInFile, ARC_SEGMENT_LENGTH, 0);
+            return gcvp.toObjReduxWithArcTolerance(linesInFile, ARC_TOLERANCE, 0);
         }
     }
 

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/jogl/VisualizationPanel.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/jogl/VisualizationPanel.java
@@ -127,6 +127,8 @@ public class VisualizationPanel extends JPanel {
 
         p.addGLEventListener(renderer);
 
+        animator.start();
+
         return p;
     }
 }

--- a/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/renderables/GcodeModel.java
+++ b/ugs-platform/ugs-platform-visualizer/src/main/java/com/willwinder/ugs/nbm/visualizer/renderables/GcodeModel.java
@@ -60,7 +60,7 @@ import java.util.logging.Logger;
  * @author wwinder
  */
 public class GcodeModel extends Renderable implements UGSEventListener {
-    public static final double ARC_SEGMENT_LENGTH = 0.1;
+    public static final double ARC_TOLERANCE = 0.01;
     private static final Logger logger = Logger.getLogger(GcodeModel.class.getName());
     private final GcodeLineColorizer colorizer = new GcodeLineColorizer();
     private final BackendAPI backend;
@@ -266,10 +266,10 @@ public class GcodeModel extends Renderable implements UGSEventListener {
 
     private List<LineSegment> loadModel(GcodeViewParse gcvp) throws IOException, GcodeParserException {
         try (IGcodeStreamReader gsr = new GcodeStreamReader(new File(gcodeFile), new DefaultCommandCreator())) {
-            return gcvp.toObjFromReader(gsr, ARC_SEGMENT_LENGTH, VisualizerOptions.getDoubleOption(VisualizerOptions.VISUALIZER_OPTION_MIN_SEGMENT_LENGTH_MM, 0));
+            return gcvp.toObjFromReaderWithArcTolerance(gsr, ARC_TOLERANCE, VisualizerOptions.getDoubleOption(VisualizerOptions.VISUALIZER_OPTION_MIN_SEGMENT_LENGTH_MM, 0));
         } catch (GcodeStreamReader.NotGcodeStreamFile e) {
             List<String> linesInFile = VisualizerUtils.readFiletoArrayList(this.gcodeFile);
-            return gcvp.toObjRedux(linesInFile, ARC_SEGMENT_LENGTH, VisualizerOptions.getDoubleOption(VisualizerOptions.VISUALIZER_OPTION_MIN_SEGMENT_LENGTH_MM, 0));
+            return gcvp.toObjReduxWithArcTolerance(linesInFile, ARC_TOLERANCE, VisualizerOptions.getDoubleOption(VisualizerOptions.VISUALIZER_OPTION_MIN_SEGMENT_LENGTH_MM, 0));
         }
     }
 


### PR DESCRIPTION
Previously when expanding arcs to be displayed in the visualizer we used a min segment length. This would cause a huge number of segments on larger arcs. With this change we use a choord tolerance. For large models with low curvature the chords barely deviates it will generate larger segments. For small models requires more subdivisions.

A test with a "normal" size model that was 200x200mm got 10x fewer segments without noticable differences.

Fixes: #2430
Fixes: #1477 (segment count went from 21632032 to 767032 segments)
