### PR TITLE
Fix settings not being copied

### DIFF
--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/entities/cuttable/AbstractCuttable.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/entities/cuttable/AbstractCuttable.java
@@ -358,11 +358,14 @@ public abstract class AbstractCuttable extends AbstractEntity implements Cuttabl
         copy.setCutType(getCutType());
         copy.setSpindleSpeed(getSpindleSpeed());
         copy.setPasses(getPasses());
+        copy.setFeedRate(getFeedRate());
+        copy.setLeadInPercent(getLeadInPercent());
         copy.setHidden(isHidden());
         copy.setIncludeInExport(getIncludeInExport());
         copy.setDirection(getDirection());
         copy.setPlungeType(getPlungeType());
         copy.setToolPathAngle(getToolPathAngle());
+        copy.setToolPathDirection(getToolPathDirection());
         copy.setFinishingPass(isFinishingPass());
         copy.setStockToLeave(getStockToLeave());
     }

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/entities/cuttable/GroupTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/entities/cuttable/GroupTest.java
@@ -38,6 +38,24 @@ public class GroupTest {
     }
 
     @Test
+    public void copy_shouldRetainSettingsOnChildren() {
+        Rectangle rectangle = new Rectangle(1, 1);
+        rectangle.setFeedRate(1234);
+        rectangle.setLeadInPercent(40);
+        rectangle.setToolPathDirection(ToolPathDirection.VERTICAL);
+
+        Group group = new Group();
+        group.addChild(rectangle);
+
+        Group copy = (Group) group.copy();
+
+        Cuttable child = (Cuttable) copy.getChildren().get(0);
+        assertEquals(1234, child.getFeedRate());
+        assertEquals(40, child.getLeadInPercent());
+        assertEquals(ToolPathDirection.VERTICAL, child.getToolPathDirection());
+    }
+
+    @Test
     public void getSettingsShouldReturnACombinedListOfSettings() {
         Point point1 = new Point();
         Point point2 = new Point();

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/entities/cuttable/RectangleTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/entities/cuttable/RectangleTest.java
@@ -4,9 +4,11 @@ import com.willwinder.ugs.designer.entities.EntitySetting;
 import com.willwinder.ugs.designer.entities.EventType;
 import com.willwinder.ugs.designer.model.Size;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
+import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RectangleTest {
@@ -38,6 +40,46 @@ public class RectangleTest {
         });
         rectangle.setRotation(10);
         assertTrue(triggeredEvent.get());
+    }
+
+    @Test
+    public void copy_shouldRetainAllCuttableSettingsFromAnExistingEntity() {
+        Rectangle rectangle = new Rectangle(1, 1);
+        rectangle.setCutType(CutType.POCKET);
+        rectangle.setStartDepth(1.5);
+        rectangle.setTargetDepth(4.5);
+        rectangle.setSpindleSpeed(80);
+        rectangle.setPasses(3);
+        rectangle.setFeedRate(1234);
+        rectangle.setLeadInPercent(40);
+        rectangle.setToolPathAngle(45);
+        rectangle.setToolPathDirection(ToolPathDirection.VERTICAL);
+        rectangle.setDirection(Direction.CONVENTIONAL);
+        rectangle.setPlungeType(PlungeType.STRAIGHT);
+        rectangle.setFinishingPass(true);
+        rectangle.setStockToLeave(0.3);
+        rectangle.setIncludeInExport(false);
+        rectangle.setHidden(true);
+        EnumSet<EntitySetting> settings = rectangle.getSettings();
+
+        Cuttable copy = (Cuttable) rectangle.copy();
+
+        assertEquals(CutType.POCKET, copy.getCutType());
+        assertEquals(1.5, copy.getStartDepth(), 0.1);
+        assertEquals(4.5, copy.getTargetDepth(), 0.1);
+        assertEquals(80, copy.getSpindleSpeed());
+        assertEquals(3, copy.getPasses());
+        assertEquals(1234, copy.getFeedRate());
+        assertEquals(40, copy.getLeadInPercent());
+        assertEquals(45, copy.getToolPathAngle(), 0.1);
+        assertEquals(ToolPathDirection.VERTICAL, copy.getToolPathDirection());
+        assertEquals(Direction.CONVENTIONAL, copy.getDirection());
+        assertEquals(PlungeType.STRAIGHT, copy.getPlungeType());
+        assertTrue(copy.isFinishingPass());
+        assertEquals(0.3, copy.getStockToLeave(), 0.1);
+        assertFalse(copy.getIncludeInExport());
+        assertTrue(copy.isHidden());
+        assertEquals(settings, copy.getSettings());
     }
 
     @Test


### PR DESCRIPTION
When moving an object in the object tree it looses its assigned feed rate. This fixes the missing properties copied using the copy function.