### PR TITLE
Stop laser output on rapid moves

### DIFF
--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/Segment.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/Segment.java
@@ -28,6 +28,13 @@ import java.awt.geom.Point2D;
  */
 public final class Segment {
     /**
+     * A spindle speed that stops the spindle, or turns a laser off, instead of running it at a
+     * speed. A laser is switched off with this before every rapid so that it can not burn the
+     * material between two cuts.
+     */
+    public static final int SPINDLE_OFF = 0;
+
+    /**
      * The type of the segment
      */
     public final SegmentType type;
@@ -113,7 +120,7 @@ public final class Segment {
     /**
      * Get the segment comment/label
      *
-     * @return
+     * @return the segment label
      */
     public String getLabel() {
         return label;

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/SegmentType.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/path/SegmentType.java
@@ -76,4 +76,11 @@ public enum SegmentType {
     public boolean isArc() {
         return this == CWARC || this == CCWARC;
     }
+
+    /**
+     * @return true for the moves that feed through the material at the programmed feed rate
+     */
+    public boolean isCuttingMove() {
+        return this == LINE || isArc();
+    }
 }

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserFillToolPath.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserFillToolPath.java
@@ -35,8 +35,9 @@ public class LaserFillToolPath extends AbstractToolPath {
     }
 
     public void appendGcodePath(GcodePath gcodePath, Settings settings) {
-        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d)), source.getFeedRate()));
+        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, null, source.getFeedRate()));
 
+        int laserPower = (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d));
         double toolPathAngle = source.getToolPathAngle();
         List<Geometry> geometries = getGeometries();
         geometries.forEach(g -> {
@@ -52,7 +53,7 @@ public class LaserFillToolPath extends AbstractToolPath {
                 while (currentOffset <= offsetRange[1]) {
                     LineString lineString = generateLineString(envelope, currentOffset, toolPathAngle);
                     if (lineString != null) {
-                        addLineIntersectionSegments(gcodePath, g, lineString, reverse);
+                        addLineIntersectionSegments(gcodePath, g, lineString, reverse, laserPower);
                     }
                     currentOffset += settings.getLaserDiameter();
                     reverse = !reverse;
@@ -61,7 +62,7 @@ public class LaserFillToolPath extends AbstractToolPath {
         });
     }
 
-    private static void addLineIntersectionSegments(GcodePath gcodePath, Geometry geometry, LineString lineString, boolean reverse) {
+    private void addLineIntersectionSegments(GcodePath gcodePath, Geometry geometry, LineString lineString, boolean reverse, int laserPower) {
         Geometry intersection = geometry.intersection(lineString);
 
         // If the intersection is a multipoint we should not connect the points with a line
@@ -79,8 +80,8 @@ public class LaserFillToolPath extends AbstractToolPath {
             }
 
             for (int i = 0; i + 1 < partialPosition.size(); i += 2) {
-                gcodePath.addSegment(SegmentType.MOVE, partialPosition.get(i));
-                gcodePath.addSegment(SegmentType.LINE, partialPosition.get(i + 1));
+                gcodePath.addSegment(new Segment(SegmentType.MOVE, partialPosition.get(i), null, Segment.SPINDLE_OFF, null));
+                gcodePath.addSegment(new Segment(SegmentType.LINE, partialPosition.get(i + 1), null, laserPower, source.getFeedRate()));
             }
         }
     }

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserOutlineToolPath.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserOutlineToolPath.java
@@ -20,7 +20,7 @@ public class LaserOutlineToolPath extends AbstractToolPath {
     }
 
     public void appendGcodePath(GcodePath gcodePath, Settings settings) {
-        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d)), source.getFeedRate()));
+        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, null, source.getFeedRate()));
 
         List<Geometry> geometries = getGeometries();
         geometries.forEach(g -> addGeometrySegments(g, gcodePath));
