### PR TITLE
Depth map fixes

### DIFF
--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/actions/ToolImportAction.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/actions/ToolImportAction.java
@@ -25,6 +25,7 @@ import com.willwinder.ugs.designer.io.eagle.EaglePnpReader;
 import com.willwinder.ugs.designer.io.excellon.ExcellonReader;
 import com.willwinder.ugs.designer.io.gerber.GerberReader;
 import com.willwinder.ugs.designer.io.kicad.KiCadPosReader;
+import com.willwinder.ugs.designer.io.stl.StlReader;
 import com.willwinder.ugs.designer.io.svg.SvgReader;
 import com.willwinder.ugs.designer.io.ugsd.UgsDesignReader;
 import com.willwinder.ugs.designer.logic.Controller;
@@ -54,7 +55,7 @@ public class ToolImportAction extends AbstractDesignAction {
     private static final Logger LOGGER = Logger.getLogger(ToolImportAction.class.getName());
 
     public static final FileNameExtensionFilter[] FILE_NAME_EXTENSION_FILTERS = new FileNameExtensionFilter[]{
-            new FileNameExtensionFilter("All supported formats", "svg", "dxf", "c2d", "mnt", "mnb", "drl", "pos", "gbr", "ugsd", "png", "jpg", "jpeg"),
+            new FileNameExtensionFilter("All supported formats", "svg", "dxf", "c2d", "mnt", "mnb", "drl", "pos", "gbr", "ugsd", "stl", "png", "jpg", "jpeg"),
             new FileNameExtensionFilter("Scalable Vector Graphics (.svg)", "svg"),
             new FileNameExtensionFilter("Autodesk CAD (.dxf)", "dxf"),
             new FileNameExtensionFilter("Carbide Create (.c2d)", "c2d"),
@@ -63,6 +64,7 @@ public class ToolImportAction extends AbstractDesignAction {
             new FileNameExtensionFilter("KiCad (.pos)", "pos"),
             new FileNameExtensionFilter("Gerber (.gbr)", "gbr"),
             new FileNameExtensionFilter("UGS design (.ugsd)", "ugsd"),
+            new FileNameExtensionFilter("Stereolithography (.stl)", "stl"),
             new FileNameExtensionFilter("Portable Network Graphics (.png)", "png"),
             new FileNameExtensionFilter("JPEG (.jpg)", "jpg", "jpeg"),
             new FileNameExtensionFilter("Bitmap (.bmp)", "bmp"),
@@ -111,6 +113,9 @@ public class ToolImportAction extends AbstractDesignAction {
             optionalDesign = reader.read(f);
         } else if (StringUtils.endsWithIgnoreCase(f.getName(), ".drl")) {
             ExcellonReader reader = new ExcellonReader();
+            optionalDesign = reader.read(f);
+        } else if (StringUtils.endsWithIgnoreCase(f.getName(), ".stl")) {
+            StlReader reader = new StlReader();
             optionalDesign = reader.read(f);
         }
 

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/entities/cuttable/Raster.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/entities/cuttable/Raster.java
@@ -36,6 +36,7 @@ import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -55,6 +56,9 @@ import java.util.logging.Logger;
 public class Raster extends AbstractCuttable {
 
     private static final Logger LOGGER = Logger.getLogger(Raster.class.getSimpleName());
+
+    private static final int MAX_8BIT = 255;
+    private static final int MAX_16BIT = 65535;
 
     private static final ExecutorService DEPTH_MAP_EXECUTOR = Executors.newSingleThreadExecutor(runnable -> {
         Thread thread = new Thread(runnable, "depth-map-generator");
@@ -535,14 +539,19 @@ public class Raster extends AbstractCuttable {
         BufferedImage gray = getOrCreateProcessedGray();
         int w = gray.getWidth();
         int h = gray.getHeight();
-        byte[] grayData = ((java.awt.image.DataBufferByte) gray.getRaster().getDataBuffer()).getData();
+        int maxValue = maxSampleValue(gray);
+        WritableRaster grayRaster = gray.getRaster();
 
         BufferedImage mask = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
         int[] maskData = ((java.awt.image.DataBufferInt) mask.getRaster().getDataBuffer()).getData();
 
-        for (int i = 0; i < grayData.length; i++) {
-            int v = grayData[i] & 0xFF;
-            maskData[i] = (255 - v) << 24; // white → transparent, black → opaque
+        int[] row = new int[w];
+        for (int y = 0; y < h; y++) {
+            grayRaster.getSamples(0, y, w, 1, 0, row);
+            for (int x = 0; x < w; x++) {
+                int v = row[x] * MAX_8BIT / maxValue;
+                maskData[y * w + x] = (MAX_8BIT - v) << 24; // white → transparent, black → opaque
+            }
         }
 
         processedInkMask = mask;
@@ -550,6 +559,10 @@ public class Raster extends AbstractCuttable {
     }
 
 
+    /**
+     * The processed grayscale keeps the bit depth of the source, so a 16-bit height field is carved at
+     * its full resolution instead of being flattened to 256 height steps.
+     */
     private BufferedImage getOrCreateProcessedGray() {
         if (processedGray != null) {
             return processedGray;
@@ -559,15 +572,26 @@ public class Raster extends AbstractCuttable {
         int w = src.getWidth();
         int h = src.getHeight();
 
+        if (src.getType() == BufferedImage.TYPE_USHORT_GRAY) {
+            processedGray = mapSamples(src, BufferedImage.TYPE_USHORT_GRAY, buildMasterLut(MAX_16BIT), MAX_16BIT);
+            return processedGray;
+        }
+
         // Pre-compute a master LUT: luminance (0–255) → final gray value.
         // The entire pipeline (invert, levels, power curve) depends only on the
         // scalar luminance, so it collapses into a single table.
-        int[] masterLut = buildMasterLut();
+        int[] masterLut = buildMasterLut(MAX_8BIT);
 
-        int[] srcPixels = src.getRGB(0, 0, w, h, null, 0, w);
+        if (src.getType() == BufferedImage.TYPE_BYTE_GRAY) {
+            // Reading a gray image through getRGB would convert it from linear gray to sRGB and
+            // brighten it, so the stored intensities are taken verbatim instead
+            processedGray = mapSamples(src, BufferedImage.TYPE_BYTE_GRAY, masterLut, MAX_8BIT);
+            return processedGray;
+        }
+
         BufferedImage dst = new BufferedImage(w, h, BufferedImage.TYPE_BYTE_GRAY);
         byte[] dstData = ((java.awt.image.DataBufferByte) dst.getRaster().getDataBuffer()).getData();
-
+        int[] srcPixels = src.getRGB(0, 0, w, h, null, 0, w);
         for (int i = 0; i < srcPixels.length; i++) {
             int argb = srcPixels[i];
             int r = (argb >> 16) & 0xFF;
@@ -581,29 +605,65 @@ public class Raster extends AbstractCuttable {
         return processedGray;
     }
 
-    private int[] buildMasterLut() {
-        final int[] curveLut = getOrCreatePowerCurveLut();
-        int[] masterLut = new int[256];
+    private static BufferedImage mapSamples(BufferedImage src, int type, int[] lut, int maxValue) {
+        int w = src.getWidth();
+        int h = src.getHeight();
+        BufferedImage dst = new BufferedImage(w, h, type);
+        WritableRaster srcRaster = src.getRaster();
+        WritableRaster dstRaster = dst.getRaster();
 
-        for (int i = 0; i < 256; i++) {
-            double l = i / 255.0;
+        int[] row = new int[w];
+        for (int y = 0; y < h; y++) {
+            srcRaster.getSamples(0, y, w, 1, 0, row);
+            for (int x = 0; x < w; x++) {
+                row[x] = lut[MathUtils.clamp(row[x], 0, maxValue)];
+            }
+            dstRaster.setSamples(0, y, w, 1, 0, row);
+        }
+        return dst;
+    }
+
+    private static int maxSampleValue(BufferedImage image) {
+        return image.getType() == BufferedImage.TYPE_USHORT_GRAY ? MAX_16BIT : MAX_8BIT;
+    }
+
+    private int[] buildMasterLut(int maxValue) {
+        final int[] curveLut = getOrCreatePowerCurveLut();
+        int[] masterLut = new int[maxValue + 1];
+
+        for (int i = 0; i <= maxValue; i++) {
+            double l = (double) i / maxValue;
 
             if (invert) {
                 l = 1.0 - l;
             }
 
-            int curveInput = (int) Math.round(clamp(l, 0.0, 1.0) * 255.0);
-            double ql = curveLut[Math.max(0, Math.min(255, curveInput))] / 255.0;
+            double ql = samplePowerCurve(curveLut, clamp(l, 0.0, 1.0));
 
-            if (levels < 255) {
+            if (levels < MAX_8BIT) {
                 double steps = levels - 1;
                 ql = Math.round(ql * steps) / steps;
             }
 
-            masterLut[i] = (int) Math.round(ql * 255.0);
+            masterLut[i] = (int) Math.round(ql * maxValue);
         }
 
         return masterLut;
+    }
+
+    /**
+     * Samples the 8-bit power curve at a normalized position. The curve is interpolated so that a
+     * 16-bit height field is not quantized down to the 256 entries of the curve table.
+     */
+    private static double samplePowerCurve(int[] curveLut, double normalized) {
+        double position = normalized * (curveLut.length - 1);
+        int index = (int) Math.floor(position);
+        if (index >= curveLut.length - 1) {
+            return curveLut[curveLut.length - 1] / (double) MAX_8BIT;
+        }
+
+        double fraction = position - index;
+        return (curveLut[index] + (curveLut[index + 1] - curveLut[index]) * fraction) / MAX_8BIT;
     }
 
 
@@ -682,10 +742,8 @@ public class Raster extends AbstractCuttable {
             return 1;
         }
 
-        int argb = gray.getRGB(px, py);
-        int v = argb & 0xFF; // gray value
-
-        return v / 255.0;
+        // Sampled rather than read via getRGB, which would convert the linear gray to sRGB
+        return gray.getRaster().getSample(px, py, 0) / (double) maxSampleValue(gray);
     }
 
     @Override

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/HeightMapToolPath.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/HeightMapToolPath.java
@@ -35,6 +35,7 @@ import org.locationtech.jts.geom.LineString;
 
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -49,9 +50,14 @@ import java.util.List;
  */
 public class HeightMapToolPath extends AbstractToolPath {
     private static final double EPSILON = 1e-6;
+    private static final int FOOTPRINT_RINGS = 8;
+    private static final double MAX_FOOTPRINT_SAMPLE_SPACING = 0.5;
 
     private final Raster source;
     private final double toolPathAngle;
+
+    private double[][] footprintOffsets;
+    private double footprintOffsetsRadius = Double.NaN;
 
     public HeightMapToolPath(Settings settings, Cuttable source) {
         super(settings);
@@ -218,12 +224,14 @@ public class HeightMapToolPath extends AbstractToolPath {
 
         double[] xs = new double[steps + 1];
         double[] ys = new double[steps + 1];
+        double[] required = new double[steps + 1];
         int firstEngaged = -1;
         int lastEngaged = -1;
         for (int i = 0; i <= steps; i++) {
             xs[i] = c0.x + sx * i;
             ys[i] = c0.y + sy * i;
-            if (requiredRoughDepth(xs[i], ys[i]) > previousLayer + EPSILON) {
+            required[i] = requiredRoughDepth(xs[i], ys[i]);
+            if (required[i] > previousLayer + EPSILON) {
                 if (firstEngaged < 0) {
                     firstEngaged = i;
                 }
@@ -240,16 +248,15 @@ public class HeightMapToolPath extends AbstractToolPath {
         // material within the span, ride over it at the previous cleared height instead of lifting to
         // safe height and plunging again.
         gcodePath.addSegment(new Segment(SegmentType.MOVE, PartialPosition.builder(UnitUtils.Units.MM).setX(xs[firstEngaged]).setY(ys[firstEngaged]).build(), null, null, null));
-        gcodePath.addSegment(new Segment(SegmentType.POINT, roughPosition(xs[firstEngaged], ys[firstEngaged], layerDepth, previousLayer), null, null, source.getFeedRate()));
+        gcodePath.addSegment(new Segment(SegmentType.POINT, roughPosition(xs[firstEngaged], ys[firstEngaged], required[firstEngaged], layerDepth, previousLayer), null, null, source.getFeedRate()));
         for (int i = firstEngaged + 1; i <= lastEngaged; i++) {
-            gcodePath.addSegment(new Segment(SegmentType.LINE, roughPosition(xs[i], ys[i], layerDepth, previousLayer), null, null, source.getFeedRate()));
+            gcodePath.addSegment(new Segment(SegmentType.LINE, roughPosition(xs[i], ys[i], required[i], layerDepth, previousLayer), null, null, source.getFeedRate()));
         }
 
         addSafeHeightSegment(gcodePath, null, true);
     }
 
-    private PartialPosition roughPosition(double x, double y, double layerDepth, double previousLayer) {
-        double required = requiredRoughDepth(x, y);
+    private PartialPosition roughPosition(double x, double y, double required, double layerDepth, double previousLayer) {
         double depth = required > previousLayer + EPSILON
                 ? Math.min(layerDepth, required)
                 : Math.min(previousLayer, required);
@@ -287,10 +294,10 @@ public class HeightMapToolPath extends AbstractToolPath {
     }
 
     private double requiredRoughDepth(double x, double y) {
-        // Roughing follows the true surface at this point (not the radius-compensated one) so it clears
-        // material right up to the edges, leaving only the stock-to-leave for the finishing tool. The
-        // finishing pass stays radius compensated to avoid gouging the final surface.
-        return clamp(surfaceDepthAt(x, y) - source.getStockToLeave(), getStartDepth(), getTargetDepth());
+        // Radius compensated like the finishing pass: the tool cannot remove material it does not fit
+        // into, so a feature narrower than the tool must be left standing rather than plunged through.
+        // Roughing only differs in stopping short of the final surface by the stock-to-leave amount.
+        return clamp(footprintSurfaceDepth(x, y) - source.getStockToLeave(), getStartDepth(), getTargetDepth());
     }
 
     private double surfaceDepthAt(double x, double y) {
@@ -300,28 +307,51 @@ public class HeightMapToolPath extends AbstractToolPath {
     }
 
     /**
-     * Returns the shallowest surface depth under the tool footprint at {@code (x, y)}, sampled on two
-     * concentric rings plus the centre. The tool cannot cut below this without gouging material that
-     * should remain, so it is the deepest the tool may safely descend at this position.
+     * Returns the shallowest surface depth under the tool footprint at {@code (x, y)}. The tool cannot
+     * cut below this without gouging material that should remain, so it is the deepest the tool may
+     * safely descend at this position.
      */
     private double footprintSurfaceDepth(double x, double y) {
         double radius = settings.getToolDiameter() / 2.0;
-        double minDepth = surfaceDepthAt(x, y);
         if (radius <= 0) {
-            return minDepth;
+            return surfaceDepthAt(x, y);
         }
 
-        int directions = 8;
-        double[] radii = {radius * 0.5, radius};
-        for (double r : radii) {
-            for (int i = 0; i < directions; i++) {
-                double angle = (2.0 * Math.PI * i) / directions;
-                double sx = x + r * Math.cos(angle);
-                double sy = y + r * Math.sin(angle);
-                minDepth = Math.min(minDepth, surfaceDepthAt(sx, sy));
-            }
+        double minDepth = Double.POSITIVE_INFINITY;
+        for (double[] offset : footprintOffsets(radius)) {
+            minDepth = Math.min(minDepth, surfaceDepthAt(x + offset[0], y + offset[1]));
         }
         return minDepth;
+    }
+
+    /**
+     * Sample offsets covering the whole tool disc, on a grid rather than a few rays so that a feature
+     * narrower than the tool cannot slip between samples and be plunged through. Spacing is at most
+     * {@link #MAX_FOOTPRINT_SAMPLE_SPACING}, so every feature wider than that is seen by at least one
+     * sample; larger tools get a proportionally denser grid but also produce far fewer tool-path points,
+     * which keeps the total sampling cost roughly flat.
+     */
+    private double[][] footprintOffsets(double radius) {
+        if (footprintOffsets != null && footprintOffsetsRadius == radius) {
+            return footprintOffsets;
+        }
+
+        double spacing = Math.min(radius / FOOTPRINT_RINGS, MAX_FOOTPRINT_SAMPLE_SPACING);
+        int extent = (int) Math.ceil(radius / spacing);
+        List<double[]> offsets = new ArrayList<>();
+        for (int iy = -extent; iy <= extent; iy++) {
+            for (int ix = -extent; ix <= extent; ix++) {
+                double ox = ix * spacing;
+                double oy = iy * spacing;
+                if (ox * ox + oy * oy <= radius * radius + EPSILON) {
+                    offsets.add(new double[]{ox, oy});
+                }
+            }
+        }
+
+        footprintOffsetsRadius = radius;
+        footprintOffsets = offsets.toArray(new double[0][]);
+        return footprintOffsets;
     }
 
     private PartialPosition position(double x, double y, double depth) {

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlDepthMapRasterizer.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlDepthMapRasterizer.java
@@ -1,0 +1,166 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.stl;
+
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferUShort;
+import java.util.Arrays;
+
+/**
+ * Renders a mesh as a grayscale depth map seen from above: for every pixel the highest surface found
+ * along -Z is kept, the brightest pixel being the top of the model and black being its lowest point.
+ * This matches the height map convention used when carving a
+ * {@link com.willwinder.ugs.designer.entities.cuttable.Raster}, so the depth map can be carved as a
+ * relief of the original mesh.
+ * <p>
+ * Areas the mesh does not cover are left at the lowest point, meaning they are cleared down to the
+ * bottom of the model.
+ *
+ * @author Joacim Breiler
+ */
+public class StlDepthMapRasterizer {
+    public static final double DEFAULT_PIXELS_PER_MM = 10;
+    private static final int MAX_SAMPLE = 65535;
+    private static final int MIN_PIXELS = 2;
+    private static final int MAX_PIXELS = 2048;
+
+    private final double pixelsPerMm;
+
+    public StlDepthMapRasterizer() {
+        this(DEFAULT_PIXELS_PER_MM);
+    }
+
+    public StlDepthMapRasterizer(double pixelsPerMm) {
+        this.pixelsPerMm = pixelsPerMm;
+    }
+
+    public BufferedImage rasterize(StlMesh mesh) {
+        Rectangle2D.Double bounds = mesh.getBounds();
+        int width = pixelCount(bounds.width, bounds.height);
+        int height = pixelCount(bounds.height, bounds.width);
+
+        float[] depthBuffer = renderDepthBuffer(mesh, bounds, width, height);
+        return toGrayscale(depthBuffer, width, height, mesh.getMinZ(), mesh.getMaxZ());
+    }
+
+    /**
+     * The resolution follows the physical size of the model, but the longest side is capped so that a
+     * large model does not produce an unreasonably large image.
+     */
+    private int pixelCount(double size, double otherSize) {
+        double longestSide = Math.max(size, otherSize);
+        double scale = Math.min(1, MAX_PIXELS / Math.max(1e-9, longestSide * pixelsPerMm));
+        return (int) Math.max(MIN_PIXELS, Math.round(size * pixelsPerMm * scale));
+    }
+
+    private static float[] renderDepthBuffer(StlMesh mesh, Rectangle2D.Double bounds, int width, int height) {
+        float[] depthBuffer = new float[width * height];
+        Arrays.fill(depthBuffer, Float.NEGATIVE_INFINITY);
+
+        // Pixel centers sample the model, so world and pixel space are offset by half a pixel
+        double pixelWidth = bounds.width / width;
+        double pixelHeight = bounds.height / height;
+        if (pixelWidth <= 0 || pixelHeight <= 0) {
+            return depthBuffer;
+        }
+
+        float[] coordinates = mesh.getCoordinates();
+        for (int i = 0; i < coordinates.length; i += StlMesh.COORDINATES_PER_TRIANGLE) {
+            // Rows are ordered top down while the world is Y-up, so the Y axis is flipped here
+            double x0 = (coordinates[i] - bounds.x) / pixelWidth - 0.5;
+            double y0 = (bounds.getMaxY() - coordinates[i + 1]) / pixelHeight - 0.5;
+            double x1 = (coordinates[i + 3] - bounds.x) / pixelWidth - 0.5;
+            double y1 = (bounds.getMaxY() - coordinates[i + 4]) / pixelHeight - 0.5;
+            double x2 = (coordinates[i + 6] - bounds.x) / pixelWidth - 0.5;
+            double y2 = (bounds.getMaxY() - coordinates[i + 7]) / pixelHeight - 0.5;
+
+            rasterizeTriangle(depthBuffer, width, height,
+                    x0, y0, coordinates[i + 2],
+                    x1, y1, coordinates[i + 5],
+                    x2, y2, coordinates[i + 8]);
+        }
+
+        return depthBuffer;
+    }
+
+    private static void rasterizeTriangle(float[] depthBuffer, int width, int height,
+                                          double x0, double y0, float z0,
+                                          double x1, double y1, float z1,
+                                          double x2, double y2, float z2) {
+        double area = edge(x0, y0, x1, y1, x2, y2);
+        if (area == 0) {
+            // Seen edge on from above, so it contributes no surface
+            return;
+        }
+
+        int minX = (int) Math.max(0, Math.ceil(Math.min(x0, Math.min(x1, x2))));
+        int maxX = (int) Math.min(width - 1, Math.floor(Math.max(x0, Math.max(x1, x2))));
+        int minY = (int) Math.max(0, Math.ceil(Math.min(y0, Math.min(y1, y2))));
+        int maxY = (int) Math.min(height - 1, Math.floor(Math.max(y0, Math.max(y1, y2))));
+
+        // A tolerance relative to the triangle size keeps pixels exactly on a shared edge covered
+        double tolerance = Math.abs(area) * 1e-9;
+
+        for (int y = minY; y <= maxY; y++) {
+            for (int x = minX; x <= maxX; x++) {
+                double w0 = edge(x1, y1, x2, y2, x, y) / area;
+                double w1 = edge(x2, y2, x0, y0, x, y) / area;
+                double w2 = edge(x0, y0, x1, y1, x, y) / area;
+                if (w0 < -tolerance || w1 < -tolerance || w2 < -tolerance) {
+                    continue;
+                }
+
+                float z = (float) (w0 * z0 + w1 * z1 + w2 * z2);
+                int index = y * width + x;
+                if (z > depthBuffer[index]) {
+                    depthBuffer[index] = z;
+                }
+            }
+        }
+    }
+
+    private static double edge(double ax, double ay, double bx, double by, double px, double py) {
+        return (bx - ax) * (py - ay) - (by - ay) * (px - ax);
+    }
+
+    /**
+     * The depth map is 16-bit so that the height resolution is limited by the mesh rather than by the
+     * 256 steps an 8-bit image would allow.
+     */
+    private static BufferedImage toGrayscale(float[] depthBuffer, int width, int height, double minZ, double maxZ) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_USHORT_GRAY);
+        short[] pixels = ((DataBufferUShort) image.getRaster().getDataBuffer()).getData();
+
+        double range = maxZ - minZ;
+        for (int i = 0; i < depthBuffer.length; i++) {
+            float z = depthBuffer[i];
+            if (z == Float.NEGATIVE_INFINITY) {
+                pixels[i] = 0;
+            } else if (range <= 0) {
+                pixels[i] = (short) MAX_SAMPLE;
+            } else {
+                double normalized = (z - minZ) / range;
+                pixels[i] = (short) Math.round(Math.max(0, Math.min(1, normalized)) * MAX_SAMPLE);
+            }
+        }
+
+        return image;
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlMesh.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlMesh.java
@@ -1,0 +1,102 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.stl;
+
+import java.awt.geom.Rectangle2D;
+
+/**
+ * An immutable triangle soup read from an STL file. Coordinates are stored flat, nine floats per
+ * triangle, as {@code x0, y0, z0, x1, y1, z1, x2, y2, z2}.
+ *
+ * @author Joacim Breiler
+ */
+public class StlMesh {
+    public static final int COORDINATES_PER_TRIANGLE = 9;
+
+    private final float[] coordinates;
+    private final Rectangle2D.Double bounds;
+    private final double minZ;
+    private final double maxZ;
+
+    public StlMesh(float[] coordinates) {
+        if (coordinates.length % COORDINATES_PER_TRIANGLE != 0) {
+            throw new IllegalArgumentException("The number of coordinates must be a multiple of " + COORDINATES_PER_TRIANGLE);
+        }
+        this.coordinates = coordinates;
+
+        double minX = Double.POSITIVE_INFINITY;
+        double maxX = Double.NEGATIVE_INFINITY;
+        double minY = Double.POSITIVE_INFINITY;
+        double maxY = Double.NEGATIVE_INFINITY;
+        double lowestZ = Double.POSITIVE_INFINITY;
+        double highestZ = Double.NEGATIVE_INFINITY;
+
+        for (int i = 0; i < coordinates.length; i += 3) {
+            minX = Math.min(minX, coordinates[i]);
+            maxX = Math.max(maxX, coordinates[i]);
+            minY = Math.min(minY, coordinates[i + 1]);
+            maxY = Math.max(maxY, coordinates[i + 1]);
+            lowestZ = Math.min(lowestZ, coordinates[i + 2]);
+            highestZ = Math.max(highestZ, coordinates[i + 2]);
+        }
+
+        if (coordinates.length == 0) {
+            this.bounds = new Rectangle2D.Double();
+            this.minZ = 0;
+            this.maxZ = 0;
+        } else {
+            this.bounds = new Rectangle2D.Double(minX, minY, maxX - minX, maxY - minY);
+            this.minZ = lowestZ;
+            this.maxZ = highestZ;
+        }
+    }
+
+    public boolean isEmpty() {
+        return coordinates.length == 0;
+    }
+
+    public int getTriangleCount() {
+        return coordinates.length / COORDINATES_PER_TRIANGLE;
+    }
+
+    public float[] getCoordinates() {
+        return coordinates;
+    }
+
+    /**
+     * Returns the extents of the mesh projected onto the XY plane.
+     *
+     * @return the bounds in the XY plane
+     */
+    public Rectangle2D.Double getBounds() {
+        return (Rectangle2D.Double) bounds.clone();
+    }
+
+    public double getMinZ() {
+        return minZ;
+    }
+
+    public double getMaxZ() {
+        return maxZ;
+    }
+
+    public double getHeight() {
+        return maxZ - minZ;
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlParser.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlParser.java
@@ -1,0 +1,111 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.stl;
+
+import com.willwinder.ugs.designer.io.DesignReaderException;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reads both the binary and the ASCII flavour of STL into a {@link StlMesh}.
+ *
+ * @author Joacim Breiler
+ */
+public class StlParser {
+    private static final int BINARY_HEADER_SIZE = 80;
+    private static final int BINARY_TRIANGLE_SIZE = 50;
+    private static final Pattern VERTEX = Pattern.compile("vertex\\s+(\\S+)\\s+(\\S+)\\s+(\\S+)", Pattern.CASE_INSENSITIVE);
+
+    public StlMesh parse(byte[] data) {
+        if (isBinary(data)) {
+            return parseBinary(data);
+        }
+        return parseAscii(new String(data, StandardCharsets.US_ASCII));
+    }
+
+    /**
+     * An ASCII file starts with {@code solid}, but so do binary files written by some tools, so the
+     * declared triangle count is checked against the actual file length instead.
+     */
+    private static boolean isBinary(byte[] data) {
+        if (data.length < BINARY_HEADER_SIZE + 4) {
+            return false;
+        }
+
+        long triangleCount = ByteBuffer.wrap(data, BINARY_HEADER_SIZE, 4)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .getInt() & 0xFFFFFFFFL;
+        return data.length == BINARY_HEADER_SIZE + 4 + triangleCount * BINARY_TRIANGLE_SIZE;
+    }
+
+    private static StlMesh parseBinary(byte[] data) {
+        ByteBuffer buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
+        buffer.position(BINARY_HEADER_SIZE);
+        int triangleCount = buffer.getInt();
+
+        float[] coordinates = new float[triangleCount * StlMesh.COORDINATES_PER_TRIANGLE];
+        int index = 0;
+        for (int triangle = 0; triangle < triangleCount; triangle++) {
+            buffer.position(buffer.position() + 12); // The facet normal is derived from the winding instead
+            for (int i = 0; i < StlMesh.COORDINATES_PER_TRIANGLE; i++) {
+                coordinates[index++] = buffer.getFloat();
+            }
+            buffer.position(buffer.position() + 2); // Attribute byte count
+        }
+
+        return new StlMesh(coordinates);
+    }
+
+    private static StlMesh parseAscii(String text) {
+        Matcher matcher = VERTEX.matcher(text);
+        float[] coordinates = new float[StlMesh.COORDINATES_PER_TRIANGLE * 64];
+        int index = 0;
+
+        while (matcher.find()) {
+            if (index + 3 > coordinates.length) {
+                float[] grown = new float[coordinates.length * 2];
+                System.arraycopy(coordinates, 0, grown, 0, index);
+                coordinates = grown;
+            }
+            for (int axis = 0; axis < 3; axis++) {
+                coordinates[index++] = parseFloat(matcher.group(axis + 1));
+            }
+        }
+
+        if (index % StlMesh.COORDINATES_PER_TRIANGLE != 0) {
+            throw new DesignReaderException("The STL file contains an incomplete triangle");
+        }
+
+        float[] trimmed = new float[index];
+        System.arraycopy(coordinates, 0, trimmed, 0, index);
+        return new StlMesh(trimmed);
+    }
+
+    private static float parseFloat(String value) {
+        try {
+            return Float.parseFloat(value);
+        } catch (NumberFormatException e) {
+            throw new DesignReaderException("Could not parse the vertex coordinate '" + value + "'", e);
+        }
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlReader.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/stl/StlReader.java
@@ -1,0 +1,104 @@
+/*
+    Copyright 2026 Joacim Breiler
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.io.stl;
+
+import com.willwinder.ugs.designer.entities.Entity;
+import com.willwinder.ugs.designer.entities.cuttable.CutType;
+import com.willwinder.ugs.designer.entities.cuttable.Raster;
+import com.willwinder.ugs.designer.io.DesignReader;
+import com.willwinder.ugs.designer.io.DesignReaderException;
+import com.willwinder.ugs.designer.model.Design;
+import com.willwinder.ugs.designer.model.Size;
+
+import java.awt.EventQueue;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Imports an STL mesh as a {@link Raster} holding a depth map of the model as seen from above. The
+ * raster is sized to the footprint of the mesh and its target depth is set to the height of the
+ * model, so carving it as a height map reproduces the mesh at its original scale.
+ *
+ * @author Joacim Breiler
+ */
+public class StlReader implements DesignReader {
+
+    private final StlDepthMapRasterizer rasterizer;
+
+    public StlReader() {
+        this(new StlDepthMapRasterizer());
+    }
+
+    public StlReader(StlDepthMapRasterizer rasterizer) {
+        this.rasterizer = rasterizer;
+    }
+
+    @Override
+    public Optional<Design> read(File file) {
+        try (InputStream inputStream = new FileInputStream(file)) {
+            return read(inputStream).map(design -> {
+                design.getEntities().forEach(entity -> entity.setName(file.getName()));
+                return design;
+            });
+        } catch (IOException e) {
+            throw new DesignReaderException("Could not read the STL file " + file.getName(), e);
+        }
+    }
+
+    @Override
+    public Optional<Design> read(InputStream inputStream) {
+        if (EventQueue.isDispatchThread()) {
+            throw new DesignReaderException("Method can not be executed in dispatch thread");
+        }
+
+        StlMesh mesh;
+        try {
+            mesh = new StlParser().parse(inputStream.readAllBytes());
+        } catch (IOException e) {
+            throw new DesignReaderException("Could not read the STL model", e);
+        }
+
+        if (mesh.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Design design = new Design();
+        design.setEntities(List.of(createRaster(mesh)));
+        return Optional.of(design);
+    }
+
+    private Entity createRaster(StlMesh mesh) {
+        BufferedImage depthMap = rasterizer.rasterize(mesh);
+
+        Raster raster = new Raster(depthMap);
+        raster.setName("Depth map");
+        raster.setCutType(CutType.HEIGHT_MAP);
+        raster.setTargetDepth(mesh.getHeight());
+
+        Rectangle2D.Double bounds = mesh.getBounds();
+        raster.setSize(new Size(bounds.width, bounds.height));
+        return raster;
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/utils/DepthMapGenerator.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/utils/DepthMapGenerator.java
@@ -131,15 +131,19 @@ public class DepthMapGenerator {
         h = detailBlend(h, luma, parameters.detailBlendAmount(), DETAIL_SCALE);
         clamp01(h);
 
-        return toByteGray(h, originalWidth, originalHeight);
+        return toGrayscale(h, originalWidth, originalHeight);
     }
 
-    private static BufferedImage toByteGray(float[][] map, int width, int height) {
-        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY);
+    /**
+     * The height field is kept at 16 bits so the carved depth resolution is limited by the estimate
+     * rather than by the 256 steps an 8-bit image would allow.
+     */
+    private static BufferedImage toGrayscale(float[][] map, int width, int height) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_USHORT_GRAY);
         var raster = image.getRaster();
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                int value = Math.round(Math.max(0f, Math.min(1f, map[y][x])) * 255f);
+                int value = Math.round(Math.max(0f, Math.min(1f, map[y][x])) * 65535f);
                 raster.setSample(x, y, 0, value);
             }
         }

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/entities/cuttable/RasterTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/entities/cuttable/RasterTest.java
@@ -1,0 +1,100 @@
+package com.willwinder.ugs.designer.entities.cuttable;
+
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+import static org.junit.Assert.assertEquals;
+
+public class RasterTest {
+
+    /**
+     * Builds an image where every column has a constant sample value, so an intensity can be looked up
+     * by its column alone.
+     */
+    private static BufferedImage columns(int type, int... values) {
+        BufferedImage image = new BufferedImage(values.length, 2, type);
+        for (int x = 0; x < values.length; x++) {
+            for (int y = 0; y < 2; y++) {
+                image.getRaster().setSample(x, y, 0, values[x]);
+            }
+        }
+        return image;
+    }
+
+    @Test
+    public void getIntensityAt_shouldReadSixteenBitGrayscaleVerbatim() {
+        Raster raster = new Raster(columns(BufferedImage.TYPE_USHORT_GRAY, 0, 32768, 65535));
+
+        double first = raster.getIntensityAt(new Point2D.Double(0.5, 1));
+        double middle = raster.getIntensityAt(new Point2D.Double(1.5, 1));
+        double last = raster.getIntensityAt(new Point2D.Double(2.5, 1));
+
+        assertEquals(0.0, first, 1e-9);
+        assertEquals(32768 / 65535.0, middle, 1e-9);
+        assertEquals(1.0, last, 1e-9);
+    }
+
+    @Test
+    public void getIntensityAt_shouldResolveIntensitiesFinerThanEightBits() {
+        Raster raster = new Raster(columns(BufferedImage.TYPE_USHORT_GRAY, 30000, 30001));
+
+        double first = raster.getIntensityAt(new Point2D.Double(0.5, 1));
+        double second = raster.getIntensityAt(new Point2D.Double(1.5, 1));
+
+        // An 8-bit raster would report 117/255 for both of these
+        assertEquals(30000 / 65535.0, first, 1e-9);
+        assertEquals(30001 / 65535.0, second, 1e-9);
+    }
+
+    @Test
+    public void getIntensityAt_shouldReadEightBitGrayscaleVerbatim() {
+        Raster raster = new Raster(columns(BufferedImage.TYPE_BYTE_GRAY, 0, 128, 255));
+
+        double first = raster.getIntensityAt(new Point2D.Double(0.5, 1));
+        double middle = raster.getIntensityAt(new Point2D.Double(1.5, 1));
+        double last = raster.getIntensityAt(new Point2D.Double(2.5, 1));
+
+        assertEquals(0.0, first, 1e-9);
+        assertEquals(128 / 255.0, middle, 1e-9);
+        assertEquals(1.0, last, 1e-9);
+    }
+
+    @Test
+    public void getIntensityAt_shouldInvertSixteenBitGrayscale() {
+        Raster raster = new Raster(columns(BufferedImage.TYPE_USHORT_GRAY, 30000, 30001));
+        raster.setInvert(true);
+
+        double first = raster.getIntensityAt(new Point2D.Double(0.5, 1));
+
+        assertEquals(1.0 - 30000 / 65535.0, first, 1e-4);
+    }
+
+    @Test
+    public void getIntensityAt_shouldQuantizeToTheConfiguredNumberOfLevels() {
+        Raster raster = new Raster(columns(BufferedImage.TYPE_USHORT_GRAY, 30000, 40000));
+        raster.setLevels(3);
+
+        double first = raster.getIntensityAt(new Point2D.Double(0.5, 1));
+        double second = raster.getIntensityAt(new Point2D.Double(1.5, 1));
+
+        assertEquals(0.5, first, 1e-4);
+        assertEquals(0.5, second, 1e-4);
+    }
+
+    @Test
+    public void getImageData_shouldPreserveSixteenBitPrecision() throws IOException {
+        Raster raster = new Raster(columns(BufferedImage.TYPE_USHORT_GRAY, 30000, 30001));
+
+        BufferedImage restored = ImageIO.read(new ByteArrayInputStream(Base64.getDecoder().decode(raster.getImageData())));
+
+        assertEquals(BufferedImage.TYPE_USHORT_GRAY, restored.getType());
+        assertEquals(30000, restored.getRaster().getSample(0, 0, 0));
+        assertEquals(30001, restored.getRaster().getSample(1, 0, 0));
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/HeightMapToolPathTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/HeightMapToolPathTest.java
@@ -185,6 +185,74 @@ public class HeightMapToolPathTest {
                 distanceToCorner(angledSegments, cornerX, cornerY) < 1.0);
     }
 
+    @Test
+    public void appendGcodePath_ShouldNotCutPocketNarrowerThanTheTool() {
+        // A 1mm wide slot in an otherwise untouched surface. A 6mm tool does not fit into it, so nothing
+        // may be removed anywhere - cutting the slot would carve a 6mm wide trench through the surface.
+        Raster raster = new Raster(createSlotImage(20, 20, 8, 1));
+        raster.setRoughing(true);
+        Settings settings = createSettings();
+        settings.setToolDiameter(6);
+        HeightMapToolPath toolPath = new HeightMapToolPath(settings, raster);
+        toolPath.setStartDepth(0);
+        toolPath.setTargetDepth(3);
+
+        List<Segment> segments = toolPath.toGcodePath().getSegments();
+
+        assertEquals("A 6mm tool must not descend into a 1mm wide slot", 0, deepestZ(segments), 0.01);
+    }
+
+    @Test
+    public void appendGcodePath_ShouldNotMachineAwayIslandNarrowerThanTheTool() {
+        // A 1mm wide raised island surrounded by material to be cut 3mm deep. A 6mm tool cannot cut
+        // anywhere within its radius of the island without machining the island away.
+        Raster raster = new Raster(createIslandImage(20, 20, 8, 1));
+        raster.setRoughing(true);
+        Settings settings = createSettings();
+        settings.setToolDiameter(6);
+        HeightMapToolPath toolPath = new HeightMapToolPath(settings, raster);
+        toolPath.setStartDepth(0);
+        toolPath.setTargetDepth(3);
+
+        List<Segment> segments = toolPath.toGcodePath().getSegments();
+
+        assertEquals("The tool must stay clear of a raised island it cannot machine around",
+                0, deepestZBetween(segments, 5.5, 11.5), 0.01);
+    }
+
+    /**
+     * All white (surface) except a dark vertical slot {@code widthPx} wide starting at {@code slotX}.
+     */
+    private static BufferedImage createSlotImage(int width, int height, int slotX, int widthPx) {
+        return createColumnImage(width, height, slotX, widthPx, Color.BLACK, Color.WHITE);
+    }
+
+    /**
+     * All black (cut to target depth) except a raised white island {@code widthPx} wide at {@code islandX}.
+     */
+    private static BufferedImage createIslandImage(int width, int height, int islandX, int widthPx) {
+        return createColumnImage(width, height, islandX, widthPx, Color.WHITE, Color.BLACK);
+    }
+
+    private static BufferedImage createColumnImage(int width, int height, int columnX, int widthPx, Color column, Color background) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                boolean inColumn = x >= columnX && x < columnX + widthPx;
+                image.setRGB(x, y, (inColumn ? column : background).getRGB());
+            }
+        }
+        return image;
+    }
+
+    private static double deepestZ(List<Segment> segments) {
+        return segments.stream()
+                .filter(s -> s.point != null && s.point.hasZ())
+                .mapToDouble(s -> s.point.getZ())
+                .min()
+                .orElse(Double.NaN);
+    }
+
     private static double maxCoordinate(List<Segment> segments, boolean useX) {
         return segments.stream()
                 .filter(s -> s.point != null && s.point.hasX() && s.point.hasY())

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlDepthMapRasterizerTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlDepthMapRasterizerTest.java
@@ -1,0 +1,110 @@
+package com.willwinder.ugs.designer.io.stl;
+
+import org.junit.Test;
+
+import java.awt.image.BufferedImage;
+
+import static org.junit.Assert.assertEquals;
+
+public class StlDepthMapRasterizerTest {
+
+    private static int gray(BufferedImage image, int x, int y) {
+        return image.getRaster().getSample(x, y, 0);
+    }
+
+    @Test
+    public void rasterize_shouldSizeImageFromTheFootprintAndResolution() {
+        StlMesh mesh = new StlMesh(StlTestFiles.flatQuad(0, 0, 20, 10, 1));
+
+        BufferedImage image = new StlDepthMapRasterizer(2).rasterize(mesh);
+
+        assertEquals(40, image.getWidth());
+        assertEquals(20, image.getHeight());
+    }
+
+    @Test
+    public void rasterize_shouldCapTheLongestSideWhileKeepingTheAspectRatio() {
+        StlMesh mesh = new StlMesh(StlTestFiles.flatQuad(0, 0, 2000, 1000, 1));
+
+        BufferedImage image = new StlDepthMapRasterizer(10).rasterize(mesh);
+
+        assertEquals(2048, image.getWidth());
+        assertEquals(1024, image.getHeight());
+    }
+
+    @Test
+    public void rasterize_shouldMapTheHighestPointToWhiteAndTheLowestToBlack() {
+        StlMesh mesh = new StlMesh(StlTestFiles.rampAlongX(10, 10, 10));
+
+        BufferedImage image = new StlDepthMapRasterizer(1).rasterize(mesh);
+
+        assertEquals(3277, gray(image, 0, 5));
+        assertEquals(62258, gray(image, 9, 5));
+    }
+
+    @Test
+    public void rasterize_shouldPutTheTopOfTheModelInTheFirstRow() {
+        StlMesh mesh = new StlMesh(StlTestFiles.rampAlongY(10, 10, 10));
+
+        BufferedImage image = new StlDepthMapRasterizer(1).rasterize(mesh);
+
+        assertEquals(62258, gray(image, 5, 0));
+        assertEquals(3277, gray(image, 5, 9));
+    }
+
+    @Test
+    public void rasterize_shouldKeepTheHighestSurfaceWhenTrianglesOverlap() {
+        StlMesh mesh = new StlMesh(StlTestFiles.concat(
+                StlTestFiles.flatQuad(0, 0, 10, 10, 2),
+                StlTestFiles.flatQuad(0, 0, 5, 5, 5)));
+
+        BufferedImage image = new StlDepthMapRasterizer(1).rasterize(mesh);
+
+        assertEquals(65535, gray(image, 1, 8));
+        assertEquals(0, gray(image, 8, 1));
+    }
+
+    @Test
+    public void rasterize_shouldLeaveAreasOutsideTheMeshBlack() {
+        StlMesh mesh = new StlMesh(new float[]{
+                0, 0, 1,
+                10, 0, 1,
+                10, 10, 1
+        });
+
+        BufferedImage image = new StlDepthMapRasterizer(1).rasterize(mesh);
+
+        assertEquals(65535, gray(image, 9, 9));
+        assertEquals(0, gray(image, 0, 0));
+    }
+
+    @Test
+    public void rasterize_shouldProduceA16BitDepthMap() {
+        StlMesh mesh = new StlMesh(StlTestFiles.flatQuad(0, 0, 10, 10, 1));
+
+        BufferedImage image = new StlDepthMapRasterizer(1).rasterize(mesh);
+
+        assertEquals(BufferedImage.TYPE_USHORT_GRAY, image.getType());
+    }
+
+    @Test
+    public void rasterize_shouldResolveHeightStepsFinerThanEightBits() {
+        StlMesh mesh = new StlMesh(StlTestFiles.rampAlongX(100, 10, 1));
+
+        BufferedImage image = new StlDepthMapRasterizer(10).rasterize(mesh);
+
+        // Neighbouring columns differ by 1/1000 of the height, which an 8-bit map would collapse to 128
+        assertEquals(32800, gray(image, 500, 50));
+        assertEquals(32866, gray(image, 501, 50));
+    }
+
+    @Test
+    public void rasterize_shouldRenderAFlatModelAsWhite() {
+        StlMesh mesh = new StlMesh(StlTestFiles.flatQuad(0, 0, 10, 10, 3));
+
+        BufferedImage image = new StlDepthMapRasterizer(1).rasterize(mesh);
+
+        assertEquals(65535, gray(image, 5, 5));
+        assertEquals(65535, gray(image, 0, 9));
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlParserTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlParserTest.java
@@ -1,0 +1,77 @@
+package com.willwinder.ugs.designer.io.stl;
+
+import com.willwinder.ugs.designer.io.DesignReaderException;
+import org.junit.Test;
+
+import java.awt.geom.Rectangle2D;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class StlParserTest {
+
+    @Test
+    public void parse_shouldReadTrianglesFromAsciiFile() {
+        byte[] data = StlTestFiles.ascii(StlTestFiles.rampAlongX(20, 10, 4));
+
+        StlMesh mesh = new StlParser().parse(data);
+
+        assertEquals(2, mesh.getTriangleCount());
+        assertEquals(new Rectangle2D.Double(0, 0, 20, 10), mesh.getBounds());
+        assertEquals(0, mesh.getMinZ(), 0.0001);
+        assertEquals(4, mesh.getMaxZ(), 0.0001);
+    }
+
+    @Test
+    public void parse_shouldReadTrianglesFromBinaryFile() {
+        byte[] data = StlTestFiles.binary(StlTestFiles.rampAlongX(20, 10, 4));
+
+        StlMesh mesh = new StlParser().parse(data);
+
+        assertEquals(2, mesh.getTriangleCount());
+        assertEquals(new Rectangle2D.Double(0, 0, 20, 10), mesh.getBounds());
+        assertEquals(4, mesh.getHeight(), 0.0001);
+    }
+
+    @Test
+    public void parse_shouldReadBinaryFileWithHeaderStartingWithSolid() {
+        byte[] data = StlTestFiles.binary(StlTestFiles.flatQuad(0, 0, 10, 10, 2));
+        System.arraycopy("solid".getBytes(StandardCharsets.US_ASCII), 0, data, 0, 5);
+
+        StlMesh mesh = new StlParser().parse(data);
+
+        assertEquals(2, mesh.getTriangleCount());
+    }
+
+    @Test
+    public void parse_shouldHandleNegativeCoordinates() {
+        byte[] data = StlTestFiles.ascii(StlTestFiles.flatQuad(-5, -2, 5, 2, -3));
+
+        StlMesh mesh = new StlParser().parse(data);
+
+        assertEquals(new Rectangle2D.Double(-5, -2, 10, 4), mesh.getBounds());
+        assertEquals(-3, mesh.getMinZ(), 0.0001);
+    }
+
+    @Test
+    public void parse_shouldReturnEmptyMeshForFileWithoutTriangles() {
+        byte[] data = "solid empty\nendsolid empty\n".getBytes(StandardCharsets.US_ASCII);
+
+        StlMesh mesh = new StlParser().parse(data);
+
+        assertTrue(mesh.isEmpty());
+    }
+
+    @Test
+    public void parse_shouldThrowExceptionForIncompleteTriangle() {
+        byte[] data = "solid broken\nfacet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nendloop\nendfacet\nendsolid broken\n"
+                .getBytes(StandardCharsets.US_ASCII);
+        StlParser parser = new StlParser();
+
+        DesignReaderException exception = assertThrows(DesignReaderException.class, () -> parser.parse(data));
+
+        assertEquals("The STL file contains an incomplete triangle", exception.getMessage());
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlReaderTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlReaderTest.java
@@ -1,0 +1,98 @@
+package com.willwinder.ugs.designer.io.stl;
+
+import com.willwinder.ugs.designer.entities.Entity;
+import com.willwinder.ugs.designer.entities.cuttable.CutType;
+import com.willwinder.ugs.designer.entities.cuttable.Raster;
+import com.willwinder.ugs.designer.model.Design;
+
+import org.junit.Test;
+
+import java.awt.geom.Point2D;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StlReaderTest {
+
+    private static Raster readRaster(byte[] data) {
+        Optional<Design> design = new StlReader().read(new ByteArrayInputStream(data));
+        assertTrue(design.isPresent());
+
+        List<Entity> entities = design.get().getEntities();
+        assertEquals(1, entities.size());
+        assertTrue(entities.get(0) instanceof Raster);
+        return (Raster) entities.get(0);
+    }
+
+    @Test
+    public void read_shouldCreateRasterSizedToTheModelFootprint() {
+        Raster raster = readRaster(StlTestFiles.binary(StlTestFiles.rampAlongX(20, 10, 4)));
+
+        assertEquals(20, raster.getSize().getWidth(), 0.0001);
+        assertEquals(10, raster.getSize().getHeight(), 0.0001);
+    }
+
+    @Test
+    public void read_shouldSetTargetDepthToTheModelHeight() {
+        Raster raster = readRaster(StlTestFiles.binary(StlTestFiles.rampAlongX(20, 10, 4)));
+
+        assertEquals(4, raster.getTargetDepth(), 0.0001);
+    }
+
+    @Test
+    public void read_shouldCutTheRasterAsAHeightMap() {
+        Raster raster = readRaster(StlTestFiles.ascii(StlTestFiles.rampAlongX(20, 10, 4)));
+
+        assertEquals(CutType.HEIGHT_MAP, raster.getCutType());
+    }
+
+    @Test
+    public void read_shouldNotUseTheEstimatedDepthMapping() {
+        Raster raster = readRaster(StlTestFiles.ascii(StlTestFiles.rampAlongX(20, 10, 4)));
+
+        assertFalse(raster.isDepthMapping());
+    }
+
+    @Test
+    public void read_shouldMakeTheTopOfTheModelUncut() {
+        Raster raster = readRaster(StlTestFiles.binary(StlTestFiles.rampAlongX(20, 10, 4)));
+
+        assertEquals(1.0, raster.getIntensityAt(new Point2D.Double(19.9, 5)), 0.02);
+        assertEquals(0.0, raster.getIntensityAt(new Point2D.Double(0.1, 5)), 0.02);
+    }
+
+    @Test
+    public void read_shouldResolveHeightsFinerThanEightBits() {
+        Raster raster = readRaster(StlTestFiles.binary(StlTestFiles.rampAlongX(100, 10, 25)));
+
+        double first = raster.getIntensityAt(new Point2D.Double(50.05, 5));
+        double second = raster.getIntensityAt(new Point2D.Double(50.15, 5));
+
+        // These lie 0.025mm apart on a 25mm tall model, well inside a single 8-bit height step
+        assertEquals(0.5005, first, 0.0002);
+        assertEquals(0.5015, second, 0.0002);
+    }
+
+    @Test
+    public void read_shouldNameTheEntityAfterTheFile() throws Exception {
+        File file = Files.createTempFile("model", ".stl").toFile();
+        Files.write(file.toPath(), StlTestFiles.binary(StlTestFiles.rampAlongX(20, 10, 4)));
+
+        Optional<Design> design = new StlReader().read(file);
+
+        assertEquals(file.getName(), design.orElseThrow().getEntities().get(0).getName());
+    }
+
+    @Test
+    public void read_shouldReturnEmptyForMeshWithoutTriangles() {
+        Optional<Design> design = new StlReader().read(new ByteArrayInputStream(StlTestFiles.binary()));
+
+        assertTrue(design.isEmpty());
+    }
+}

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlTestFiles.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/stl/StlTestFiles.java
@@ -1,0 +1,97 @@
+package com.willwinder.ugs.designer.io.stl;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Builds STL files in both flavours from a flat list of triangle coordinates.
+ */
+final class StlTestFiles {
+
+    private StlTestFiles() {
+    }
+
+    static byte[] ascii(float... coordinates) {
+        StringBuilder builder = new StringBuilder("solid test\n");
+        for (int i = 0; i < coordinates.length; i += StlMesh.COORDINATES_PER_TRIANGLE) {
+            builder.append("facet normal 0 0 1\n  outer loop\n");
+            for (int vertex = 0; vertex < 3; vertex++) {
+                int offset = i + vertex * 3;
+                builder.append("    vertex ")
+                        .append(coordinates[offset]).append(' ')
+                        .append(coordinates[offset + 1]).append(' ')
+                        .append(coordinates[offset + 2]).append('\n');
+            }
+            builder.append("  endloop\nendfacet\n");
+        }
+        builder.append("endsolid test\n");
+        return builder.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    static byte[] binary(float... coordinates) {
+        int triangleCount = coordinates.length / StlMesh.COORDINATES_PER_TRIANGLE;
+        ByteBuffer buffer = ByteBuffer.allocate(80 + 4 + triangleCount * 50).order(ByteOrder.LITTLE_ENDIAN);
+        buffer.put(new byte[80]);
+        buffer.putInt(triangleCount);
+
+        for (int i = 0; i < coordinates.length; i += StlMesh.COORDINATES_PER_TRIANGLE) {
+            buffer.putFloat(0).putFloat(0).putFloat(1);
+            for (int offset = 0; offset < StlMesh.COORDINATES_PER_TRIANGLE; offset++) {
+                buffer.putFloat(coordinates[i + offset]);
+            }
+            buffer.putShort((short) 0);
+        }
+
+        return buffer.array();
+    }
+
+    /**
+     * A quad spanning the given footprint lying on the plane {@code z = height * x / width}.
+     */
+    static float[] rampAlongX(float width, float height, float depth) {
+        return new float[]{
+                0, 0, 0,
+                width, 0, depth,
+                width, height, depth,
+
+                0, 0, 0,
+                width, height, depth,
+                0, height, 0
+        };
+    }
+
+    /**
+     * A quad spanning the given footprint lying on the plane {@code z = depth * y / height}.
+     */
+    static float[] rampAlongY(float width, float height, float depth) {
+        return new float[]{
+                0, 0, 0,
+                width, 0, 0,
+                width, height, depth,
+
+                0, 0, 0,
+                width, height, depth,
+                0, height, depth
+        };
+    }
+
+    static float[] flatQuad(float minX, float minY, float maxX, float maxY, float z) {
+        return new float[]{
+                minX, minY, z,
+                maxX, minY, z,
+                maxX, maxY, z,
+
+                minX, minY, z,
+                maxX, maxY, z,
+                minX, maxY, z
+        };
+    }
+
+    static float[] concat(float[] first, float[] second) {
+        float[] result = new float[first.length + second.length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+}


### PR DESCRIPTION
Added a fix for the depth map tool path that removed too much material.

Also added a convenient way to import STL files which will automatically be transformed into a 16-bit depth map:

<img width="1641" height="1164" alt="image" src="https://github.com/user-attachments/assets/3f4b13f1-13ca-4faa-954c-f4641ed83e2a" />
