### PR TITLE
Arc fit

### DIFF
--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/ToolSettingsPanel.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/ToolSettingsPanel.java
@@ -71,6 +71,7 @@ public class ToolSettingsPanel extends JPanel {
     private TextFieldWithUnit maxSpindleSpeed;
     private JComboBox<String> spindleDirection;
     private TextFieldWithUnit flatnessPrecision;
+    private JCheckBox arcFitting;
 
     private transient ToolDefinition librarySnapshot;
 
@@ -157,9 +158,13 @@ public class ToolSettingsPanel extends JPanel {
         spindleDirection.setSelectedItem(controller.getSettings().getSpindleDirection());
         add(spindleDirection, TOOL_FIELD_CONSTRAINT);
 
-        add(new JLabel("Arc precision"));
+        add(new JLabel("Curve precision"));
         flatnessPrecision = new TextFieldWithUnit(Unit.MM, 3, controller.getSettings().getFlatnessPrecision());
         add(flatnessPrecision, TOOL_FIELD_CONSTRAINT);
+
+        add(new JLabel("Generate arcs"));
+        arcFitting = new JCheckBox("", controller.getSettings().getArcFitting());
+        add(arcFitting, TOOL_FIELD_CONSTRAINT);
     }
 
     private void rebuildDiameterField(UnitUtils.Units unit, double valueInFieldUnit) {
@@ -365,6 +370,7 @@ public class ToolSettingsPanel extends JPanel {
         }
     }
 
+
     public Settings getSettings() {
         Settings settings = new Settings();
         settings.applySettings(controller.getSettings());
@@ -379,6 +385,7 @@ public class ToolSettingsPanel extends JPanel {
         settings.setDetectMaxSpindleSpeed(getDetectMaxSpindleSpeed());
         settings.setSpindleDirection(getSpindleDirection());
         settings.setFlatnessPrecision(getFlatnessPrecision());
+        settings.setArcFitting(arcFitting.isSelected());
         if (librarySnapshot != null) {
             settings.setCurrentToolId(librarySnapshot.getId());
             settings.setCurrentToolSnapshot(new ToolDefinition(librarySnapshot));

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/ArcFitter.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/ArcFitter.java
@@ -1,0 +1,422 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.gcode.path;
+
+import com.willwinder.universalgcodesender.model.PartialPosition;
+
+import java.awt.geom.Line2D;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Replaces runs of straight lines with circular arcs where the lines are within a given tolerance
+ * of a circle.
+ * <p>
+ * Tool paths are generated from flattened geometry, so curves in the source design have already
+ * been reduced to short line segments by the time they reach this point. Recovering arcs from those
+ * lines produces smaller gcode and lets the controller move along the curve instead of through a
+ * series of corners.
+ * <p>
+ * The tolerance is the largest distance a fitted arc is allowed to deviate from the lines it
+ * replaces. It adds to whatever error the geometry stages introduced when flattening, so the
+ * flattening precision should be considerably finer than this tolerance.
+ */
+public class ArcFitter {
+
+    /**
+     * Any three points describe a circle exactly, so more than three are needed before a fit says
+     * anything about the points actually following a curve.
+     */
+    private static final int MINIMUM_ARC_POINTS = 5;
+
+    private static final double FULL_CIRCLE = 2 * Math.PI;
+
+    /**
+     * How many points that do not fit may be looked past while growing an arc, before the arc is
+     * considered finished.
+     */
+    private static final int MAXIMUM_POINTS_LOOKED_PAST = 4;
+
+    /**
+     * How small the fitted determinant may become, relative to its own scale, before the points are
+     * treated as describing a line rather than a circle.
+     */
+    private static final double COLLINEAR_EPSILON = 1e-12;
+
+    /**
+     * Arcs are kept to half a circle at most so that their two ends stay far apart.
+     * <p>
+     * A controller works out how far an arc travels from the angle between its start and its end,
+     * and reads an arc ending where it started as a full circle. Coordinates are rounded when
+     * written, so the ends of a nearly complete circle can round onto each other and turn the arc
+     * into a full circle, or just off each other and turn a full circle into almost no movement at
+     * all. Splitting well before that point keeps every arc unambiguous.
+     */
+    private static final double MAXIMUM_SWEEP = Math.PI;
+
+    /**
+     * Slack for accumulated rounding when adding up the steps of an arc, so that an arc landing
+     * exactly on the maximum sweep is not rejected for overshooting it.
+     */
+    private static final double SWEEP_EPSILON = 1e-9;
+
+    private final double tolerance;
+    private final double chordBulgeAllowance;
+
+    /**
+     * @param tolerance         the largest distance a fitted arc may deviate from the points it
+     *                          replaces
+     * @param flatnessPrecision the error the given points already carry from having been flattened
+     *                          from the original shape
+     */
+    public ArcFitter(double tolerance, double flatnessPrecision) {
+        if (tolerance <= 0) {
+            throw new IllegalArgumentException("The arc fitting tolerance must be larger than zero");
+        }
+        if (flatnessPrecision <= 0) {
+            throw new IllegalArgumentException("The flatness precision must be larger than zero");
+        }
+
+        this.tolerance = tolerance;
+        this.chordBulgeAllowance = Math.max(tolerance, flatnessPrecision);
+    }
+
+    /**
+     * Converts a run of positions into the segments needed to cut it, using arcs where possible.
+     * The first position is treated as the already reached start of the run, so the returned
+     * segments describe the movement from the first to the last position.
+     *
+     * @param points   the positions to move through, in order
+     * @param feedRate the feed rate to cut with
+     * @return the segments describing the run, never containing the first position on its own
+     */
+    public List<Segment> fit(List<PartialPosition> points, Integer feedRate) {
+        if (!isFittable(points)) {
+            return toLines(points, feedRate);
+        }
+
+        List<Segment> segments = new ArrayList<>();
+        int startIndex = 0;
+        while (startIndex < points.size() - 1) {
+            Arc arc = findLongestArc(points, startIndex);
+            if (arc == null) {
+                segments.add(toLine(points.get(startIndex + 1), feedRate));
+                startIndex++;
+            } else {
+                segments.add(Segment.arc(arc.type(), points.get(arc.endIndex()), arc.center(), feedRate));
+                startIndex = arc.endIndex();
+            }
+        }
+
+        return segments;
+    }
+
+    private boolean isFittable(List<PartialPosition> points) {
+        if (points.size() < MINIMUM_ARC_POINTS) {
+            return false;
+        }
+
+        PartialPosition first = points.get(0);
+        return points.stream().allMatch(p -> p.hasX() && p.hasY() && hasSameDepth(p, first));
+    }
+
+    /**
+     * Arcs are cut in the XY plane, so a run that changes depth would need a helical arc which is
+     * left to be cut as lines.
+     */
+    private boolean hasSameDepth(PartialPosition point, PartialPosition reference) {
+        if (point.hasZ() != reference.hasZ()) {
+            return false;
+        }
+
+        return !point.hasZ() || Math.abs(point.getZ() - reference.getZ()) < tolerance;
+    }
+
+    /**
+     * Grows the arc one point at a time for as long as it keeps fitting, so that each arc covers as
+     * much of the run as it can.
+     * <p>
+     * Each added point shifts the fitted circle slightly, which can push a borderline point just
+     * outside the tolerance even though a longer run of points fits comfortably. A few points are
+     * therefore looked past before giving up. This can not bridge a real corner, since every point
+     * in the run still has to sit on the arc that gets returned.
+     */
+    private Arc findLongestArc(List<PartialPosition> points, int startIndex) {
+        Arc longestArc = null;
+        int pointsSinceLastFit = 0;
+        for (int endIndex = startIndex + MINIMUM_ARC_POINTS - 1; endIndex < points.size(); endIndex++) {
+            Arc arc = fitArc(points, startIndex, endIndex);
+            if (arc == null) {
+                pointsSinceLastFit++;
+                if (pointsSinceLastFit > MAXIMUM_POINTS_LOOKED_PAST) {
+                    break;
+                }
+            } else {
+                pointsSinceLastFit = 0;
+                longestArc = arc;
+            }
+        }
+
+        return longestArc;
+    }
+
+    private Arc fitArc(List<PartialPosition> points, int startIndex, int endIndex) {
+        if (isWithinToleranceOfStraightLine(points, startIndex, endIndex)) {
+            return null;
+        }
+
+        Point2D center = fitCenter(points, startIndex, endIndex);
+        if (center == null) {
+            return null;
+        }
+
+        center = balanceCenterBetweenEnds(center, points.get(startIndex), points.get(endIndex));
+        double radius = distanceTo(center, points.get(startIndex));
+        if (!isOnCircle(points, startIndex, endIndex, center, radius)) {
+            return null;
+        }
+        if (!coversChordsWithinTolerance(points, startIndex, endIndex, radius)) {
+            return null;
+        }
+
+        Integer direction = findSweepDirection(points, startIndex, endIndex, center);
+        if (direction == null) {
+            return null;
+        }
+
+        return new Arc(direction > 0 ? SegmentType.CCWARC : SegmentType.CWARC, center, endIndex);
+    }
+
+    /**
+     * A straight line is both shorter to write and more accurate than an arc with an enormous
+     * radius, so nearly collinear points are left alone.
+     */
+    private boolean isWithinToleranceOfStraightLine(List<PartialPosition> points, int startIndex, int endIndex) {
+        PartialPosition start = points.get(startIndex);
+        PartialPosition end = points.get(endIndex);
+        for (int i = startIndex + 1; i < endIndex; i++) {
+            PartialPosition point = points.get(i);
+            double distance = Line2D.ptSegDist(start.getX(), start.getY(), end.getX(), end.getY(), point.getX(), point.getY());
+            if (distance > tolerance) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Finds the center of the circle that best fits all of the points using a least squares fit.
+     * Fitting all the points rather than picking three of them averages out the error left behind
+     * when the original curve was flattened, and stays well conditioned when the run closes back on
+     * itself and its first and last point coincide.
+     * <p>
+     * The points are centered on their centroid before fitting, which keeps the sums well scaled
+     * for geometry that sits far from the origin.
+     *
+     * @return the center of the fitted circle, or null when the points describe no circle
+     */
+    private Point2D fitCenter(List<PartialPosition> points, int startIndex, int endIndex) {
+        int count = (endIndex - startIndex) + 1;
+        double centroidX = 0;
+        double centroidY = 0;
+        for (int i = startIndex; i <= endIndex; i++) {
+            centroidX += points.get(i).getX();
+            centroidY += points.get(i).getY();
+        }
+        centroidX /= count;
+        centroidY /= count;
+
+        double sumUu = 0;
+        double sumUv = 0;
+        double sumVv = 0;
+        double sumUuu = 0;
+        double sumVvv = 0;
+        double sumUvv = 0;
+        double sumVuu = 0;
+        for (int i = startIndex; i <= endIndex; i++) {
+            double u = points.get(i).getX() - centroidX;
+            double v = points.get(i).getY() - centroidY;
+            sumUu += u * u;
+            sumUv += u * v;
+            sumVv += v * v;
+            sumUuu += u * u * u;
+            sumVvv += v * v * v;
+            sumUvv += u * v * v;
+            sumVuu += v * u * u;
+        }
+
+        double determinant = (sumUu * sumVv) - (sumUv * sumUv);
+        if (determinant <= COLLINEAR_EPSILON * sumUu * sumVv) {
+            return null;
+        }
+
+        double halfSumU = (sumUuu + sumUvv) / 2;
+        double halfSumV = (sumVvv + sumVuu) / 2;
+        double centerU = ((halfSumU * sumVv) - (halfSumV * sumUv)) / determinant;
+        double centerV = ((halfSumV * sumUu) - (halfSumU * sumUv)) / determinant;
+
+        return new Point2D.Double(centroidX + centerU, centroidY + centerV);
+    }
+
+    /**
+     * Moves the center onto the perpendicular bisector of the line between the first and last point,
+     * placing both ends of the arc on exactly the same radius.
+     * <p>
+     * Controllers derive the radius from the start point and the center they are given, and reject
+     * the move when the end point does not land on that same radius. Balancing the center here keeps
+     * the arc acceptable without having to discard arcs whose ends happen to sit a fraction apart.
+     */
+    private Point2D balanceCenterBetweenEnds(Point2D center, PartialPosition start, PartialPosition end) {
+        double chordX = end.getX() - start.getX();
+        double chordY = end.getY() - start.getY();
+        double chordLength = Math.hypot(chordX, chordY);
+        if (chordLength == 0) {
+            return center;
+        }
+
+        double midX = (start.getX() + end.getX()) / 2;
+        double midY = (start.getY() + end.getY()) / 2;
+        double normalX = -chordY / chordLength;
+        double normalY = chordX / chordLength;
+        double distanceAlongNormal = ((center.getX() - midX) * normalX) + ((center.getY() - midY) * normalY);
+
+        return new Point2D.Double(midX + (distanceAlongNormal * normalX), midY + (distanceAlongNormal * normalY));
+    }
+
+    /**
+     * The radius is measured from the start of the arc rather than averaged over the points, because
+     * that is the radius the controller derives from the center it is given and therefore the radius
+     * it actually cuts. Averaging would report a closer fit than the machine will follow.
+     */
+    private boolean isOnCircle(List<PartialPosition> points, int startIndex, int endIndex, Point2D center, double radius) {
+        for (int i = startIndex; i <= endIndex; i++) {
+            if (Math.abs(distanceTo(center, points.get(i)) - radius) > tolerance) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks how far the arc strays from the lines it replaces between the points, which the points
+     * alone can not tell us.
+     * <p>
+     * Straight edges often arrive as nothing but their two end points, and any large enough circle
+     * passes through a pair of points. Without this check a long straight edge would be replaced by
+     * a wide arc bowing away from it, cutting into material that should have been left alone.
+     * <p>
+     * The bulge is allowed to reach the flatness precision rather than only the fitting tolerance.
+     * A curve was flattened into points spaced closely enough to stay within that precision, so a
+     * bulge of that size means the points are consistent with having come from a curve of this
+     * radius. A bulge far beyond it means the points were spaced out because the shape was straight.
+     */
+    private boolean coversChordsWithinTolerance(List<PartialPosition> points, int startIndex, int endIndex, double radius) {
+        for (int i = startIndex; i < endIndex; i++) {
+            double halfChord = distanceBetween(points.get(i), points.get(i + 1)) / 2;
+            if (halfChord >= radius) {
+                return false;
+            }
+
+            double bulge = radius - Math.sqrt((radius * radius) - (halfChord * halfChord));
+            if (bulge > chordBulgeAllowance) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks that the points progress around the center in one direction without completing more
+     * than a full circle, which the radius alone can not tell us. Without this a path that doubles
+     * back along the same circle would be mistaken for an arc.
+     *
+     * @return 1 when the points sweep counter clockwise, -1 when clockwise, null when they do not
+     * describe a single sweep
+     */
+    private Integer findSweepDirection(List<PartialPosition> points, int startIndex, int endIndex, Point2D center) {
+        Integer direction = null;
+        double totalSweep = 0;
+        double previousAngle = angleTo(center, points.get(startIndex));
+
+        for (int i = startIndex + 1; i <= endIndex; i++) {
+            double angle = angleTo(center, points.get(i));
+            double step = normalizeAngle(angle - previousAngle);
+            previousAngle = angle;
+
+            if (step == 0) {
+                continue;
+            }
+
+            int stepDirection = step > 0 ? 1 : -1;
+            if (direction == null) {
+                direction = stepDirection;
+            } else if (direction != stepDirection) {
+                return null;
+            }
+
+            totalSweep += Math.abs(step);
+            if (totalSweep > MAXIMUM_SWEEP + SWEEP_EPSILON) {
+                return null;
+            }
+        }
+
+        return direction;
+    }
+
+    private static double normalizeAngle(double angle) {
+        double normalized = angle % FULL_CIRCLE;
+        if (normalized > Math.PI) {
+            normalized -= FULL_CIRCLE;
+        } else if (normalized <= -Math.PI) {
+            normalized += FULL_CIRCLE;
+        }
+
+        return normalized;
+    }
+
+    private static double distanceTo(Point2D center, PartialPosition point) {
+        return Math.hypot(point.getX() - center.getX(), point.getY() - center.getY());
+    }
+
+    private static double distanceBetween(PartialPosition from, PartialPosition to) {
+        return Math.hypot(to.getX() - from.getX(), to.getY() - from.getY());
+    }
+
+    private static double angleTo(Point2D center, PartialPosition point) {
+        return Math.atan2(point.getY() - center.getY(), point.getX() - center.getX());
+    }
+
+    private static List<Segment> toLines(List<PartialPosition> points, Integer feedRate) {
+        return points.stream()
+                .skip(1)
+                .map(point -> toLine(point, feedRate))
+                .toList();
+    }
+
+    private static Segment toLine(PartialPosition point, Integer feedRate) {
+        return new Segment(SegmentType.LINE, point, null, null, feedRate);
+    }
+
+    private record Arc(SegmentType type, Point2D center, int endIndex) {
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/Segment.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/Segment.java
@@ -18,6 +18,8 @@ package com.willwinder.ugs.designer.io.gcode.path;
 
 import com.willwinder.universalgcodesender.model.PartialPosition;
 
+import java.awt.geom.Point2D;
+
 /**
  * Path segment
  *
@@ -50,12 +52,51 @@ public final class Segment {
      */
     private final Integer feedSpeed;
 
-    public Segment(SegmentType type, PartialPosition point, String label, Integer spindleSpeed, Integer feedSpeed) {
+    /**
+     * The absolute center of the arc for {@link SegmentType#CWARC} and {@link SegmentType#CCWARC}
+     * segments, null for all other segment types. It is stored as an absolute position instead of
+     * as incremental I/J offsets so that the segment stays valid no matter which position precedes
+     * it, leaving the conversion to the gcode writer.
+     */
+    private final Point2D arcCenter;
+
+    public Segment(SegmentType type, PartialPosition point, String label, Integer spindleSpeed, Integer feedSpeed, Point2D arcCenter) {
+        if (type.isArc() && arcCenter == null) {
+            throw new IllegalArgumentException("A " + type + " segment requires an arc center");
+        }
+        if (!type.isArc() && arcCenter != null) {
+            throw new IllegalArgumentException("A " + type + " segment can not have an arc center");
+        }
+        if (type.isArc() && (point == null || !point.hasX() || !point.hasY())) {
+            throw new IllegalArgumentException("A " + type + " segment requires a point with an X and Y, as an arc can not be written without them");
+        }
+
         this.type = type;
         this.point = point;
         this.label = label;
         this.spindleSpeed = spindleSpeed;
         this.feedSpeed = feedSpeed;
+        this.arcCenter = arcCenter == null ? null : new Point2D.Double(arcCenter.getX(), arcCenter.getY());
+    }
+
+    public Segment(SegmentType type, PartialPosition point, String label, Integer spindleSpeed, Integer feedSpeed) {
+        this(type, point, label, spindleSpeed, feedSpeed, null);
+    }
+
+    /**
+     * Creates an arc segment ending at the given point, curving around the given absolute center.
+     *
+     * @param type      either {@link SegmentType#CWARC} or {@link SegmentType#CCWARC}
+     * @param point     the position where the arc ends
+     * @param arcCenter the absolute center that the arc curves around
+     * @param feedSpeed the feed rate to cut the arc with
+     */
+    public static Segment arc(SegmentType type, PartialPosition point, Point2D arcCenter, Integer feedSpeed) {
+        if (!type.isArc()) {
+            throw new IllegalArgumentException("A " + type + " segment is not an arc");
+        }
+
+        return new Segment(type, point, null, null, feedSpeed, arcCenter);
     }
 
     public Segment(SegmentType type, PartialPosition point) {
@@ -98,6 +139,15 @@ public final class Segment {
             throw new NullPointerException(type + " segment has no point!");
 
         return point;
+    }
+
+    /**
+     * Get the absolute center that an arc segment curves around
+     *
+     * @return the arc center, or null if this is not an arc segment
+     */
+    public Point2D getArcCenter() {
+        return arcCenter == null ? null : new Point2D.Double(arcCenter.getX(), arcCenter.getY());
     }
 
     public Integer getSpindleSpeed() {

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/SegmentType.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/SegmentType.java
@@ -60,4 +60,8 @@ public enum SegmentType {
     SegmentType(String gc) {
         gcode = gc;
     }
+
+    public boolean isArc() {
+        return this == CWARC || this == CCWARC;
+    }
 }

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/AbstractToolPath.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/AbstractToolPath.java
@@ -19,6 +19,7 @@
 package com.willwinder.ugs.designer.io.gcode.toolpaths;
 
 import com.willwinder.ugs.designer.entities.cuttable.Cuttable;
+import com.willwinder.ugs.designer.io.gcode.path.ArcFitter;
 import com.willwinder.ugs.designer.io.gcode.path.GcodePath;
 import com.willwinder.ugs.designer.io.gcode.path.PathGenerator;
 import com.willwinder.ugs.designer.io.gcode.path.Segment;
@@ -95,18 +96,36 @@ public abstract class AbstractToolPath implements PathGenerator {
             if (source.getSpindleSpeed() > 0) {
                 gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d)), null));
             }
-            
+
             coordinateList.forEach(cl -> {
                 if (!cl.isEmpty()) {
                     addSafeHeightSegmentTo(gcodePath, cl.get(0), coordinateList.get(0) == cl);
-                            
+
                     gcodePath.addSegment(SegmentType.POINT, cl.get(0));
-                    cl.forEach(c -> gcodePath.addSegment(SegmentType.LINE, c, source.getFeedRate()));
+                    toMotionSegments(cl, source.getFeedRate()).forEach(gcodePath::addSegment);
                 }
             });
 
             addSafeHeightSegment(gcodePath, null,true);
         }
+    }
+
+    /**
+     * Converts the coordinates of a single run into the segments cutting it. The first coordinate is
+     * left out, since it has already been reached by plunging down to it.
+     */
+    private List<Segment> toMotionSegments(List<PartialPosition> coordinates, int feedRate) {
+        if (settings.getArcFitting() && settings.getFlatnessPrecision() > 0) {
+            // Arcs are held to the same precision the geometry was flattened with, so that a single
+            // setting describes how far the tool path may stray from the design
+            double precision = settings.getFlatnessPrecision();
+            return new ArcFitter(precision, precision).fit(coordinates, feedRate);
+        }
+
+        return coordinates.stream()
+                .skip(1)
+                .map(coordinate -> new Segment(SegmentType.LINE, coordinate, null, null, feedRate))
+                .toList();
     }
 
 

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/PocketToolPath.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/PocketToolPath.java
@@ -49,7 +49,7 @@ public class PocketToolPath extends AbstractToolPath {
         double stepOver = Math.min(Math.max(0.01, Math.abs(settings.getToolStepOver())), 1.0);
         Geometry geometryCollection = convertAreaToGeometry(new Area(source.getShape()), getGeometryFactory(), settings.getFlatnessPrecision());
         Geometry shell = geometryCollection.buffer(-settings.getToolDiameter() / 2d);
-        List<Geometry> geometries = bufferAndCollectGeometries(geometryCollection, settings.getToolDiameter(), stepOver);
+        List<Geometry> geometries = bufferAndCollectGeometries(geometryCollection, settings.getToolDiameter(), stepOver, settings.getFlatnessPrecision());
 
         List<List<PartialPosition>> coordinateList = new ArrayList<>();
         addGeometriesToCoordinatesList(shell, geometries, coordinateList, getStartDepth(), clockwise);

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/ToolPathUtils.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/ToolPathUtils.java
@@ -45,8 +45,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class ToolPathUtils {
-    public static final double DISTANCE_TOLERANCE = 0.1;
-
     public static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
     private ToolPathUtils() {
@@ -199,14 +197,23 @@ public class ToolPathUtils {
         return new ToolPathStats(totalFeedLength, totalRapidLength);
     }
 
-    public static List<Geometry> bufferAndCollectGeometries(Geometry geometry, double toolDiameter, double stepOver) {
+    /**
+     * Offsets the geometry inwards repeatedly to produce the rings clearing out a pocket.
+     *
+     * @param geometry          the geometry to clear out
+     * @param toolDiameter      the diameter of the tool doing the clearing
+     * @param stepOver          how much of the tool diameter to move between each ring
+     * @param simplifyTolerance how far the rings may be moved when dropping points that are not
+     *                          needed to describe them
+     */
+    public static List<Geometry> bufferAndCollectGeometries(Geometry geometry, double toolDiameter, double stepOver, double simplifyTolerance) {
         double buffer = toolDiameter / 2d;
-        List<Geometry> geometries = ToolPathUtils.bufferAndCollectGeometries(geometry, buffer, toolDiameter, stepOver);
+        List<Geometry> geometries = ToolPathUtils.bufferAndCollectGeometries(geometry, buffer, toolDiameter, stepOver, simplifyTolerance);
         geometries.sort(new GeometrySizeComparator());
         return geometries;
     }
 
-    public static List<Geometry> bufferAndCollectGeometries(Geometry geometry, double buffer, double toolDiameter, double stepOver) {
+    public static List<Geometry> bufferAndCollectGeometries(Geometry geometry, double buffer, double toolDiameter, double stepOver, double simplifyTolerance) {
         Geometry bufferedGeometry = geometry.buffer(-buffer);
         if (bufferedGeometry.getNumGeometries() <= 0 || bufferedGeometry.isEmpty()) {
             return Collections.emptyList();
@@ -215,15 +222,15 @@ public class ToolPathUtils {
         List<Geometry> result = new ArrayList<>();
         for (int i = 0; i < bufferedGeometry.getNumGeometries(); i++) {
             Geometry geom = bufferedGeometry.getGeometryN(i);
-            result.addAll(bufferAndCollectGeometries(geom, toolDiameter * stepOver, toolDiameter, stepOver));
+            result.addAll(bufferAndCollectGeometries(geom, toolDiameter * stepOver, toolDiameter, stepOver, simplifyTolerance));
 
             if (geom instanceof Polygon polygon) {
-                result.add(DouglasPeuckerSimplifier.simplify(polygon.getExteriorRing(), DISTANCE_TOLERANCE));
+                result.add(DouglasPeuckerSimplifier.simplify(polygon.getExteriorRing(), simplifyTolerance));
                 for (int j = 0; j < polygon.getNumInteriorRing(); j++) {
-                    result.add(DouglasPeuckerSimplifier.simplify(polygon.getInteriorRingN(j), DISTANCE_TOLERANCE));
+                    result.add(DouglasPeuckerSimplifier.simplify(polygon.getInteriorRingN(j), simplifyTolerance));
                 }
             } else {
-                result.add(DouglasPeuckerSimplifier.simplify(geom, DISTANCE_TOLERANCE));
+                result.add(DouglasPeuckerSimplifier.simplify(geom, simplifyTolerance));
             }
         }
 

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriter.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriter.java
@@ -28,11 +28,19 @@ import static com.willwinder.universalgcodesender.utils.MathUtils.isEqual;
 import com.willwinder.universalgcodesender.utils.Version;
 import org.apache.commons.lang3.StringUtils;
 
+import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.EnumSet;
+import java.util.Set;
 
 public class GrblGcodeWriter implements GcodeWriter {
     private static final String HEADER = "; This file was generated with \"Universal Gcode Sender " + Version.getVersionString() + "\"\n\n";
+
+    /**
+     * The axes of the plane that arcs are cut in, which is always XY since the header selects G17
+     */
+    private static final Set<Axis> PLANE_AXES = EnumSet.of(Axis.X, Axis.Y);
 
     private final Settings settings;
     private final Writer writer;
@@ -106,22 +114,63 @@ public class GrblGcodeWriter implements GcodeWriter {
                     hasFeedRateSet = true;
                 }
 
-                writer.write(getPointFormattedGCode(segment) + "\n");
+                // The arc offsets are relative to the start of the arc, so they need to be
+                // formatted before the current position is advanced to the end of the arc
+                String arcOffsets = segment.type.isArc() ? getArcOffsetFormattedGCode(segment) : "";
+                writer.write(getPointFormattedGCode(segment, segment.type.isArc()) + arcOffsets + "\n");
             }
         }
     }
 
     private String getPointFormattedGCode(Segment segment) {
+        return getPointFormattedGCode(segment, false);
+    }
+
+    /**
+     * @param alwaysWritePlaneAxes writes the axes of the current plane even when they have not
+     *                             changed. Grbl rejects an arc that carries no axis words, which
+     *                             happens when an arc ends where it started.
+     */
+    private String getPointFormattedGCode(Segment segment, boolean alwaysWritePlaneAxes) {
         StringBuilder result = new StringBuilder();
         PartialPosition newPoint = segment.getPoint();
 
         for (Axis axis : Axis.values()) {
-            if (newPoint.hasAxis(axis) && (currentPoint == null || !currentPoint.hasAxis(axis) || !isEqual(newPoint.getAxis(axis), currentPoint.getAxis(axis), 0.0001))) {
+            if (!newPoint.hasAxis(axis)) {
+                continue;
+            }
+
+            boolean isChanged = currentPoint == null || !currentPoint.hasAxis(axis) || !isEqual(newPoint.getAxis(axis), currentPoint.getAxis(axis), 0.0001);
+            if (isChanged || (alwaysWritePlaneAxes && PLANE_AXES.contains(axis))) {
                 result.append(axis.name()).append(Utils.formatter.format(newPoint.getAxis(axis)));
             }
         }
-        currentPoint = segment.point;
+        currentPoint = advanceCurrentPoint(newPoint);
         return result.toString();
+    }
+
+    /**
+     * Grbl only supports incremental arc offsets, so the absolute arc center is converted to an
+     * offset from the position where the arc starts.
+     */
+    private String getArcOffsetFormattedGCode(Segment segment) {
+        if (currentPoint == null || !currentPoint.hasX() || !currentPoint.hasY()) {
+            throw new IllegalStateException("An arc segment must be preceded by a position with a known X and Y");
+        }
+
+        Point2D arcCenter = segment.getArcCenter();
+        return "I" + Utils.formatter.format(arcCenter.getX() - currentPoint.getX())
+                + "J" + Utils.formatter.format(arcCenter.getY() - currentPoint.getY());
+    }
+
+    private PartialPosition advanceCurrentPoint(PartialPosition newPoint) {
+        if (currentPoint == null) {
+            return newPoint;
+        }
+
+        PartialPosition.Builder builder = PartialPosition.builder(currentPoint);
+        newPoint.getPositionIn(currentPoint.getUnits()).getAll().forEach(builder::setValue);
+        return builder.build();
     }
 
     @Override

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/Settings.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/Settings.java
@@ -41,7 +41,7 @@ public class Settings {
     private boolean detectMaxSpindleSpeed = true;
     private String spindleDirection = "M3";
     private double flatnessPrecision = 0.1;
-    private boolean arcFitting = false;
+    private boolean arcFitting = true;
     private String currentToolId;
     private ToolDefinition currentToolSnapshot;
 

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/Settings.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/Settings.java
@@ -41,6 +41,7 @@ public class Settings {
     private boolean detectMaxSpindleSpeed = true;
     private String spindleDirection = "M3";
     private double flatnessPrecision = 0.1;
+    private boolean arcFitting = false;
     private String currentToolId;
     private ToolDefinition currentToolSnapshot;
 
@@ -204,6 +205,7 @@ public class Settings {
         setDetectMaxSpindleSpeed(settings.getDetectMaxSpindleSpeed());
         setSpindleDirection(settings.getSpindleDirection());
         setFlatnessPrecision(settings.getFlatnessPrecision());
+        setArcFitting(settings.getArcFitting());
         setCurrentToolId(settings.getCurrentToolId());
         ToolDefinition snapshot = settings.getCurrentToolSnapshot();
         setCurrentToolSnapshot(snapshot == null ? null : new ToolDefinition(snapshot));
@@ -245,6 +247,20 @@ public class Settings {
 
     public void setFlatnessPrecision(double flatnessPrecision) {
         this.flatnessPrecision = flatnessPrecision;
+        notifyListeners();
+    }
+
+    /**
+     * Returns whether runs of straight lines in generated tool paths should be replaced by arcs
+     * where the lines follow a circle. The arcs are held to the same precision as
+     * {@link #getFlatnessPrecision()}.
+     */
+    public boolean getArcFitting() {
+        return arcFitting;
+    }
+
+    public void setArcFitting(boolean arcFitting) {
+        this.arcFitting = arcFitting;
         notifyListeners();
     }
 

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/SimpleGcodeRouterArcTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/SimpleGcodeRouterArcTest.java
@@ -1,0 +1,94 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.gcode;
+
+import com.willwinder.ugs.designer.entities.cuttable.CutType;
+import com.willwinder.ugs.designer.entities.cuttable.Cuttable;
+import com.willwinder.ugs.designer.entities.cuttable.Ellipse;
+import com.willwinder.ugs.designer.model.Settings;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class SimpleGcodeRouterArcTest {
+
+    private static final Pattern ARC_WITH_OFFSETS = Pattern.compile("G[23] .*I-?[\\d.]+J-?[\\d.]+");
+
+    @Test
+    public void toGcode_shouldWriteArcsWithCenterOffsetsWhenArcFittingIsEnabled() throws IOException {
+        Settings settings = new Settings();
+        settings.setArcFitting(true);
+
+        String gcode = routeCircle(settings);
+
+        assertTrue(gcode, gcode.lines().anyMatch(line -> ARC_WITH_OFFSETS.matcher(line).find()));
+    }
+
+    @Test
+    public void toGcode_shouldNotWriteArcsWhenArcFittingIsDisabled() throws IOException {
+        Settings settings = new Settings();
+
+        String gcode = routeCircle(settings);
+
+        assertTrue(gcode, gcode.lines().noneMatch(line -> line.startsWith("G2 ") || line.startsWith("G3 ")));
+    }
+
+    @Test
+    public void toGcode_shouldWriteAxisWordsOnEveryArc() throws IOException {
+        // Grbl rejects an arc carrying no axis words with "error:26", which happens when an arc
+        // ends where it started and the unchanged coordinates get left out
+        Settings settings = new Settings();
+        settings.setArcFitting(true);
+
+        for (CutType cutType : List.of(CutType.ON_PATH, CutType.INSIDE_PATH, CutType.OUTSIDE_PATH, CutType.POCKET)) {
+            for (double diameter : new double[]{5, 10, 40, 200}) {
+                String gcode = route(settings, cutType, diameter);
+                gcode.lines()
+                        .filter(line -> line.startsWith("G2 ") || line.startsWith("G3 "))
+                        .forEach(line -> assertTrue(
+                                cutType + " ⌀" + diameter + " produced an arc without axis words: " + line,
+                                line.contains("X") || line.contains("Y")));
+            }
+        }
+    }
+
+    private static String route(Settings settings, CutType cutType, double diameter) throws IOException {
+        Ellipse circle = new Ellipse(0, 0, diameter, diameter);
+        circle.setCutType(cutType);
+        circle.setTargetDepth(1);
+
+        StringWriter writer = new StringWriter();
+        new SimpleGcodeRouter(settings).toGcode(List.of((Cuttable) circle), writer);
+        return writer.toString();
+    }
+
+    private static String routeCircle(Settings settings) throws IOException {
+        Ellipse circle = new Ellipse(0, 0, 40, 40);
+        circle.setCutType(CutType.ON_PATH);
+        circle.setTargetDepth(1);
+
+        StringWriter writer = new StringWriter();
+        new SimpleGcodeRouter(settings).toGcode(List.of((Cuttable) circle), writer);
+        return writer.toString();
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/SimpleGcodeRouterArcTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/SimpleGcodeRouterArcTest.java
@@ -47,6 +47,7 @@ public class SimpleGcodeRouterArcTest {
     @Test
     public void toGcode_shouldNotWriteArcsWhenArcFittingIsDisabled() throws IOException {
         Settings settings = new Settings();
+        settings.setArcFitting(false);
 
         String gcode = routeCircle(settings);
 

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/path/ArcFitterTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/path/ArcFitterTest.java
@@ -1,0 +1,261 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.gcode.path;
+
+import com.willwinder.universalgcodesender.model.PartialPosition;
+import com.willwinder.universalgcodesender.model.UnitUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArcFitterTest {
+
+    private static final double TOLERANCE = 0.01;
+    private static final double FLATNESS = 0.1;
+
+    @Test
+    public void constructor_shouldFailForToleranceThatIsNotPositive() {
+        assertThrows(IllegalArgumentException.class, () -> new ArcFitter(0, FLATNESS));
+        assertThrows(IllegalArgumentException.class, () -> new ArcFitter(-0.1, FLATNESS));
+    }
+
+    @Test
+    public void constructor_shouldFailForFlatnessPrecisionThatIsNotPositive() {
+        assertThrows(IllegalArgumentException.class, () -> new ArcFitter(TOLERANCE, 0));
+        assertThrows(IllegalArgumentException.class, () -> new ArcFitter(TOLERANCE, -0.1));
+    }
+
+    @Test
+    public void fit_shouldCreateLinesForPointsSpacedTooFarApartForTheirRadius() {
+        List<PartialPosition> points = arcPoints(0, 0, 200, 0, 0.4, 5);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(4, segments.size());
+        assertTrue(segments.stream().allMatch(s -> s.getType() == SegmentType.LINE));
+    }
+
+    @Test
+    public void fit_shouldCreateCounterClockwiseArcForCounterClockwisePoints() {
+        List<PartialPosition> points = arcPoints(0, 0, 10, 0, Math.PI / 2, 20);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(1, segments.size());
+        assertEquals(SegmentType.CCWARC, segments.get(0).getType());
+        assertEquals(0d, segments.get(0).getArcCenter().getX(), 1e-6);
+        assertEquals(0d, segments.get(0).getArcCenter().getY(), 1e-6);
+    }
+
+    @Test
+    public void fit_shouldCreateClockwiseArcForClockwisePoints() {
+        List<PartialPosition> points = arcPoints(0, 0, 10, 0, -Math.PI / 2, 20);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(1, segments.size());
+        assertEquals(SegmentType.CWARC, segments.get(0).getType());
+    }
+
+    @Test
+    public void fit_shouldCreateArcEndingAtTheLastPoint() {
+        List<PartialPosition> points = arcPoints(5, 5, 10, 0, Math.PI / 2, 20);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        PartialPosition end = segments.get(segments.size() - 1).getPoint();
+        assertEquals(points.get(points.size() - 1).getX(), end.getX(), 1e-6);
+        assertEquals(points.get(points.size() - 1).getY(), end.getY(), 1e-6);
+    }
+
+    @Test
+    public void fit_shouldCreateLinesForStraightPoints() {
+        List<PartialPosition> points = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            points.add(position(i, i * 2));
+        }
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(19, segments.size());
+        assertTrue(segments.stream().allMatch(s -> s.getType() == SegmentType.LINE));
+    }
+
+    @Test
+    public void fit_shouldCreateLinesForPointsThatDoNotFollowACircle() {
+        List<PartialPosition> points = List.of(
+                position(0, 0), position(1, 1), position(2, 0),
+                position(3, 1), position(4, 0), position(5, 1));
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(5, segments.size());
+        assertTrue(segments.stream().allMatch(s -> s.getType() == SegmentType.LINE));
+    }
+
+    @Test
+    public void fit_shouldCreateLinesForFewerPointsThanNeededForAnArc() {
+        List<PartialPosition> points = arcPoints(0, 0, 10, 0, Math.PI / 2, 4);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(3, segments.size());
+        assertTrue(segments.stream().allMatch(s -> s.getType() == SegmentType.LINE));
+    }
+
+    @Test
+    public void fit_shouldCreateLinesForPointsOnCircleAtChangingDepths() {
+        List<PartialPosition> points = new ArrayList<>();
+        List<PartialPosition> circle = arcPoints(0, 0, 10, 0, Math.PI / 2, 20);
+        for (int i = 0; i < circle.size(); i++) {
+            points.add(PartialPosition.builder(circle.get(i)).setZ(-i * 0.1).build());
+        }
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(19, segments.size());
+        assertTrue(segments.stream().allMatch(s -> s.getType() == SegmentType.LINE));
+    }
+
+    @Test
+    public void fit_shouldCreateLinesForPointsDeviatingMoreThanTheTolerance() {
+        List<PartialPosition> points = new ArrayList<>(arcPoints(0, 0, 10, 0, Math.PI / 2, 20));
+        points.set(2, position(points.get(2).getX() + 1, points.get(2).getY()));
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(SegmentType.LINE, segments.get(0).getType());
+    }
+
+    @Test
+    public void fit_shouldCreateSeparateArcsForPointsChangingDirection() {
+        List<PartialPosition> points = new ArrayList<>(arcPoints(0, 0, 10, 0, Math.PI / 2, 10));
+        List<PartialPosition> back = arcPoints(0, 0, 10, Math.PI / 2, -Math.PI / 2, 10);
+        points.addAll(back.subList(1, back.size()));
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(2, segments.size());
+        assertEquals(SegmentType.CCWARC, segments.get(0).getType());
+        assertEquals(SegmentType.CWARC, segments.get(1).getType());
+    }
+
+    @Test
+    public void fit_shouldSplitClosedCircleIntoArcsThatEndWhereTheyStarted() {
+        List<PartialPosition> points = arcPoints(0, 0, 10, 0, 2 * Math.PI, 33);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertTrue(segments.size() > 1);
+        assertTrue(segments.stream().allMatch(s -> s.getType().isArc()));
+        segments.forEach(s -> {
+            assertEquals(0d, s.getArcCenter().getX(), 1e-6);
+            assertEquals(0d, s.getArcCenter().getY(), 1e-6);
+        });
+    }
+
+    @Test
+    public void fit_shouldNotCreateArcSweepingMoreThanHalfACircle() {
+        // A controller reads an arc ending where it started as a full circle, so arcs are kept
+        // well short of that to stay unambiguous once the coordinates have been rounded
+        List<PartialPosition> points = arcPoints(0, 0, 10, 0, 2 * Math.PI, 129);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        PartialPosition start = points.get(0);
+        for (Segment segment : segments) {
+            assertTrue("An arc swept more than half a circle", sweepOf(start, segment) <= Math.PI + 1e-6);
+            start = segment.getPoint();
+        }
+    }
+
+    private static double sweepOf(PartialPosition start, Segment arc) {
+        double startAngle = Math.atan2(start.getY() - arc.getArcCenter().getY(), start.getX() - arc.getArcCenter().getX());
+        double endAngle = Math.atan2(arc.getPoint().getY() - arc.getArcCenter().getY(), arc.getPoint().getX() - arc.getArcCenter().getX());
+        double sweep = arc.getType() == SegmentType.CCWARC ? endAngle - startAngle : startAngle - endAngle;
+        return sweep < 0 ? sweep + (2 * Math.PI) : sweep;
+    }
+
+    @Test
+    public void fit_shouldCreateArcWithAccurateCenterForCircleFarFromOrigin() {
+        List<PartialPosition> points = arcPoints(1_200.5, -843.25, 60, 1.1, Math.PI / 2, 30);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(1, segments.size());
+        assertEquals(1_200.5, segments.get(0).getArcCenter().getX(), 1e-6);
+        assertEquals(-843.25, segments.get(0).getArcCenter().getY(), 1e-6);
+    }
+
+    @Test
+    public void fit_shouldCreateLineFollowedByArc() {
+        List<PartialPosition> points = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            points.add(position(-20 + i, 0));
+        }
+        points.addAll(arcPoints(0, 0, 10, Math.PI, -Math.PI / 2, 20));
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertTrue(segments.stream().anyMatch(s -> s.getType() == SegmentType.LINE));
+        assertEquals(SegmentType.CWARC, segments.get(segments.size() - 1).getType());
+    }
+
+    @Test
+    public void fit_shouldKeepTheFeedRateOnEverySegment() {
+        List<PartialPosition> points = new ArrayList<>(arcPoints(0, 0, 10, 0, Math.PI / 2, 20));
+        points.add(position(0, 30));
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_234);
+
+        assertTrue(segments.stream().allMatch(s -> Integer.valueOf(1_234).equals(s.getFeedSpeed())));
+    }
+
+    @Test
+    public void fit_shouldKeepArcWithinToleranceOfTheOriginalPoints() {
+        List<PartialPosition> points = arcPoints(3, -7, 25, 0.4, Math.PI / 3, 40);
+
+        List<Segment> segments = new ArcFitter(TOLERANCE, FLATNESS).fit(points, 1_000);
+
+        assertEquals(1, segments.size());
+        double radius = segments.get(0).getArcCenter().distance(points.get(0).getX(), points.get(0).getY());
+        for (PartialPosition point : points) {
+            double distance = segments.get(0).getArcCenter().distance(point.getX(), point.getY());
+            assertEquals(radius, distance, TOLERANCE);
+        }
+    }
+
+    private static List<PartialPosition> arcPoints(double centerX, double centerY, double radius, double startAngle, double sweep, int count) {
+        List<PartialPosition> points = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            double angle = startAngle + ((sweep * i) / (count - 1));
+            points.add(position(centerX + (radius * Math.cos(angle)), centerY + (radius * Math.sin(angle))));
+        }
+
+        return points;
+    }
+
+    private static PartialPosition position(double x, double y) {
+        return PartialPosition.builder(UnitUtils.Units.MM).setX(x).setY(y).setZ(-1d).build();
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/path/SegmentTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/path/SegmentTest.java
@@ -1,0 +1,87 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.gcode.path;
+
+import com.willwinder.universalgcodesender.model.PartialPosition;
+import com.willwinder.universalgcodesender.model.UnitUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import org.junit.Test;
+
+import java.awt.geom.Point2D;
+
+public class SegmentTest {
+
+    @Test
+    public void arc_shouldCreateSegmentWithCenter() {
+        Segment segment = Segment.arc(SegmentType.CCWARC, position(), new Point2D.Double(1, 2), 500);
+
+        assertEquals(SegmentType.CCWARC, segment.getType());
+        assertEquals(new Point2D.Double(1, 2), segment.getArcCenter());
+        assertEquals(Integer.valueOf(500), segment.getFeedSpeed());
+    }
+
+    @Test
+    public void arc_shouldFailForSegmentTypeThatIsNotAnArc() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Segment.arc(SegmentType.LINE, position(), new Point2D.Double(1, 2), 500));
+    }
+
+    @Test
+    public void constructor_shouldFailForArcWithoutCenter() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Segment(SegmentType.CWARC, position(), null, null, 500, null));
+    }
+
+    @Test
+    public void constructor_shouldFailForNonArcWithCenter() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Segment(SegmentType.LINE, position(), null, null, 500, new Point2D.Double(1, 2)));
+    }
+
+    @Test
+    public void arc_shouldFailForPointWithoutXAndY() {
+        PartialPosition zOnly = PartialPosition.builder(UnitUtils.Units.MM).setZ(-1d).build();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> Segment.arc(SegmentType.CWARC, zOnly, new Point2D.Double(1, 2), 500));
+    }
+
+    @Test
+    public void getArcCenter_shouldReturnNullForNonArcSegment() {
+        Segment segment = new Segment(SegmentType.LINE, position());
+
+        assertNull(segment.getArcCenter());
+    }
+
+    @Test
+    public void getArcCenter_shouldNotBeAffectedByChangesToTheGivenCenter() {
+        Point2D.Double center = new Point2D.Double(1, 2);
+        Segment segment = Segment.arc(SegmentType.CWARC, position(), center, 500);
+
+        center.setLocation(10, 20);
+
+        assertEquals(new Point2D.Double(1, 2), segment.getArcCenter());
+    }
+
+    private static PartialPosition position() {
+        return PartialPosition.builder(UnitUtils.Units.MM).setX(0d).setY(10d).build();
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/OutlineToolPathTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/OutlineToolPathTest.java
@@ -613,6 +613,7 @@ public class OutlineToolPathTest {
     public void toGcodePath_shouldGenerateOnlyLinesForCircleWhenArcFittingIsDisabled() {
         Ellipse circle = new Ellipse(0, 0, 40, 40);
         Settings settings = new Settings();
+        settings.setArcFitting(false);
 
         GcodePath gcodePath = outlineOf(circle, settings);
 
@@ -624,10 +625,15 @@ public class OutlineToolPathTest {
         Ellipse circle = new Ellipse(0, 0, 40, 40);
         Settings fittedSettings = new Settings();
         fittedSettings.setArcFitting(true);
+        fittedSettings.setFlatnessPrecision(0.2);
 
         GcodePath fitted = outlineOf(circle, fittedSettings);
 
-        assertTrue(fitted.getSize() < outlineOf(circle, new Settings()).getSize());
+        Settings unfittedSettings = new Settings();
+        fittedSettings.setArcFitting(false);
+        fittedSettings.setFlatnessPrecision(0.2);
+        GcodePath outline = outlineOf(circle, unfittedSettings);
+        assertTrue("Expected fitted size " + fitted.getSize() + " to be smaller " + outline.getSize(), fitted.getSize() < outline.getSize());
     }
 
     @Test

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/OutlineToolPathTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/OutlineToolPathTest.java
@@ -18,6 +18,8 @@
  */
 package com.willwinder.ugs.designer.io.gcode.toolpaths;
 
+import com.willwinder.ugs.designer.entities.cuttable.Cuttable;
+import com.willwinder.ugs.designer.entities.cuttable.Ellipse;
 import com.willwinder.ugs.designer.entities.cuttable.Rectangle;
 import com.willwinder.ugs.designer.io.gcode.path.GcodePath;
 import com.willwinder.ugs.designer.io.gcode.path.Segment;
@@ -80,13 +82,6 @@ public class OutlineToolPathTest {
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.LINE, segment.type);
         assertEquals(0, segment.point.getX(), 0.01);
-        assertEquals(0, segment.point.getY(), 0.01);
-        assertEquals(-1, segment.point.getZ(), 0.01);
-        assertEquals(2000, segment.getFeedSpeed(), 0.01);
-
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.point.getX(), 0.01);
         assertEquals(10, segment.point.getY(), 0.01);
         assertEquals(-1, segment.point.getZ(), 0.01);
         assertEquals(2000, segment.getFeedSpeed(), 0.01);
@@ -119,7 +114,7 @@ public class OutlineToolPathTest {
         assertFalse(segment.point.hasY());
         assertEquals(10, segment.point.getZ(), 0.01);
 
-        assertEquals(11, segments.size());
+        assertEquals(10, segments.size());
     }
 
     @Test
@@ -168,12 +163,6 @@ public class OutlineToolPathTest {
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.LINE, segment.type);
         assertEquals(0, segment.point.getX(), 0.01);
-        assertEquals(0, segment.point.getY(), 0.01);
-        assertEquals(-1, segment.point.getZ(), 0.01);
-
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.point.getX(), 0.01);
         assertEquals(10, segment.point.getY(), 0.01);
         assertEquals(-1, segment.point.getZ(), 0.01);
 
@@ -202,7 +191,7 @@ public class OutlineToolPathTest {
         assertFalse(segment.point.hasY());
         assertEquals(0, segment.point.getZ(), 0.01);
 
-        assertEquals(11, segments.size());
+        assertEquals(10, segments.size());
     }
 
 
@@ -252,12 +241,6 @@ public class OutlineToolPathTest {
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.LINE, segment.type);
         assertEquals(0, segment.point.getX(), 0.01);
-        assertEquals(0, segment.point.getY(), 0.01);
-        assertEquals(15, segment.point.getZ(), 0.01);
-
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.point.getX(), 0.01);
         assertEquals(10, segment.point.getY(), 0.01);
         assertEquals(15, segment.point.getZ(), 0.01);
 
@@ -286,7 +269,7 @@ public class OutlineToolPathTest {
         assertFalse(segment.point.hasY());
         assertEquals(15, segment.point.getZ(), 0.01);
 
-        assertEquals(11, segments.size());
+        assertEquals(10, segments.size());
     }
 
     @Test
@@ -341,12 +324,6 @@ public class OutlineToolPathTest {
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.LINE, segment.type);
         assertEquals(0, segment.point.getX(), 0.01);
-        assertEquals(0, segment.point.getY(), 0.01);
-        assertEquals(15, segment.point.getZ(), 0.01);
-
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.point.getX(), 0.01);
         assertEquals(10, segment.point.getY(), 0.01);
         assertEquals(15, segment.point.getZ(), 0.01);
 
@@ -375,7 +352,7 @@ public class OutlineToolPathTest {
         assertFalse(segment.point.hasY());
         assertEquals(25, segment.point.getZ(), 0.01);
 
-        assertEquals(11, segments.size());
+        assertEquals(10, segments.size());
     }
 
     @Test
@@ -392,7 +369,7 @@ public class OutlineToolPathTest {
         GcodePath gcodePath = toolPath.toGcodePath();
 
         List<Segment> segments = gcodePath.getSegments();
-        assertEquals(20, segments.size());
+        assertEquals(18, segments.size());
 
         int segmentIndex = 0;
 
@@ -428,12 +405,6 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.POINT, segment.type);
         assertTrue(segment.point.hasX());
         assertTrue(segment.point.hasY());
-        assertEquals(10, segment.point.getZ(), 0.01);
-
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.point.getX(), 0.01);
-        assertEquals(0, segment.point.getY(), 0.01);
         assertEquals(10, segment.point.getZ(), 0.01);
 
         segment = segments.get(segmentIndex++);
@@ -486,12 +457,6 @@ public class OutlineToolPathTest {
         assertEquals(SegmentType.POINT, segment.type);
         assertTrue(segment.point.hasX());
         assertTrue(segment.point.hasY());
-        assertEquals(9, segment.point.getZ(), 0.01);
-
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.point.getX(), 0.01);
-        assertEquals(0, segment.point.getY(), 0.01);
         assertEquals(9, segment.point.getZ(), 0.01);
 
         segment = segments.get(segmentIndex++);
@@ -573,13 +538,6 @@ public class OutlineToolPathTest {
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.LINE, segment.type);
         assertEquals(0, segment.point.getX(), 0.01);
-        assertEquals(0, segment.point.getY(), 0.01);
-        assertEquals(-1, segment.point.getZ(), 0.01);
-        assertEquals(100, segment.getFeedSpeed(), 0.01);
-
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.point.getX(), 0.01);
         assertEquals(10, segment.point.getY(), 0.01);
         assertEquals(-1, segment.point.getZ(), 0.01);
 
@@ -608,7 +566,7 @@ public class OutlineToolPathTest {
         assertFalse(segment.point.hasY());
         assertEquals(10, segment.point.getZ(), 0.01);
 
-        assertEquals(11, segments.size());
+        assertEquals(10, segments.size());
     }
 
     @Test
@@ -635,6 +593,58 @@ public class OutlineToolPathTest {
         assertNull(segment.point);
         assertEquals(10000, segment.getSpindleSpeed(), 0.01);
 
-        assertEquals(11, segments.size());
+        assertEquals(10, segments.size());
+    }
+
+    @Test
+    public void toGcodePath_shouldGenerateArcsForCircleWhenArcFittingIsEnabled() {
+        Ellipse circle = new Ellipse(0, 0, 40, 40);
+        Settings settings = new Settings();
+        settings.setArcFitting(true);
+
+        GcodePath gcodePath = outlineOf(circle, settings);
+
+        List<Segment> arcs = gcodePath.getSegments().stream().filter(s -> s.getType().isArc()).toList();
+        assertFalse(arcs.isEmpty());
+        arcs.forEach(arc -> assertNotNull(arc.getArcCenter()));
+    }
+
+    @Test
+    public void toGcodePath_shouldGenerateOnlyLinesForCircleWhenArcFittingIsDisabled() {
+        Ellipse circle = new Ellipse(0, 0, 40, 40);
+        Settings settings = new Settings();
+
+        GcodePath gcodePath = outlineOf(circle, settings);
+
+        assertTrue(gcodePath.getSegments().stream().noneMatch(s -> s.getType().isArc()));
+    }
+
+    @Test
+    public void toGcodePath_shouldGenerateFewerSegmentsForCircleWhenArcFittingIsEnabled() {
+        Ellipse circle = new Ellipse(0, 0, 40, 40);
+        Settings fittedSettings = new Settings();
+        fittedSettings.setArcFitting(true);
+
+        GcodePath fitted = outlineOf(circle, fittedSettings);
+
+        assertTrue(fitted.getSize() < outlineOf(circle, new Settings()).getSize());
+    }
+
+    @Test
+    public void toGcodePath_shouldKeepStraightEdgesAsLinesWhenArcFittingIsEnabled() {
+        Rectangle rectangle = new Rectangle(0, 0);
+        rectangle.setSize(new Size(30, 20));
+        Settings settings = new Settings();
+        settings.setArcFitting(true);
+
+        GcodePath gcodePath = outlineOf(rectangle, settings);
+
+        assertTrue(gcodePath.getSegments().stream().noneMatch(s -> s.getType().isArc()));
+    }
+
+    private static GcodePath outlineOf(Cuttable source, Settings settings) {
+        OutlineToolPath toolPath = new OutlineToolPath(settings, source);
+        toolPath.setTargetDepth(1);
+        return toolPath.toGcodePath();
     }
 }

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/PocketToolPathTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/PocketToolPathTest.java
@@ -3,6 +3,7 @@ package com.willwinder.ugs.designer.io.gcode.toolpaths;
 import com.willwinder.ugs.designer.entities.Entity;
 import com.willwinder.ugs.designer.entities.cuttable.Cuttable;
 import com.willwinder.ugs.designer.entities.cuttable.Direction;
+import com.willwinder.ugs.designer.entities.cuttable.Ellipse;
 import com.willwinder.ugs.designer.entities.cuttable.Rectangle;
 import com.willwinder.ugs.designer.io.gcode.path.GcodePath;
 import com.willwinder.ugs.designer.io.gcode.path.Segment;
@@ -109,10 +110,9 @@ public class PocketToolPathTest {
         assertSegment(segmentList.get(2), SegmentType.MOVE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(2.5).build(), null);
         assertSegment(segmentList.get(3), SegmentType.MOVE, PartialPosition.builder(UnitUtils.Units.MM).setZ(1d).build(), null);
         assertSegment(segmentList.get(4), SegmentType.POINT, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(2.5).setZ(-0d).build(), null);
-        assertSegment(segmentList.get(5), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(2.5).setZ(-0d).build(), 1000);
-        assertSegment(segmentList.get(6), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(7.5).setZ(-0d).build(), 1000);
-        assertSegment(segmentList.get(7), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(7.5).setZ(-0d).build(), 1000);
-        assertSegment(segmentList.get(8), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(2.5).setZ(-0d).build(), 1000);
+        assertSegment(segmentList.get(5), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(7.5).setZ(-0d).build(), 1000);
+        assertSegment(segmentList.get(6), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(7.5).setZ(-0d).build(), 1000);
+        assertSegment(segmentList.get(7), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(2.5).setZ(-0d).build(), 1000);
     }
 
     @Test
@@ -145,10 +145,9 @@ public class PocketToolPathTest {
         assertSegment(segmentList.get(2), SegmentType.MOVE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(2.5).build(), null);
         assertSegment(segmentList.get(3), SegmentType.MOVE, PartialPosition.builder(UnitUtils.Units.MM).setZ(1d).build(), null);
         assertSegment(segmentList.get(4), SegmentType.POINT, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(2.5).setZ(-0d).build(), null);
-        assertSegment(segmentList.get(5), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(2.5).setZ(-0d).build(), 2000);
-        assertSegment(segmentList.get(6), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(2.5).setZ(-0d).build(), 2000);
-        assertSegment(segmentList.get(7), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(7.5).setZ(-0d).build(), 2000);
-        assertSegment(segmentList.get(8), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(7.5).setZ(-0d).build(), 2000);
+        assertSegment(segmentList.get(5), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(2.5).setZ(-0d).build(), 2000);
+        assertSegment(segmentList.get(6), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(7.5d).setY(7.5).setZ(-0d).build(), 2000);
+        assertSegment(segmentList.get(7), SegmentType.LINE, PartialPosition.builder(UnitUtils.Units.MM).setX(2.5d).setY(7.5).setZ(-0d).build(), 2000);
     }
 
 
@@ -251,5 +250,26 @@ public class PocketToolPathTest {
 
         assertTrue("The tool path was " + Math.round(totalLength) + "mm long but should have been shorter", totalLength < 22144);
         assertTrue("The tool path rapids was " + Math.round(totalRapidLength) + "mm long but should have been shorter", totalRapidLength < 730);
+    }
+
+    @Test
+    public void toGcodePath_shouldFollowCurvesCloserForFinerCurvePrecision() {
+        Settings coarseSettings = new Settings();
+        coarseSettings.setFlatnessPrecision(0.1);
+        Settings fineSettings = new Settings();
+        fineSettings.setFlatnessPrecision(0.005);
+
+        int coarseSegments = pocketOfCircle(coarseSettings).getSize();
+
+        assertTrue("A finer curve precision should keep more of the points describing the curve",
+                coarseSegments < pocketOfCircle(fineSettings).getSize());
+    }
+
+    private static GcodePath pocketOfCircle(Settings settings) {
+        Ellipse circle = new Ellipse(0, 0, 40, 40);
+        com.willwinder.ugs.designer.io.gcode.toolpaths.PocketToolPath pocket =
+                new com.willwinder.ugs.designer.io.gcode.toolpaths.PocketToolPath(settings, circle);
+        pocket.setTargetDepth(1);
+        return pocket.toGcodePath();
     }
 }

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/ToolPathUtilsTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/ToolPathUtilsTest.java
@@ -30,7 +30,7 @@ public class ToolPathUtilsTest {
 
         Geometry geometryCollection = convertAreaToGeometry(new Area(design.getEntities().get(0).getShape()), new GeometryFactory(), 0.1);
         Geometry shell = geometryCollection.buffer(-toolDiameter / 2d);
-        List<Geometry> geometries = bufferAndCollectGeometries(geometryCollection, toolDiameter, 1);
+        List<Geometry> geometries = bufferAndCollectGeometries(geometryCollection, toolDiameter, 1, 0.1);
         assertEquals(4, geometries.size());
 
         List<List<PartialPosition>> coordinateList = new ArrayList<>();

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriterTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriterTest.java
@@ -20,14 +20,16 @@ package com.willwinder.ugs.designer.io.gcode.writer;
 
 import com.willwinder.ugs.designer.io.gcode.path.Segment;
 import com.willwinder.ugs.designer.io.gcode.path.SegmentType;
-import com.willwinder.ugs.designer.io.gcode.writer.GrblGcodeWriter;
 import com.willwinder.ugs.designer.model.Settings;
+import com.willwinder.universalgcodesender.model.Axis;
 import com.willwinder.universalgcodesender.model.PartialPosition;
 import com.willwinder.universalgcodesender.model.UnitUtils;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
+import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.io.StringWriter;
 
@@ -258,30 +260,99 @@ public class GrblGcodeWriterTest {
     }
 
     @Test
-    public void arcCommandsShouldBeWrittenWithFeedOnlyOncePerRun() throws IOException {
+    public void writeSegment_shouldWriteArcWithIncrementalOffsetsToCenter() throws IOException {
         StringWriter result = new StringWriter();
         GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(10d, 0d)));
 
-        writer.writeSegment(new Segment(
-                SegmentType.CWARC,
-                PartialPosition.builder(UnitUtils.Units.MM).setX(0d).setY(0d).build(),
-                null,
-                null,
-                900
-        ));
-
-        writer.writeSegment(new Segment(
-                SegmentType.CCWARC,
-                PartialPosition.builder(UnitUtils.Units.MM).setX(1d).setY(1d).build(),
-                null,
-                null,
-                900
-        ));
+        writer.writeSegment(Segment.arc(SegmentType.CWARC, position(0d, 10d), new Point2D.Double(0, 0), 1_000));
 
         String[] lines = result.toString().split("\n");
         assertEquals(2, lines.length);
-        assertEquals("G2 F900 X0Y0", lines[0]);
-        assertEquals("G3 X1Y1", lines[1]);
+        assertEquals("G0 X10Y0", lines[0]);
+        assertEquals("G2 F1000 X0Y10I-10J0", lines[1]);
+    }
+
+    @Test
+    public void writeSegment_shouldWriteArcOffsetsRelativeToEndOfPreviousArc() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(10d, 0d)));
+
+        writer.writeSegment(Segment.arc(SegmentType.CWARC, position(0d, 10d), new Point2D.Double(0, 0), 900));
+        writer.writeSegment(Segment.arc(SegmentType.CCWARC, position(-10d, 0d), new Point2D.Double(0, 0), 900));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals(3, lines.length);
+        assertEquals("G2 F900 X0Y10I-10J0", lines[1]);
+        assertEquals("G3 X-10Y0I0J-10", lines[2]);
+    }
+
+    @Test
+    public void writeSegment_shouldWriteArcOffsetsUsingCoordinatesFromEarlierSegments() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(10d, 0d)));
+        writer.writeSegment(new Segment(SegmentType.MOVE, PartialPosition.from(Axis.Z, -1d, UnitUtils.Units.MM)));
+
+        writer.writeSegment(Segment.arc(SegmentType.CWARC, position(0d, 10d), new Point2D.Double(0, 0), 1_000));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals(3, lines.length);
+        assertEquals("G0 Z-1", lines[1]);
+        assertEquals("G2 F1000 X0Y10I-10J0", lines[2]);
+    }
+
+    @Test
+    public void writeSegment_shouldWriteCoordinatesForArcEndingWhereItStarted() throws IOException {
+        // Grbl rejects an arc that carries no axis words with "error:26", so the coordinates have
+        // to be written even though they have not changed
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(10d, 0d)));
+
+        writer.writeSegment(Segment.arc(SegmentType.CWARC, position(10d, 0d), new Point2D.Double(0, 0), 1_000));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals(2, lines.length);
+        assertEquals("G2 F1000 X10Y0I-10J0", lines[1]);
+    }
+
+    @Test
+    public void writeSegment_shouldWriteUnchangedCoordinateForArc() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(10d, 0d)));
+
+        writer.writeSegment(Segment.arc(SegmentType.CCWARC, position(10d, 5d), new Point2D.Double(10, 2.5), 1_000));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("G3 F1000 X10Y5I0J2.5", lines[1]);
+    }
+
+    @Test
+    public void writeSegment_shouldNotWriteUnchangedCoordinateForLine() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(10d, 0d)));
+
+        writer.writeSegment(new Segment(SegmentType.LINE, position(10d, 5d), null, null, 1_000));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("G1 F1000 Y5", lines[1]);
+    }
+
+    @Test
+    public void writeSegment_shouldFailForArcWithoutKnownStartPosition() {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        Segment arc = Segment.arc(SegmentType.CWARC, position(0d, 10d), new Point2D.Double(0, 0), 1_000);
+
+        assertThrows(IllegalStateException.class, () -> writer.writeSegment(arc));
+    }
+
+    private static PartialPosition position(Double x, Double y) {
+        return PartialPosition.builder(UnitUtils.Units.MM).setX(x).setY(y).build();
     }
 
     @Test

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/model/SettingsBackwardCompatTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/model/SettingsBackwardCompatTest.java
@@ -21,6 +21,7 @@ package com.willwinder.ugs.designer.model;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -51,6 +52,14 @@ public class SettingsBackwardCompatTest {
         assertEquals(1.0, settings.getDepthPerPass(), 1e-9);
         assertEquals(255, settings.getMaxSpindleSpeed());
         assertEquals("M3", settings.getSpindleDirection());
+    }
+
+    @Test
+    public void arcFittingIsOffByDefault() {
+        // Turning arc fitting on changes the generated gcode from lines into G2/G3 moves, so it
+        // stays opt-in for existing users until they ask for it.
+        Settings settings = new Settings();
+        assertFalse(settings.getArcFitting());
     }
 
     @Test

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/model/SettingsBackwardCompatTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/model/SettingsBackwardCompatTest.java
@@ -21,8 +21,8 @@ package com.willwinder.ugs.designer.model;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Guards the invariants existing users rely on: a fresh {@link Settings} looks exactly like it
@@ -55,11 +55,9 @@ public class SettingsBackwardCompatTest {
     }
 
     @Test
