### PR TITLE
Add a coolant setting to the designer tool settings

### DIFF
--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/ToolSettingsPanel.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/gui/ToolSettingsPanel.java
@@ -25,6 +25,7 @@ import com.willwinder.ugs.designer.gui.toollibrary.ToolLabels;
 import com.willwinder.ugs.designer.gui.toollibrary.ToolLibraryDialog;
 import com.willwinder.ugs.designer.logic.Controller;
 import com.willwinder.ugs.designer.logic.ToolLibraryService;
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.ugs.designer.model.toollibrary.EndmillShape;
 import com.willwinder.ugs.designer.model.toollibrary.ToolDefinition;
@@ -76,6 +77,7 @@ public class ToolSettingsPanel extends JPanel {
     private TextFieldWithUnit laserDiameter;
     private TextFieldWithUnit maxSpindleSpeed;
     private JComboBox<String> spindleDirection;
+    private JComboBox<CoolantMode> coolantMode;
     private TextFieldWithUnit flatnessPrecision;
     private JCheckBox arcFitting;
     private JCheckBox useToolChanges;
@@ -185,6 +187,12 @@ public class ToolSettingsPanel extends JPanel {
         spindleDirection = new JComboBox<>(new DefaultComboBoxModel<>(new String[]{"M3", "M4", "M5"}));
         spindleDirection.setSelectedItem(controller.getSettings().getSpindleDirection());
         add(spindleDirection, TOOL_FIELD_CONSTRAINT);
+
+        add(new JLabel("Coolant"));
+        coolantMode = new JComboBox<>(new DefaultComboBoxModel<>(CoolantMode.values()));
+        coolantMode.setSelectedItem(controller.getSettings().getCoolantMode());
+        coolantMode.setToolTipText("Turns the coolant on after the tool change and off at the end of the program.");
+        add(coolantMode, TOOL_FIELD_CONSTRAINT);
 
         add(new JLabel("Curve precision"));
         flatnessPrecision = new TextFieldWithUnit(Unit.MM, 3, controller.getSettings().getFlatnessPrecision());
@@ -445,6 +453,7 @@ public class ToolSettingsPanel extends JPanel {
         settings.setMaxSpindleSpeed((int) getMaxSpindleSpeed());
         settings.setDetectMaxSpindleSpeed(getDetectMaxSpindleSpeed());
         settings.setSpindleDirection(getSpindleDirection());
+        settings.setCoolantMode((CoolantMode) coolantMode.getSelectedItem());
         settings.setFlatnessPrecision(getFlatnessPrecision());
         settings.setArcFitting(arcFitting.isSelected());
         settings.setUseToolChanges(useToolChanges.isSelected());

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriter.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriter.java
@@ -19,6 +19,7 @@
 package com.willwinder.ugs.designer.io.gcode.writer;
 
 import com.willwinder.ugs.designer.io.gcode.path.Segment;
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.ugs.designer.model.toollibrary.ToolDefinition;
 import com.willwinder.universalgcodesender.Utils;
@@ -71,6 +72,19 @@ public class GrblGcodeWriter implements GcodeWriter {
         writer.write("; Spindle start command: " + settings.getSpindleDirection() + "\n");
         writer.write("; Max spindle speed: " + settings.getMaxSpindleSpeed() + "\n");
         writeToolHeader();
+        writeCoolantStart();
+    }
+
+    /**
+     * Opens the coolant once the tool has been selected, so that it is already flowing when the
+     * first cut starts. A program that was posted without coolant writes nothing at all here.
+     */
+    private void writeCoolantStart() throws IOException {
+        CoolantMode coolantMode = settings.getCoolantMode();
+        if (!coolantMode.isEnabled()) {
+            return;
+        }
+        writer.write("\n" + coolantMode.getStartCode().name() + " ; Coolant: " + coolantMode.getDisplayName() + "\n");
     }
 
     /**
@@ -211,5 +225,12 @@ public class GrblGcodeWriter implements GcodeWriter {
         writer.write("\n; Turning off spindle\n");
         writer.write(Code.M5.name());
         writer.append("\n");
+
+        // The coolant is closed after the spindle has stopped, and only when the program opened it
+        if (settings.getCoolantMode().isEnabled()) {
+            writer.write("\n; Turning off coolant\n");
+            writer.write(Code.M9.name());
+            writer.append("\n");
+        }
     }
 }

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/ugsd/v1/SettingsV1.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/ugsd/v1/SettingsV1.java
@@ -18,6 +18,7 @@
  */
 package com.willwinder.ugs.designer.io.ugsd.v1;
 
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.ugs.designer.model.toollibrary.EndmillShape;
 import com.willwinder.universalgcodesender.model.UnitUtils;
@@ -46,6 +47,7 @@ public class SettingsV1 implements Serializable {
     private Integer maxSpindleSpeed;
     private Boolean detectMaxSpindleSpeed;
     private String spindleDirection;
+    private CoolantMode coolantMode;
     private Double flatnessPrecision;
     private Boolean arcFitting;
     private Boolean useToolChanges;
@@ -68,6 +70,7 @@ public class SettingsV1 implements Serializable {
         result.maxSpindleSpeed = settings.getMaxSpindleSpeed();
         result.detectMaxSpindleSpeed = settings.getDetectMaxSpindleSpeed();
         result.spindleDirection = settings.getSpindleDirection();
+        result.coolantMode = settings.getCoolantMode();
         result.flatnessPrecision = settings.getFlatnessPrecision();
         result.arcFitting = settings.getArcFitting();
         result.useToolChanges = settings.getUseToolChanges();
@@ -119,6 +122,9 @@ public class SettingsV1 implements Serializable {
         }
         if (spindleDirection != null) {
             settings.setSpindleDirection(spindleDirection);
+        }
+        if (coolantMode != null) {
+            settings.setCoolantMode(coolantMode);
         }
         if (flatnessPrecision != null) {
             settings.setFlatnessPrecision(flatnessPrecision);

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/CoolantMode.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/CoolantMode.java
@@ -1,0 +1,63 @@
+/*
+    Copyright 2026 Maykol Rey
+
+    This file is part of Universal Gcode Sender (UGS).
+
+    UGS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    UGS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with UGS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.willwinder.ugs.designer.model;
+
+import com.willwinder.universalgcodesender.gcode.util.Code;
+
+/**
+ * How a generated program should turn its coolant on. Turning it off is always {@link Code#M9},
+ * which is why only the start code varies.
+ */
+public enum CoolantMode {
+    NONE("No coolant", null),
+    FLOOD("Flood (M8)", Code.M8),
+    MIST("Mist (M7)", Code.M7);
+
+    private final String displayName;
+    private final Code startCode;
+
+    CoolantMode(String displayName, Code startCode) {
+        this.displayName = displayName;
+        this.startCode = startCode;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * @return the code that turns the coolant on, or null when there is nothing to turn on
+     */
+    public Code getStartCode() {
+        return startCode;
+    }
+
+    public boolean isEnabled() {
+        return startCode != null;
+    }
+
+    /**
+     * The combo boxes in the tool settings dialogs render their values with {@code toString()}.
+     * Settings are persisted using {@code name()}, so this is safe to change.
+     */
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/Settings.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/model/Settings.java
@@ -43,6 +43,7 @@ public class Settings {
     private int maxSpindleSpeed = 255;
     private boolean detectMaxSpindleSpeed = true;
     private String spindleDirection = "M3";
+    private CoolantMode coolantMode = CoolantMode.NONE;
     private double flatnessPrecision = 0.1;
     private boolean arcFitting = true;
     private boolean useToolChanges = false;
@@ -81,6 +82,20 @@ public class Settings {
 
     public void setSpindleDirection(String newSpindleDirection) {
         this.spindleDirection = newSpindleDirection;
+        notifyListeners();
+    }
+
+    /**
+     * Returns which coolant the generated program should turn on, if any
+     *
+     * @return the coolant mode, never null
+     */
+    public CoolantMode getCoolantMode() {
+        return coolantMode;
+    }
+
+    public void setCoolantMode(CoolantMode coolantMode) {
+        this.coolantMode = coolantMode == null ? CoolantMode.NONE : coolantMode;
         notifyListeners();
     }
 
@@ -246,6 +261,7 @@ public class Settings {
         setMaxSpindleSpeed(settings.getMaxSpindleSpeed());
         setDetectMaxSpindleSpeed(settings.getDetectMaxSpindleSpeed());
         setSpindleDirection(settings.getSpindleDirection());
+        setCoolantMode(settings.getCoolantMode());
         setFlatnessPrecision(settings.getFlatnessPrecision());
         setArcFitting(settings.getArcFitting());
         setUseToolChanges(settings.getUseToolChanges());

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/ToolSettingsPanelTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/gui/ToolSettingsPanelTest.java
@@ -23,6 +23,7 @@ import com.willwinder.ugs.designer.entities.selection.SelectionManager;
 import com.willwinder.ugs.designer.gui.toollibrary.EndmillShapeCombo;
 import com.willwinder.ugs.designer.logic.Controller;
 import com.willwinder.ugs.designer.logic.ToolLibraryService;
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.ugs.designer.model.toollibrary.DefaultToolSeeds;
 import com.willwinder.ugs.designer.model.toollibrary.EndmillShape;
@@ -181,6 +182,20 @@ public class ToolSettingsPanelTest {
 
         assertEquals(EndmillShape.BALL, reopenedPanel.getEndmillShape());
         assertEquals(EndmillShape.BALL, reopenedPanel.getSettings().getToolShape());
+    }
+
+    @Test
+    public void initialCoolantModeShouldComeFromSettings() {
+        controller.getSettings().setCoolantMode(CoolantMode.FLOOD);
+
+        ToolSettingsPanel reopenedPanel = new ToolSettingsPanel(controller);
+
+        assertEquals(CoolantMode.FLOOD, reopenedPanel.getSettings().getCoolantMode());
+    }
+
+    @Test
+    public void coolantModeShouldDefaultToNone() {
+        assertEquals(CoolantMode.NONE, panel.getSettings().getCoolantMode());
     }
 
     @Test

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriterTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriterTest.java
@@ -20,6 +20,7 @@ package com.willwinder.ugs.designer.io.gcode.writer;
 
 import com.willwinder.ugs.designer.io.gcode.path.Segment;
 import com.willwinder.ugs.designer.io.gcode.path.SegmentType;
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.ugs.designer.model.toollibrary.EndmillShape;
 import com.willwinder.ugs.designer.model.toollibrary.ToolDefinition;
@@ -104,6 +105,75 @@ public class GrblGcodeWriterTest {
         writer.begin();
 
         assertFalse(result.toString().contains("M6"));
+    }
+
+    @Test
+    public void beginShouldStartFloodCoolant() throws IOException {
+        StringWriter result = new StringWriter();
+        Settings settings = new Settings();
+        settings.setCoolantMode(CoolantMode.FLOOD);
+        GrblGcodeWriter writer = new GrblGcodeWriter(settings, result);
+
+        writer.begin();
+
+        assertTrue(result.toString().contains("M8 ; Coolant: "));
+    }
+
+    @Test
+    public void beginShouldStartMistCoolant() throws IOException {
+        StringWriter result = new StringWriter();
+        Settings settings = new Settings();
+        settings.setCoolantMode(CoolantMode.MIST);
+        GrblGcodeWriter writer = new GrblGcodeWriter(settings, result);
+
+        writer.begin();
+
+        assertTrue(result.toString().contains("M7 ; Coolant: "));
+    }
+
+    @Test
+    public void beginShouldStartCoolantAfterTheToolChange() throws IOException {
+        StringWriter result = new StringWriter();
+        Settings settings = new Settings();
+        settings.setCoolantMode(CoolantMode.FLOOD);
+        settings.setUseToolChanges(true);
+        settings.setToolNumber(2);
+        GrblGcodeWriter writer = new GrblGcodeWriter(settings, result);
+
+        writer.begin();
+
+        String written = result.toString();
+        assertTrue("The coolant must be opened once the tool has been selected",
+                written.indexOf("M6 T2") < written.indexOf("M8"));
+    }
+
+    @Test
+    public void endShouldStopCoolantAfterTheSpindle() throws IOException {
+        StringWriter result = new StringWriter();
+        Settings settings = new Settings();
+        settings.setCoolantMode(CoolantMode.FLOOD);
+        GrblGcodeWriter writer = new GrblGcodeWriter(settings, result);
+
+        writer.end();
+
+        String written = result.toString();
+        assertTrue(written.contains("M9"));
+        assertTrue("The coolant must be closed after the spindle has stopped",
+                written.indexOf("M5") < written.indexOf("M9"));
+    }
+
+    @Test
+    public void shouldNotWriteAnyCoolantCodesByDefault() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+
+        writer.begin();
+        writer.end();
+
+        String written = result.toString();
+        assertFalse(written.contains("M7"));
+        assertFalse(written.contains("M8"));
+        assertFalse(written.contains("M9"));
     }
 
     @Test

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/ugsd/UgsDesignWriterTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/ugsd/UgsDesignWriterTest.java
@@ -22,6 +22,7 @@ import com.willwinder.ugs.designer.entities.EntityGroup;
 import com.willwinder.ugs.designer.entities.cuttable.Rectangle;
 import com.willwinder.ugs.designer.gui.Drawing;
 import com.willwinder.ugs.designer.logic.Controller;
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Design;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.ugs.designer.model.toollibrary.EndmillShape;
@@ -80,6 +81,7 @@ public class UgsDesignWriterTest {
         assertEquals(24000, writtenSettings.getMaxSpindleSpeed());
         assertFalse(writtenSettings.getDetectMaxSpindleSpeed());
         assertEquals("M4", writtenSettings.getSpindleDirection());
+        assertEquals(CoolantMode.MIST, writtenSettings.getCoolantMode());
         assertEquals(0.05, writtenSettings.getFlatnessPrecision(), 0.01);
         assertFalse(writtenSettings.getArcFitting());
         assertTrue(writtenSettings.getUseToolChanges());
@@ -132,6 +134,7 @@ public class UgsDesignWriterTest {
         settings.setMaxSpindleSpeed(24000);
         settings.setDetectMaxSpindleSpeed(false);
         settings.setSpindleDirection("M4");
+        settings.setCoolantMode(CoolantMode.MIST);
         settings.setFlatnessPrecision(0.05);
         settings.setArcFitting(false);
         settings.setUseToolChanges(true);

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/model/SettingsBackwardCompatTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/model/SettingsBackwardCompatTest.java
@@ -61,6 +61,14 @@ public class SettingsBackwardCompatTest {
     }
 
     @Test
+    public void coolantIsOffByDefault() {
+        // Programs posted by a version that did not know about coolant must keep their exact
+        // output, which only holds while the default mode writes no M-code at all
+        Settings settings = new Settings();
+        assertEquals(CoolantMode.NONE, settings.getCoolantMode());
+    }
+
+    @Test
     public void applyingLegacyShapedSettingsPreservesNullLibraryBinding() {
         // A "legacy-shaped" Settings mirrors what an older in-memory instance would look like —
         // no currentToolId, no snapshot. Apply() must not spin up new library state.

--- a/ugs-fx/src/main/java/com/willwinder/universalgcodesender/fx/stage/ToolSettingsStage.java
+++ b/ugs-fx/src/main/java/com/willwinder/universalgcodesender/fx/stage/ToolSettingsStage.java
@@ -20,6 +20,7 @@ package com.willwinder.universalgcodesender.fx.stage;
 
 import com.willwinder.ugs.designer.actions.ChangeToolSettingsAction;
 import com.willwinder.ugs.designer.logic.Controller;
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.universalgcodesender.fx.component.ButtonBox;
 import com.willwinder.universalgcodesender.fx.component.SettingsRow;
@@ -62,6 +63,7 @@ public class ToolSettingsStage extends Stage {
     private final UnitTextField maxSpindleSpeed;
     private final UnitTextField laserDiameter;
     private final ComboBox<String> spindleDirection;
+    private final ComboBox<CoolantMode> coolantMode;
     private final UnitTextField flatnessPrecision;
     private final SwitchButton arcFitting;
 
@@ -86,13 +88,16 @@ public class ToolSettingsStage extends Stage {
         spindleDirection = new ComboBox<>(FXCollections.observableArrayList("M3", "M4", "M5"));
         spindleDirection.setValue(settings.getSpindleDirection());
         spindleDirection.setMaxWidth(Double.MAX_VALUE);
+        coolantMode = new ComboBox<>(FXCollections.observableArrayList(CoolantMode.values()));
+        coolantMode.setValue(settings.getCoolantMode());
+        coolantMode.setMaxWidth(Double.MAX_VALUE);
         flatnessPrecision = numericField(Unit.MM, settings.getFlatnessPrecision());
         arcFitting = new SwitchButton();
         arcFitting.selectedProperty().set(settings.getArcFitting());
 
         setScene(createScene());
         setWidth(380);
-        setHeight(580);
+        setHeight(610);
         setResizable(true);
 
         setOnShowing(event -> centerOnOwner());
@@ -112,6 +117,7 @@ public class ToolSettingsStage extends Stage {
                 new SettingsRow("Detect max spindle speed", detectMaxSpindleSpeed),
                 new SettingsRow("Max spindle speed", maxSpindleSpeed),
                 new SettingsRow("Spindle start command", spindleDirection),
+                new SettingsRow("Coolant", coolantMode),
                 new Separator(),
                 new SettingsRow("Laser diameter", laserDiameter),
                 new SettingsRow("Curve precision", flatnessPrecision),
@@ -154,6 +160,7 @@ public class ToolSettingsStage extends Stage {
         settings.setMaxSpindleSpeed((int) Math.round(maxSpindleSpeed.getValue()));
         settings.setLaserDiameter(laserDiameter.getValue());
         settings.setSpindleDirection(spindleDirection.getValue());
+        settings.setCoolantMode(coolantMode.getValue());
         settings.setFlatnessPrecision(flatnessPrecision.getValue());
         settings.setArcFitting(arcFitting.selectedProperty().get());
 

--- a/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsAdapter.java
+++ b/ugs-platform/ugs-platform-plugin-designer/src/main/java/com/willwinder/ugs/nbp/designer/platform/SettingsAdapter.java
@@ -18,6 +18,7 @@ package com.willwinder.ugs.nbp.designer.platform;
     along with UGS.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import com.willwinder.ugs.designer.model.CoolantMode;
 import com.willwinder.ugs.designer.model.Settings;
 import com.willwinder.ugs.designer.model.toollibrary.EndmillShape;
 import org.openide.util.NbPreferences;
@@ -42,6 +43,7 @@ public class SettingsAdapter {
     private static final String DEPTH_PER_PASS = "depthPerPass";
     private static final String STOCK_THICKNESS = "stockThickness";
     private static final String SPINDLE_DIRECTION = "spindleDirection";
+    private static final String COOLANT_MODE = "coolantMode";
     private static final String FLATNESS_PRECISION = "flatnessPrecision";
     private static final String ARC_FITTING = "arcFitting";
     private static final String USE_TOOL_CHANGES = "useToolChanges";
@@ -63,6 +65,7 @@ public class SettingsAdapter {
         settings.setVBitAngle(preferences.getDouble(V_BIT_ANGLE, 60d));
         settings.setStockThickness(preferences.getDouble(STOCK_THICKNESS, 10));
         settings.setSpindleDirection(preferences.get(SPINDLE_DIRECTION, "M3"));
+        settings.setCoolantMode(readCoolantMode());
         settings.setFlatnessPrecision(preferences.getDouble(FLATNESS_PRECISION, 0.02d));
         settings.setArcFitting(preferences.getBoolean(ARC_FITTING, false));
         settings.setUseToolChanges(preferences.getBoolean(USE_TOOL_CHANGES, false));
@@ -83,9 +86,19 @@ public class SettingsAdapter {
         preferences.putDouble(V_BIT_ANGLE, settings.getVBitAngle());
         preferences.putDouble(STOCK_THICKNESS, settings.getStockThickness());
         preferences.put(SPINDLE_DIRECTION, settings.getSpindleDirection());
+        preferences.put(COOLANT_MODE, settings.getCoolantMode().name());
         preferences.putDouble(FLATNESS_PRECISION, settings.getFlatnessPrecision());
         preferences.putBoolean(ARC_FITTING, settings.getArcFitting());
         preferences.putBoolean(USE_TOOL_CHANGES, settings.getUseToolChanges());
+    }
+
+    private static CoolantMode readCoolantMode() {
+        String stored = preferences.get(COOLANT_MODE, CoolantMode.NONE.name());
+        try {
+            return CoolantMode.valueOf(stored);
+        } catch (IllegalArgumentException e) {
+            return CoolantMode.NONE;
+        }
     }
 
     private static EndmillShape readToolShape() {


### PR DESCRIPTION
The generated program can now open flood (M8) or mist (M7) coolant after the tool change, and close it with M9 once the spindle has stopped. The mode is stored with the design and defaults to off, so programs posted without coolant stay byte for byte identical.

Fixes #3084