@@ -37,6 +37,7 @@ public class LaserOutlineToolPath extends AbstractToolPath {
 
     private void addGeometrySegments(Geometry geometry, GcodePath gcodePath) {
         List<Tabs.Section> sections = toSections(ToolPathUtils.geometryToCoordinates(geometry));
+        int laserPower = getLaserPower();
 
         int currentPass = 0;
         while (currentPass < source.getPasses()) {
@@ -50,11 +51,16 @@ public class LaserOutlineToolPath extends AbstractToolPath {
                 List<PartialPosition> coordinates = section.coordinates().stream()
                         .map(numericCoordinate -> PartialPosition.builder(numericCoordinate).build()).toList();
 
-                gcodePath.addSegment(SegmentType.MOVE, coordinates.get(0), label);
-                coordinates.forEach(c -> gcodePath.addSegment(SegmentType.LINE, c));
+                gcodePath.addSegment(new Segment(SegmentType.MOVE, coordinates.getFirst(), label, Segment.SPINDLE_OFF, null));
+                coordinates.stream().skip(1)
+                        .forEach(c -> gcodePath.addSegment(new Segment(SegmentType.LINE, c, null, laserPower, source.getFeedRate())));
                 label = null;
             }
         }
+    }
+
+    private int getLaserPower() {
+        return (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d));
     }
 
     /**

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserRasterToolPath.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserRasterToolPath.java
@@ -71,7 +71,7 @@ public class LaserRasterToolPath extends AbstractToolPath {
     public void appendGcodePath(GcodePath gcodePath, Settings settings) {
         source.awaitDepthMap();
 
-        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, (int) Math.round(settings.getMaxSpindleSpeed() * (source.getSpindleSpeed() / 100d)), source.getFeedRate()));
+        gcodePath.addSegment(new Segment(SegmentType.SEAM, null, null, null, source.getFeedRate()));
 
         List<Geometry> geometries = getGeometries();
         geometries.forEach(g -> {
@@ -163,7 +163,7 @@ public class LaserRasterToolPath extends AbstractToolPath {
                                     SegmentType.MOVE,
                                     start,
                                     null,
-                                    null,
+                                    Segment.SPINDLE_OFF,
                                     null
                             )
                     );

--- a/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriter.java
+++ b/ugs-designer/src/main/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriter.java
@@ -127,10 +127,9 @@ public class GrblGcodeWriter implements GcodeWriter {
             writer.write(";" + segment.getLabel() + "\n");
         }
 
-        if (segment.getSpindleSpeed() != null && (!segment.getSpindleSpeed().equals(currentSpindle) || !hasStartedSpindle)) {
-            writer.write(settings.getSpindleDirection() + " S" + segment.getSpindleSpeed() + "\n");
-            hasStartedSpindle = true;
-            currentSpindle = segment.getSpindleSpeed();
+        boolean changesSpeedWhileCutting = isRunningSpindleSpeedChange(segment);
+        if (!changesSpeedWhileCutting) {
+            writeSpindleSpeed(segment.getSpindleSpeed());
         }
 
         switch (segment.type) {
@@ -170,9 +169,57 @@ public class GrblGcodeWriter implements GcodeWriter {
                 // The arc offsets are relative to the start of the arc, so they need to be
                 // formatted before the current position is advanced to the end of the arc
                 String arcOffsets = segment.type.isArc() ? getArcOffsetFormattedGCode(segment) : "";
-                writer.write(getPointFormattedGCode(segment, segment.type.isArc()) + arcOffsets + "\n");
+                String motion = getPointFormattedGCode(segment, segment.type.isArc()) + arcOffsets;
+                String spindleWord = changesSpeedWhileCutting ? getInlineSpindleSpeedWord(segment, motion) : "";
+                writer.write(motion + spindleWord + "\n");
             }
         }
+    }
+
+    /**
+     * A running spindle changes speed with an S word on the cutting move itself. Grbl treats a
+     * standalone M3 as a synchronization point that drains the planner and stops the motion, which
+     * would stutter a laser raster that changes power every fraction of a millimeter.
+     */
+    private boolean isRunningSpindleSpeedChange(Segment segment) {
+        Integer spindleSpeed = segment.getSpindleSpeed();
+        return hasStartedSpindle
+                && segment.type.isCuttingMove()
+                && spindleSpeed != null
+                && spindleSpeed != Segment.SPINDLE_OFF
+                && !spindleSpeed.equals(currentSpindle);
+    }
+
+    private String getInlineSpindleSpeedWord(Segment segment, String motion) {
+        currentSpindle = segment.getSpindleSpeed();
+        return (motion.isEmpty() ? "" : " ") + "S" + currentSpindle;
+    }
+
+    private void writeSpindleSpeed(Integer spindleSpeed) throws IOException {
+        if (spindleSpeed == null) {
+            return;
+        }
+
+        if (spindleSpeed == Segment.SPINDLE_OFF) {
+            writeSpindleStop();
+            return;
+        }
+
+        if (!spindleSpeed.equals(currentSpindle) || !hasStartedSpindle) {
+            writer.write(settings.getSpindleDirection() + " S" + spindleSpeed + "\n");
+            hasStartedSpindle = true;
+            currentSpindle = spindleSpeed;
+        }
+    }
+
+    private void writeSpindleStop() throws IOException {
+        if (!hasStartedSpindle) {
+            return;
+        }
+
+        writer.write(Code.M5.name() + "\n");
+        hasStartedSpindle = false;
+        currentSpindle = null;
     }
 
     private void writePenUp() throws IOException {

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserFillToolPathTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserFillToolPathTest.java
@@ -14,6 +14,7 @@ import static com.willwinder.ugs.designer.io.gcode.path.SegmentType.MOVE;
 import static com.willwinder.ugs.designer.io.gcode.path.SegmentType.SEAM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 public class LaserFillToolPathTest {
 
@@ -66,7 +67,7 @@ public class LaserFillToolPathTest {
 
         GcodePath gcodePath = toolPath.toGcodePath();
         List<Segment> segments = gcodePath.getSegments();
-        assertEquals(SEAM, segments.get(0).type);
+        assertEquals(SEAM, segments.getFirst().type);
 
         List<Segment> lineSegments = segments.stream().filter(s -> s.type == LINE).toList();
         assertFalse("Expected the fill to produce line segments", lineSegments.isEmpty());
@@ -74,6 +75,39 @@ public class LaserFillToolPathTest {
         // A 90 degree angle fills with vertical passes, so every line moves along Y while keeping X constant
         lineSegments.forEach(segment ->
                 assertEquals(segment.getPoint().getX(), findMovePreceding(segments, segment).getPoint().getX(), 0.01));
+    }
+
+    @Test
+    public void appendGcodePath_shouldTurnTheLaserOffOnEveryRapidAndOnAgainOnEveryFillLine() {
+        Path path = new Path();
+        path.setPasses(1);
+        path.setSpindleSpeed(50);
+        path.setFeedRate(800);
+        path.moveTo(0, 0);
+        path.lineTo(0, 1);
+        path.lineTo(1, 1);
+        path.lineTo(1, 0);
+        path.lineTo(0, 0);
+        path.close();
+
+        Settings settings = new Settings();
+        settings.setMaxSpindleSpeed(10000);
+
+        LaserFillToolPath toolPath = new LaserFillToolPath(settings, path);
+
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+        assertNull("The laser must stay off until the first fill line", segments.getFirst().getSpindleSpeed());
+        List<Segment> moveSegments = segments.stream().filter(s -> s.type == MOVE).toList();
+        List<Segment> lineSegments = segments.stream().filter(s -> s.type == LINE).toList();
+        assertFalse(moveSegments.isEmpty());
+        assertEquals(moveSegments.size(), lineSegments.size());
+        moveSegments.forEach(s -> assertEquals(Segment.SPINDLE_OFF, s.getSpindleSpeed(), 0.01));
+        lineSegments.forEach(s -> {
+            assertEquals(5000, s.getSpindleSpeed(), 0.01);
+            assertEquals(800, s.getFeedSpeed(), 0.01);
+        });
     }
 
     private Segment findMovePreceding(List<Segment> segments, Segment lineSegment) {

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserOutlinePathTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/toolpaths/LaserOutlinePathTest.java
@@ -31,10 +31,10 @@ public class LaserOutlinePathTest {
 
         List<Segment> segments = gcodePath.getSegments();
 
-        Segment segment = segments.get(0);
+        Segment segment = segments.getFirst();
         assertEquals(SegmentType.SEAM, segment.type);
         assertNull(segment.point);
-        assertEquals(10000, segment.getSpindleSpeed(), 0.01);
+        assertNull(segment.getSpindleSpeed());
 
         assertEquals(1, segments.size());
     }
@@ -58,27 +58,26 @@ public class LaserOutlinePathTest {
         List<Segment> segments = gcodePath.getSegments();
         int segmentIndex = 0;
 
-        // Start spindle
+        // The seam only sets the feed rate, the laser is not fired until the first cutting line
         Segment segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.SEAM, segment.type);
         assertNull(segment.point);
-        assertEquals(5000, segment.getSpindleSpeed(), 0.01);
+        assertNull(segment.getSpindleSpeed());
         assertEquals(500, segment.getFeedSpeed(), 0.01);
 
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.MOVE, segment.type);
         assertEquals(0, segment.getPoint().getX(), 0.01);
         assertEquals(0, segment.getPoint().getY(), 0.01);
+        assertEquals(Segment.SPINDLE_OFF, segment.getSpindleSpeed(), 0.01);
 
-        segment = segments.get(segmentIndex++);
-        assertEquals(SegmentType.LINE, segment.type);
-        assertEquals(0, segment.getPoint().getX(), 0.01);
-        assertEquals(0, segment.getPoint().getY(), 0.01);
-
+        // The rapid already landed on the first coordinate, so the first cut goes straight to the second
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.LINE, segment.type);
         assertEquals(0, segment.getPoint().getX(), 0.01);
         assertEquals(10, segment.getPoint().getY(), 0.01);
+        assertEquals(5000, segment.getSpindleSpeed(), 0.01);
+        assertEquals(500, segment.getFeedSpeed(), 0.01);
 
         segment = segments.get(segmentIndex++);
         assertEquals(SegmentType.LINE, segment.type);
@@ -95,7 +94,7 @@ public class LaserOutlinePathTest {
         assertEquals(0, segment.getPoint().getX(), 0.01);
         assertEquals(0, segment.getPoint().getY(), 0.01);
 
-        assertEquals(7, segments.size());
+        assertEquals(6, segments.size());
     }
 
     @Test
@@ -121,5 +120,29 @@ public class LaserOutlinePathTest {
         // that leaves the laser off while it crosses a tab
         long rapids = segments.stream().filter(s -> s.type == SegmentType.MOVE).count();
         assertEquals(5, rapids);
+    }
+
+    @Test
+    public void appendGcodePath_shouldTurnTheLaserOffOnEveryRapidAndOnAgainOnEveryCut() {
+        Rectangle rectangle = new Rectangle(0, 0);
+        rectangle.setFeedRate(500);
+        rectangle.setSpindleSpeed(50);
+        rectangle.setSize(new Size(10, 10));
+        rectangle.setPasses(2);
+        rectangle.setTabs(true);
+        rectangle.setTabCount(4);
+
+        Settings settings = new Settings();
+        settings.setMaxSpindleSpeed(10000);
+        settings.setTabLength(4);
+
+        LaserOutlineToolPath toolPath = new LaserOutlineToolPath(settings, rectangle);
+        GcodePath gcodePath = toolPath.toGcodePath();
+
+        List<Segment> segments = gcodePath.getSegments();
+        segments.stream().filter(s -> s.type == SegmentType.MOVE)
+                .forEach(s -> assertEquals(Segment.SPINDLE_OFF, s.getSpindleSpeed(), 0.01));
+        segments.stream().filter(s -> s.type == SegmentType.LINE)
+                .forEach(s -> assertEquals(5000, s.getSpindleSpeed(), 0.01));
     }
 }

--- a/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriterTest.java
+++ b/ugs-designer/src/test/java/com/willwinder/ugs/designer/io/gcode/writer/GrblGcodeWriterTest.java
@@ -340,13 +340,12 @@ public class GrblGcodeWriterTest {
                 11_000, 1_200));
 
         String[] lines = result.toString().split("\n");