-    public void arcFittingIsOffByDefault() {
-        // Turning arc fitting on changes the generated gcode from lines into G2/G3 moves, so it
-        // stays opt-in for existing users until they ask for it.
+    public void arcFittingIsOnByDefault() {
         Settings settings = new Settings();
-        assertFalse(settings.getArcFitting());
+        assertTrue(settings.getArcFitting());
     }
 
     @Test

--- a/ugs-fx/src/main/java/com/willwinder/universalgcodesender/fx/stage/ToolSettingsStage.java
+++ b/ugs-fx/src/main/java/com/willwinder/universalgcodesender/fx/stage/ToolSettingsStage.java
@@ -59,6 +59,7 @@ public class ToolSettingsStage extends Stage {
     private final UnitTextField laserDiameter;
     private final ComboBox<String> spindleDirection;
     private final UnitTextField flatnessPrecision;
+    private final SwitchButton arcFitting;
 
     public ToolSettingsStage(Window owner, Controller controller) {
         this.controller = controller;
@@ -81,6 +82,8 @@ public class ToolSettingsStage extends Stage {
         spindleDirection.setValue(settings.getSpindleDirection());
         spindleDirection.setMaxWidth(Double.MAX_VALUE);
         flatnessPrecision = numericField(Unit.MM, settings.getFlatnessPrecision());
+        arcFitting = new SwitchButton();
+        arcFitting.selectedProperty().set(settings.getArcFitting());
 
         setScene(createScene());
         setWidth(380);
@@ -105,7 +108,8 @@ public class ToolSettingsStage extends Stage {
                 new SettingsRow("Spindle start command", spindleDirection),
                 new Separator(),
                 new SettingsRow("Laser diameter", laserDiameter),
-                new SettingsRow("Arc precision", flatnessPrecision));
+                new SettingsRow("Curve precision", flatnessPrecision),
+                new SettingsRow("Generate arcs", arcFitting));
         form.setPadding(new Insets(16));
 
         ScrollPane scroll = new ScrollPane(form);
@@ -144,6 +148,7 @@ public class ToolSettingsStage extends Stage {
         settings.setLaserDiameter(laserDiameter.getValue());
         settings.setSpindleDirection(spindleDirection.getValue());
         settings.setFlatnessPrecision(flatnessPrecision.getValue());
+        settings.setArcFitting(arcFitting.selectedProperty().get());
 
         ChangeToolSettingsAction action = new ChangeToolSettingsAction(controller, settings);
         action.actionPerformed(null);

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsAdapter.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsAdapter.java
@@ -1,6 +1,6 @@
 package com.willwinder.ugs.nbp.designer.platform;
 /*
-    Copyright 2024 Will Winder
+    Copyright 2026 Will Winder
 
     This file is part of Universal Gcode Sender (UGS).
 
@@ -40,6 +40,7 @@ public class SettingsAdapter {
     private static final String STOCK_THICKNESS = "stockThickness";
     private static final String SPINDLE_DIRECTION = "spindleDirection";
     private static final String FLATNESS_PRECISION = "flatnessPrecision";
+    private static final String ARC_FITTING = "arcFitting";
 
     private SettingsAdapter() {}
 
@@ -56,7 +57,8 @@ public class SettingsAdapter {
         settings.setToolStepOver(preferences.getDouble(TOOL_STEP_OVER, 0.3));
         settings.setStockThickness(preferences.getDouble(STOCK_THICKNESS, 10));
         settings.setSpindleDirection(preferences.get(SPINDLE_DIRECTION, "M3"));
-        settings.setFlatnessPrecision(preferences.getDouble(FLATNESS_PRECISION, 0.1d));
+        settings.setFlatnessPrecision(preferences.getDouble(FLATNESS_PRECISION, 0.02d));
+        settings.setArcFitting(preferences.getBoolean(ARC_FITTING, false));
         return settings;
     }
 
@@ -73,5 +75,6 @@ public class SettingsAdapter {
         preferences.putDouble(STOCK_THICKNESS, settings.getStockThickness());
         preferences.put(SPINDLE_DIRECTION, settings.getSpindleDirection());
         preferences.putDouble(FLATNESS_PRECISION, settings.getFlatnessPrecision());
+        preferences.putBoolean(ARC_FITTING, settings.getArcFitting());
     }
 }


### PR DESCRIPTION
Add a feature that will try and replace line segments with arcs in the designer. This will reduce the gcode rows needed to be sent to the controller and make the shapes more accurate.

Made three test runs with pocketing this shape:
<img width="1839" height="1103" alt="image" src="https://github.com/user-attachments/assets/ca0d7184-9014-4ef0-b334-770d05ba117e" />

The number of rows was reduced by around 60-80%. The run time were reduced by 5-7%.