-        assertEquals(6, lines.length);
+        assertEquals(5, lines.length);
         assertEquals("M3 S10000", lines[0]);
         assertEquals("G0 X0Y0", lines[1]);
         assertEquals("G1 F1000 X10Y10", lines[2]);
         assertEquals("G1 X15Y15", lines[3]);
-        assertEquals("M3 S11000", lines[4]);
-        assertEquals("G1 F1200 X20Y20", lines[5]);
+        assertEquals("G1 F1200 X20Y20 S11000", lines[4]);
     }
 
     @Test
@@ -546,6 +545,51 @@ public class GrblGcodeWriterTest {
     }
 
     @Test
+    public void writeSegment_shouldStopTheSpindleBeforeARapidWithSpindleSpeedOff() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.LINE, position(1d, 0d), null, 1000, 500));
+
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(5d, 0d), null, Segment.SPINDLE_OFF, null));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("M3 S1000", lines[0]);
+        assertEquals("G1 F500 X1Y0", lines[1]);
+        assertEquals("M5", lines[2]);
+        assertEquals("G0 X5", lines[3]);
+        assertEquals(4, lines.length);
+    }
+
+    @Test
+    public void writeSegment_shouldStartTheSpindleAgainAfterItWasStopped() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.LINE, position(1d, 0d), null, 1000, 500));
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(5d, 0d), null, Segment.SPINDLE_OFF, null));
+
+        writer.writeSegment(new Segment(SegmentType.LINE, position(6d, 0d), null, 1000, 500));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("M5", lines[2]);
+        assertEquals("G0 X5", lines[3]);
+        assertEquals("M3 S1000", lines[4]);
+        assertEquals("G1 F500 X6", lines[5]);
+        assertEquals(6, lines.length);
+    }
+
+    @Test
+    public void writeSegment_shouldNotStopASpindleThatWasNeverStarted() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(5d, 0d), null, Segment.SPINDLE_OFF, null));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("G0 X5Y0", lines[0]);
+        assertEquals(1, lines.length);
+    }
+
+    @Test
     public void spindleShouldNotRestartForSameSpeedUntilChanged() throws IOException {
         StringWriter result = new StringWriter();
         GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
@@ -575,12 +619,62 @@ public class GrblGcodeWriterTest {
         ));
 
         String[] lines = result.toString().split("\n");
-        assertEquals(5, lines.length);
+        assertEquals(4, lines.length);
         assertEquals("M3 S10000", lines[0]);
         assertEquals("G0 X0", lines[1]);
         assertEquals("G1 F500 X1", lines[2]);
-        assertEquals("M3 S11000", lines[3]);
-        assertEquals("G1 F600 X2", lines[4]);
+        assertEquals("G1 F600 X2 S11000", lines[3]);
+    }
+
+    @Test
+    public void writeSegment_shouldChangeSpeedOfRunningSpindleOnTheCuttingLineInsteadOfANewM3() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(2d, 0d), null, Segment.SPINDLE_OFF, null));
+        writer.writeSegment(new Segment(SegmentType.LINE, position(1.9, 0d), null, 82, 1000));
+
+        writer.writeSegment(new Segment(SegmentType.LINE, position(1.8, 0d), null, 125, 1000));
+        writer.writeSegment(new Segment(SegmentType.LINE, position(1.7, 0d), null, 125, 1000));
+        writer.writeSegment(new Segment(SegmentType.LINE, position(1.6, 0d), null, 24, 1000));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("G0 X2Y0", lines[0]);
+        assertEquals("M3 S82", lines[1]);
+        assertEquals("G1 F1000 X1.9", lines[2]);
+        assertEquals("G1 X1.8 S125", lines[3]);
+        assertEquals("G1 X1.7", lines[4]);
+        assertEquals("G1 X1.6 S24", lines[5]);
+        assertEquals(6, lines.length);
+    }
+
+    @Test
+    public void writeSegment_shouldChangeSpeedOfRunningSpindleOnAnArc() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.LINE, position(0d, 0d), null, 500, 1000));
+
+        writer.writeSegment(new Segment(SegmentType.CWARC, position(10d, 0d), null, 800, 1000, new Point2D.Double(5, 0)));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("G2 X10Y0I5J0 S800", lines[2]);
+        assertEquals(3, lines.length);
+    }
+
+    @Test
+    public void writeSegment_shouldStartStoppedSpindleWithM3EvenOnACuttingLine() throws IOException {
+        StringWriter result = new StringWriter();
+        GrblGcodeWriter writer = new GrblGcodeWriter(new Settings(), result);
+        writer.writeSegment(new Segment(SegmentType.LINE, position(1d, 0d), null, 500, 1000));
+        writer.writeSegment(new Segment(SegmentType.MOVE, position(5d, 0d), null, Segment.SPINDLE_OFF, null));
+
+        writer.writeSegment(new Segment(SegmentType.LINE, position(6d, 0d), null, 800, 1000));
+
+        String[] lines = result.toString().split("\n");
+        assertEquals("M5", lines[2]);
+        assertEquals("G0 X5", lines[3]);
+        assertEquals("M3 S800", lines[4]);
+        assertEquals("G1 F1000 X6", lines[5]);
+        assertEquals(6, lines.length);
     }
 
     @Test
@@ -611,13 +705,12 @@ public class GrblGcodeWriterTest {
                 11_000, 1_200));
 
         String[] lines = result.toString().split("\n");
-        assertEquals(6, lines.length);
+        assertEquals(5, lines.length);
         assertEquals("M3 S10000", lines[0]);
         assertEquals("G0 X0Y0", lines[1]);
         assertEquals("G1 F1000 X10Y10", lines[2]);
         assertEquals("G0 X15Y15", lines[3]);
-        assertEquals("M3 S11000", lines[4]);
-        assertEquals("G1 F1200 X20Y20", lines[5]);
+        assertEquals("G1 F1200 X20Y20 S11000", lines[4]);
     }
 
     @Test


### PR DESCRIPTION
Some controllers do not support the GRBL $32=1 laser mode. This fix should resolve that by always turning of laser between rapids.